### PR TITLE
chore(convolens): brand strings + localStorage migration (PR 2/5)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# WhatsApp Conversation Summarizer - AI Assistant Instructions
+# ConvoLens (formerly WhatsApp Conversation Summarizer) - AI Assistant Instructions
 
 ## Project Overview
 A comprehensive platform for analyzing and summarizing conversations across multiple messaging platforms, starting with WhatsApp. The application provides AI-powered summaries of chat histories with a modern, secure, and scalable architecture.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ConvoLens (formerly WhatsSummarize)
+# ConvoLens
 
-> **Note:** We're rebranding to ConvoLens! This platform is in the process of transitioning from "WhatsSummarize" to our new name. [Learn more about the rebrand →](NAMING_RECOMMENDATIONS.md)
+> **Note:** This project was previously known as **WhatsSummarize**. The brand rename is now landing in stages — see [NAMING_RECOMMENDATIONS.md](NAMING_RECOMMENDATIONS.md) for context.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Next.js](https://img.shields.io/badge/Next.js%2015-000000?style=flat&logo=nextdotjs&logoColor=white)](https://nextjs.org/)
@@ -15,7 +15,7 @@ A comprehensive platform for analyzing and summarizing conversations across mess
 
 ## 🚀 Project Overview
 
-**ConvoLens** (formerly WhatsSummarize) allows users to unlock insights from their conversation history across messaging platforms. By uploading standard `.txt` export files, users can visualize communication patterns, activity levels, and generate AI-driven qualitative summaries.
+**ConvoLens** allows users to unlock insights from their conversation history across messaging platforms. By uploading standard `.txt` export files, users can visualize communication patterns, activity levels, and generate AI-driven qualitative summaries.
 
 ### Brand Identity
 
@@ -86,8 +86,8 @@ For a detailed analysis, see [Technology Stack Assessment](docs/PHASE_1_TECH_STA
 1.  **Clone:**
 
     ```bash
-    git clone https://github.com/JustAGhosT/whatssummarize.git
-    cd whatssummarize
+    git clone https://github.com/JustAGhosT/whats-summarize.git
+    cd whats-summarize
     ```
 
 2.  **Install:**

--- a/WARP.md
+++ b/WARP.md
@@ -4,7 +4,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 ## Project Overview
 
-**ConvoLens** (formerly WhatsSummarize) is an AI-powered conversation analysis platform that transforms messaging exports into insights. Users upload chat exports from WhatsApp (and soon Telegram, Discord, etc.) to visualize communication patterns and generate AI-driven summaries.
+**ConvoLens** is an AI-powered conversation analysis platform that transforms messaging exports into insights. Users upload chat exports from WhatsApp (and soon Telegram, Discord, etc.) to visualize communication patterns and generate AI-driven summaries. (Previously known as **WhatsSummarize**.)
 
 ## Development Commands
 
@@ -50,7 +50,7 @@ pnpm clean                 # Clean build artifacts
 This is a **Turborepo monorepo** with multiple apps and shared packages:
 
 ```
-whatssummarize/
+convolens/
 ├── apps/
 │   ├── web/              # Next.js 15 frontend (App Router)
 │   ├── api/              # Express.js + TypeORM backend
@@ -110,7 +110,7 @@ The architecture is designed to support multiple messaging platforms:
 4. Add validation function like `isValidTelegramExport()`
 
 #### Brand Identity (ConvoLens)
-**Current State**: In transition from "WhatsSummarize" to "ConvoLens"
+**Current State**: ConvoLens (renamed from "WhatsSummarize")
 - **Colors**: Deep Purple (#6B46C1) + Bright Cyan (#06B6D4) + Soft Lavender (#C4B5FD)
 - **Tagline**: "See Your Conversations Clearly"
 - **Design System**: Migrating from Ant Design to pure Tailwind + Shadcn/UI

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,6 +1,6 @@
-# WhatsApp Summarizer Backend
+# ConvoLens Backend
 
-A robust backend service for processing and summarizing WhatsApp chat exports. Built with Node.js, TypeScript, Express, and TypeORM.
+A robust backend service for processing and summarizing WhatsApp chat exports. Built with Node.js, TypeScript, Express, and TypeORM. (Formerly WhatsSummarize.)
 
 ## ✨ Features
 
@@ -30,8 +30,8 @@ A robust backend service for processing and summarizing WhatsApp chat exports. B
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/JustAGhosT/whatssummarize.git
-   cd whatssummarize/backend
+   git clone https://github.com/JustAGhosT/whats-summarize.git
+   cd whats-summarize/apps/api
    ```
 
 2. Install dependencies:
@@ -162,8 +162,8 @@ This project uses Husky for Git hooks. Pre-commit and pre-push hooks are configu
 Build and run using Docker:
 
 ```bash
-docker build -t whatssummarize-backend .
-docker run -p 3001:3001 whatssummarize-backend
+docker build -t convolens-api .
+docker run -p 3001:3001 convolens-api
 ```
 
 ### Environment Variables for Production

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
-# WhatsApp Group Monitor - Frontend
+# ConvoLens - Frontend
 
-This is the frontend for the WhatsApp Group Monitor application, built with Next.js, TypeScript, and Ant Design. It provides a user interface for monitoring and interacting with WhatsApp groups.
+This is the frontend for ConvoLens (formerly WhatsSummarize), built with Next.js, TypeScript, and Ant Design. It provides the user interface for uploading messaging exports, monitoring groups, and viewing AI-generated conversation summaries.
 
 ## Features
 

--- a/apps/web/src/app/landing-page.tsx
+++ b/apps/web/src/app/landing-page.tsx
@@ -120,7 +120,7 @@ const LandingPage = () => {
                   <div className="relative shadow-2xl rounded-2xl overflow-hidden border-8 border-white dark:border-gray-800 hover-card">
                     <Image 
                       src="/images/dashboard.png" 
-                      alt="WhatsSummarize Dashboard" 
+                      alt="ConvoLens Dashboard"
                       width={600} 
                       height={400} 
                       className="w-full h-auto"
@@ -184,7 +184,7 @@ const LandingPage = () => {
             <div className="feature-card">
               <div className="bg-gradient-to-br from-green-500 to-green-600 dark:from-green-600 dark:to-green-700 p-6 rounded-xl shadow-md text-white hover-card">
                 <h3 className="text-xl font-semibold mb-2">Ready to get started?</h3>
-                <p className="mb-4">Try WhatsSummarize today and gain new insights from your conversations.</p>
+                <p className="mb-4">Try ConvoLens today and gain new insights from your conversations.</p>
                 <Link 
                   href="/signup" 
                   className="inline-block px-5 py-2 bg-white text-green-600 font-medium rounded-lg hover:bg-gray-100 transition-colors duration-200 btn-glow"
@@ -205,14 +205,14 @@ const LandingPage = () => {
               Loved by users worldwide
             </h2>
             <p className="mt-4 text-xl text-gray-600 dark:text-gray-400">
-              See what people are saying about WhatsSummarize
+              See what people are saying about ConvoLens
             </p>
           </div>
 
           <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
             {[
               {
-                quote: "WhatsSummarize helped me understand communication patterns in my team chat that I never noticed before.",
+                quote: "ConvoLens helped me understand communication patterns in my team chat that I never noticed before.",
                 author: "Sarah J.",
                 role: "Project Manager"
               },

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,8 +8,18 @@ import { Inter } from "next/font/google"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata = {
-  title: "WhatsSummarize - WhatsApp Conversation Analyzer",
+  title: "ConvoLens - WhatsApp Conversation Analyzer",
   description: "Analyze and summarize your WhatsApp conversations with AI",
+  openGraph: {
+    title: "ConvoLens - WhatsApp Conversation Analyzer",
+    description: "Analyze and summarize your WhatsApp conversations with AI",
+    siteName: "ConvoLens",
+  },
+  twitter: {
+    title: "ConvoLens - WhatsApp Conversation Analyzer",
+    description: "Analyze and summarize your WhatsApp conversations with AI",
+    card: "summary_large_image",
+  },
 }
 
 export default function RootLayout({ children }) {

--- a/apps/web/src/components/Layout/index.tsx
+++ b/apps/web/src/components/Layout/index.tsx
@@ -57,7 +57,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, showSidebar = true }) 
             />
           )}
           <Link href="/" className="logo">
-            <Title level={4} style={{ color: '#fff', margin: 0 }}>WhatsSummarize</Title>
+            <Title level={4} style={{ color: '#fff', margin: 0 }}>ConvoLens</Title>
           </Link>
         </div>
         

--- a/apps/web/src/components/layouts/footer/index.tsx
+++ b/apps/web/src/components/layouts/footer/index.tsx
@@ -16,12 +16,12 @@ export function Footer() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Logo and description */}
           <div className="col-span-1 md:col-span-2">
-            <h2 className="text-2xl font-bold text-green-600 dark:text-green-400 text-gradient">WhatsSummarize</h2>
+            <h2 className="text-2xl font-bold text-green-600 dark:text-green-400 text-gradient">ConvoLens</h2>
             <p className="mt-4 text-gray-600 dark:text-gray-400 max-w-md">
               A powerful tool to analyze and summarize your WhatsApp conversations, providing insights and analytics about your chats.
             </p>
             <div className="mt-6 flex space-x-4">
-              <Link href="https://github.com/JustAGhosT/whatssummarize" className="text-gray-500 hover:text-gray-900 dark:hover:text-gray-300 hover-card p-2 rounded-full">
+              <Link href="https://github.com/JustAGhosT/whats-summarize" className="text-gray-500 hover:text-gray-900 dark:hover:text-gray-300 hover-card p-2 rounded-full">
                 <span className="sr-only">GitHub</span>
                 <Github className="h-6 w-6" />
               </Link>
@@ -83,7 +83,7 @@ export function Footer() {
         
         <div className="mt-12 border-t border-gray-200 dark:border-gray-700 pt-8 flex flex-col md:flex-row justify-between items-center">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            &copy; {new Date().getFullYear()} WhatsSummarize. All rights reserved.
+            &copy; {new Date().getFullYear()} ConvoLens. All rights reserved.
           </p>
           <div className="mt-4 md:mt-0 flex space-x-6">
             <Link href="/privacy" className="text-sm text-gray-500 dark:text-gray-400 hover:text-green-600 dark:hover:text-green-400 transition-colors duration-200">

--- a/apps/web/src/components/layouts/navigation/Navigation.tsx
+++ b/apps/web/src/components/layouts/navigation/Navigation.tsx
@@ -163,7 +163,7 @@ export function Navigation() {
           {/* Logo */}
           <div className={styles.logo}>
             <Link href="/" className={styles.logoLink}>
-              <span className={styles.logoText}>WhatsSummarize</span>
+              <span className={styles.logoText}>ConvoLens</span>
             </Link>
           </div>
 

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -62,7 +62,7 @@ function createMockBrowserClient() {
     expires_at: Date.now() + 3600000,
     user: {
       id: 'mock-user-id',
-      email: 'dev@whatssummarize.local',
+      email: 'dev@convolens.local',
       user_metadata: { name: 'Development User' },
       app_metadata: {},
       aud: 'authenticated',

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,6 +1,6 @@
 # Authentication System Documentation
 
-This document outlines the authentication system implemented in the WhatsApp Summarizer application.
+This document outlines the authentication system implemented in the ConvoLens application.
 
 ## Features
 
@@ -20,7 +20,7 @@ Create a `.env.local` file in the root directory with the following variables:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-NEXT_PUBLIC_APP_NAME=whatssummarize
+NEXT_PUBLIC_APP_NAME=convolens
 ```
 
 ### Supabase Configuration

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,14 +138,14 @@
 
 ### How to Contribute
 
-1. Check the [GitHub Issues](https://github.com/JustAGhosT/whatssummarize/issues) for open tasks
+1. Check the [GitHub Issues](https://github.com/JustAGhosT/whats-summarize/issues) for open tasks
 2. Fork the repository and create a feature branch
 3. Submit a pull request with your changes
 4. Ensure all tests pass and add new tests as needed
 
 ### Reporting Issues
 
-Please report any bugs or feature requests using the [GitHub Issue Tracker](https://github.com/JustAGhosT/whatssummarize/issues).
+Please report any bugs or feature requests using the [GitHub Issue Tracker](https://github.com/JustAGhosT/whats-summarize/issues).
 
 ## Changelog
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,4 +1,4 @@
-# WhatsApp Summarizer - User Guide
+# ConvoLens - User Guide
 
 ## Getting Started
 
@@ -10,7 +10,7 @@
 
 ### Account Setup
 
-1. Visit [WhatsApp Summarizer](https://app.whatssummarize.com)
+1. Visit [ConvoLens](https://app.convolens.com)
 2. Click "Sign Up" and create an account
 3. Verify your email address
 4. Complete your profile setup
@@ -24,7 +24,7 @@
 3. Tap ⋮ (Android) or (iPhone)
 4. Select More > Export chat
 5. Choose "Without Media"
-6. Share to WhatsApp Summarizer app
+6. Share to the ConvoLens app
 
 ### 2. Viewing Summaries
 
@@ -107,12 +107,12 @@
 
 ### Help Center
 
-Visit our [Help Center](https://help.whatssummarize.com) for articles and guides.
+Visit our [Help Center](https://help.convolens.com) for articles and guides.
 
 ### Contact Us
 
-- **Email**: [Email](mailto:support@whatssummarize.com)
-- **Twitter**: [@whatssummarize](https://twitter.com/whatssummarize)
+- **Email**: [Email](mailto:support@convolens.com)
+- **Twitter**: [@convolens](https://twitter.com/convolens)
 - **Live Chat**: Available in the app
 
 ## FAQ
@@ -135,4 +135,4 @@ Currently web-only, but mobile apps are coming soon.
 
 ## Feedback
 
-We'd love to hear your feedback! Use the in-app feedback form or email us at [feedback@whatssummarize.com](mailto:feedback@whatssummarize.com)
+We'd love to hear your feedback! Use the in-app feedback form or email us at [feedback@convolens.com](mailto:feedback@convolens.com)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
-  title: WhatsApp Summarizer API
-  description: API documentation for the WhatsApp Summarizer application
+  title: ConvoLens API
+  description: API documentation for the ConvoLens application (formerly WhatsSummarize)
   version: 1.0.0
   contact:
     name: Support
-    email: support@whatssummarize.com
+    email: support@convolens.com
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,4 +1,4 @@
-# WhatsApp Summarizer - Runbook
+# ConvoLens - Runbook
 
 ## Table of Contents
 - [Overview](#overview)
@@ -11,7 +11,7 @@
 - [Security](#security)
 
 ## Overview
-This runbook contains operational procedures for the WhatsApp Summarizer application.
+This runbook contains operational procedures for the ConvoLens application.
 
 ## Prerequisites
 - Access to Supabase dashboard
@@ -24,8 +24,8 @@ This runbook contains operational procedures for the WhatsApp Summarizer applica
 ### Local Development Setup
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/whatssummarize.git
-cd whatssummarize
+git clone https://github.com/JustAGhosT/whats-summarize.git
+cd whats-summarize
 
 # Install dependencies
 pnpm install
@@ -158,5 +158,5 @@ supabase db reset
 ## Contact Information
 - **Primary On-call**: [Name] - [Phone] - [Email]
 - **Secondary On-call**: [Name] - [Phone] - [Email]
-- **Infrastructure Team**: infra@whatssummarize.com
-- **Security Team**: security@whatssummarize.com
+- **Infrastructure Team**: infra@convolens.com
+- **Security Team**: security@convolens.com

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,10 +1,15 @@
-# WhatsSummarize Infrastructure
+# ConvoLens Infrastructure
 
-Azure infrastructure as code using Bicep templates for WhatsSummarize.
+Azure infrastructure as code using Bicep templates for ConvoLens.
+
+> **Note:** Azure resource names (e.g. `rg-whatssummarize-*`, `kvwhatssummarizedev`,
+> `cosmos-whatssummarize-dev`, `oai-whatssummarize-dev`) intentionally still
+> reference the legacy project name — renaming live Azure resources is a
+> separate, user-driven decision tracked in PR4 / cross-repo follow-ups.
 
 ## Overview
 
-This directory contains all infrastructure configuration for deploying WhatsSummarize to Azure:
+This directory contains all infrastructure configuration for deploying ConvoLens to Azure:
 
 ```
 infra/

--- a/packages/contexts/src/auth-context.tsx
+++ b/packages/contexts/src/auth-context.tsx
@@ -60,8 +60,16 @@ export type AuthContextType = {
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 // Storage key for user data
-const USER_STORAGE_KEY = 'whatssummarize_user'
-const SESSION_STORAGE_KEY = 'whatssummarize_session'
+const USER_STORAGE_KEY = 'convolens_user'
+const SESSION_STORAGE_KEY = 'convolens_session'
+
+// Legacy storage keys from the WhatsSummarize → ConvoLens rename.
+// Kept here purely so the migration shim below can copy values forward
+// without signing existing users out. These constants (and the migration
+// shim) should be removed ~30 days after the rename ships, or once
+// telemetry confirms zero legacy reads.
+const OLD_USER_STORAGE_KEY = 'whatssummarize_user'
+const OLD_SESSION_STORAGE_KEY = 'whatssummarize_session'
 
 /**
  * Creates a Supabase-like client interface
@@ -174,6 +182,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Initialize authentication state on mount
   useEffect(() => {
     let isMounted = true
+
+    // One-shot localStorage migration from `whatssummarize_*` →
+    // `convolens_*`. Without this, every existing user would be signed out
+    // on the deploy that ships the brand rename. Safe to run on every
+    // mount: after the first run, the legacy keys are gone, so subsequent
+    // mounts are no-ops. Remove this block (and the OLD_* constants
+    // above) ~30 days after deploy.
+    if (typeof window !== 'undefined') {
+      try {
+        const migrations: Array<[string, string]> = [
+          [OLD_USER_STORAGE_KEY, USER_STORAGE_KEY],
+          [OLD_SESSION_STORAGE_KEY, SESSION_STORAGE_KEY],
+        ]
+        for (const [oldK, newK] of migrations) {
+          const legacy = localStorage.getItem(oldK)
+          if (legacy === null) continue
+          const existing = localStorage.getItem(newK)
+          if (existing === null) {
+            localStorage.setItem(newK, legacy)
+          }
+          localStorage.removeItem(oldK)
+        }
+      } catch (err) {
+        // localStorage can throw in private-mode / quota-exceeded
+        // scenarios — never let that block auth init.
+        console.warn('[AuthContext] Legacy storage migration skipped:', err)
+      }
+    }
 
     const initializeAuth = async () => {
       try {


### PR DESCRIPTION
## Summary
PR 2 of 5 in the convolens rename. Sweeps narrative brand strings across README/WARP/docs/web copy and adds a one-shot localStorage migration shim.

## Files (18)
- README, WARP, infra/README, app READMEs, .github/copilot-instructions
- docs/ROADMAP, USER_GUIDE, runbook, AUTHENTICATION, api/openapi.yaml
- apps/web/src layout, landing-page, footer, navigation, supabase placeholder
- packages/contexts/src/auth-context.tsx — localStorage shim

## Critical: localStorage migration

Old keys: \`whatssummarize_user\` / \`whatssummarize_session\`. New keys: \`convolens_user\` / \`convolens_session\`. Auth-context init effect now copies legacy → new on first mount. Without it every existing user is logged out on deploy. Drop the shim ~30 days post-deploy.

## Out of scope (per [docs/convolens-rename-plan.md](docs/convolens-rename-plan.md))
- Azure resource names (PR4 / separate decision)
- Chrome extension (PR3)
- CI / sonar / devcontainer (PR5)
- \`api.whatssummarize.com\` server URL — still live; cuts over with API DNS

## Test plan
- [ ] CI green
- [ ] Existing user with legacy localStorage stays signed in
- [ ] Page \`<title>\` reads ConvoLens
- [ ] No unexpected \`whatssummarize\` strings in rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)