### PR TITLE
chore(convolens): CI / sonar / devcontainer brand refs (PR 5/5)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "WhatsApp Conversation Summarizer Development Environment",
+  "name": "ConvoLens Development Environment",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
 
   "features": {

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -239,7 +239,7 @@ jobs:
             az group create \
               --name "$RG_NAME" \
               --location "${{ env.AZURE_LOCATION }}" \
-              --tags project=whatssummarize environment=${{ matrix.environment }} managedBy=github-actions
+              --tags project=convolens environment=${{ matrix.environment }} managedBy=github-actions
           fi
 
       - name: Deploy Infrastructure

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
     "typeorm",
     "uuidv",
     "vaul",
+    "convolens",
     "whatssummarize",
     "whatwg",
     "xlarge"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 # SonarCloud Configuration
-sonar.projectKey=JustAGhosT_whatssummarize
+sonar.projectKey=JustAGhosT_convolens
 sonar.organization=justaghosth
 
 # Source directories (only scan application source, not tests)


### PR DESCRIPTION
## Summary
PR 5 of 5 in the convolens rename. CI / sonar / devcontainer / cspell brand refs.

## Files (4)
- \`.github/workflows/infrastructure.yml\` — \`--tags project=whatssummarize\` → \`convolens\`
- \`.devcontainer/devcontainer.json\` — container \`name\` → ConvoLens Development Environment
- \`sonar-project.properties\` — \`sonar.projectKey=JustAGhosT_whatssummarize\` → \`JustAGhosT_convolens\`
- \`.vscode/settings.json\` — cSpell.words gains \`convolens\` (legacy \`whatssummarize\` kept; Azure resource names still surface in code)

## Deliberately not changed (per plan)
- \`AZURE_RESOURCE_GROUP_*=rg-whatssummarize-*\` — PR4 leaves rg names alone; separate Azure rename decision
- \`.github/workflows/release-validation.yml\` \`PROJECT=\"whatssummarize\"\` — drives every Azure resource lookup (kv, oai, cosmos, redis, appi, cae, ca); flipping breaks validation
- \`.github/settings.yml\` repo \`name:\` — would force GH repo rename (separate decision)
- \`.github/whatssummarize-mcp-app.json\` — verify live/stale before touching

## User action

**SonarCloud project-key rename is a separate manual UI step**: log into SonarCloud, navigate to project, rename \`JustAGhosT_whatssummarize\` → \`JustAGhosT_convolens\`. May need to rotate \`SONAR_TOKEN\` GH secret afterward.

## Test plan
- [ ] CI workflows still pass (or fail in expected predictable ways pending Sonar UI rename)
- [ ] Devcontainer rebuild shows new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)