### PR TITLE
chore(convolens): db logical names + env defaults (PR 4/5)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,5 @@
 # ===========================================
-# WhatsSummarize API Server - Environment Variables
+# ConvoLens API Server - Environment Variables
 # ===========================================
 # Copy this file to .env and fill in your values
 # NEVER commit .env to version control
@@ -21,7 +21,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
-DB_NAME=whatssummarize
+DB_NAME=convolens
 DB_SYNCHRONIZE=false
 DB_LOGGING=false
 DB_MIGRATIONS_RUN=true
@@ -106,12 +106,12 @@ FRONTEND_URL=http://localhost:3000
 # Azure Cosmos DB (NoSQL database alternative)
 # AZURE_COSMOS_ENDPOINT=https://your-account.documents.azure.com
 # AZURE_COSMOS_KEY=your-cosmos-key
-# AZURE_COSMOS_DATABASE=whatssummarize
+# AZURE_COSMOS_DATABASE=convolens
 # AZURE_COSMOS_CONTAINER=chats
 
 # Azure SQL Database (relational database alternative)
 # AZURE_SQL_SERVER=your-server.database.windows.net
-# AZURE_SQL_DATABASE=whatssummarize
+# AZURE_SQL_DATABASE=convolens
 # AZURE_SQL_USERNAME=your-username
 # AZURE_SQL_PASSWORD=your-password
 # AZURE_SQL_ENCRYPT=true

--- a/apps/api/src/config/azure/index.ts
+++ b/apps/api/src/config/azure/index.ts
@@ -130,7 +130,7 @@ export function getAzureCosmosDBConfig(): AzureCosmosDBConfig | null {
   return {
     endpoint,
     key,
-    databaseName: process.env.AZURE_COSMOS_DATABASE || 'whatssummarize',
+    databaseName: process.env.AZURE_COSMOS_DATABASE || 'convolens',
     containerName: process.env.AZURE_COSMOS_CONTAINER || 'chats',
   };
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
 # ===========================================
-# WhatsSummarize Web App - Environment Variables
+# ConvoLens Web App - Environment Variables
 # ===========================================
 # Copy this file to .env.local and fill in your values
 # NEVER commit .env.local to version control

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -1,7 +1,7 @@
 // =============================================================================
-// WhatsSummarize - Azure Infrastructure (Main Template)
+// ConvoLens - Azure Infrastructure (Main Template)
 // =============================================================================
-// This template deploys all Azure resources required for WhatsSummarize.
+// This template deploys all Azure resources required for ConvoLens.
 // Use with appropriate parameter files for each environment.
 //
 // Resources deployed:
@@ -30,10 +30,15 @@ param environment string = 'dev'
 @description('Azure region for resources')
 param location string = resourceGroup().location
 
-@description('Project name used for resource naming')
+@description('Project name used for resource naming. Resource names retain the legacy "whatssummarize" prefix until a separate user-driven Azure rename decision lands.')
 @minLength(3)
 @maxLength(15)
 param projectName string = 'whatssummarize'
+
+@description('Logical database name used for Cosmos DB (and future Azure SQL). Decoupled from projectName so the brand rename can land without renaming Azure resources. Override at deploy time only when migrating data.')
+@minLength(3)
+@maxLength(40)
+param databaseName string = 'convolens'
 
 @description('Enable Azure OpenAI deployment')
 param enableOpenAI bool = true
@@ -152,7 +157,7 @@ module cosmosDB 'modules/cosmos-db.bicep' = if (enableCosmosDB) {
     name: 'cosmos-${resourcePrefix}'
     location: location
     tags: tags
-    databaseName: projectName
+    databaseName: databaseName
     containers: [
       {
         name: 'users'


### PR DESCRIPTION
## Summary
PR 4 of 5 in the convolens rename. Decouples the Cosmos **logical database name** from the Azure **resource-naming prefix** so the brand rename can land without renaming any Azure resources.

## Changes (4 files, +15/-10)

- \`apps/api/.env.example\` — header → ConvoLens; \`DB_NAME\`, \`AZURE_COSMOS_DATABASE\`, \`AZURE_SQL_DATABASE\` example values → \`convolens\`
- \`apps/web/.env.example\` — header → ConvoLens
- \`apps/api/src/config/azure/index.ts\` — \`AZURE_COSMOS_DATABASE\` fallback → \`'convolens'\`
- \`infra/bicep/main.bicep\` — header → ConvoLens; **new param \`databaseName\`** defaulting to \`'convolens'\`, wired into Cosmos module (was \`databaseName: projectName\`)

## Azure resource names — intentionally unchanged

\`rg-whatssummarize-*\`, \`kvwhatssummarizedev\`, \`cosmos-whatssummarize-dev\`, \`oai-whatssummarize-dev\`, etc. all stay. Separate Azure rename decision is queued. \`infra/scripts/*\` PROJECT_NAME also unchanged for the same reason — those drive resource lookups, not naming logic.

## Production deploy note

The Bicep change deploys a *new* \`convolens\` Cosmos database on the *existing* \`cosmos-whatssummarize-dev\` account. Any prod env currently pointing app config at \`DB_NAME=whatssummarize\` needs an explicit override at deploy time until the data migrates over.

## Test plan
- [ ] \`az bicep build --file infra/bicep/main.bicep\` succeeds (syntax)
- [ ] \`az deployment group what-if\` (against existing \`rg-whatssummarize-dev\`) shows only the new \`databaseName\` param and Cosmos DB diff — no resource-group / app-service / KV renames
- [ ] \`pnpm --filter @convolens/api typecheck\` passes
- [ ] \`.env.example\` keys match what \`apps/api/src/config/*\` reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)