### PR TITLE
chore: seed .todo.yaml and .roadmap.yaml for baton sync

### DIFF
--- a/.roadmap.yaml
+++ b/.roadmap.yaml
@@ -1,0 +1,49 @@
+version: "1.0"
+scope: roadmap
+repo: neuralliquid/convolens
+updated_at: 2026-05-11
+# Seeded from org-meta/roadmaps/convolens.md (week-by-week plan).
+
+tasks:
+  - id: week1-harden-upload
+    title: "Week 1 — Harden file upload + add DB persistence (TypeORM ChatExport entity, real progress, fix auth token)"
+    priority: high
+    status: todo
+    quarter: "2026-Q2"
+    tags: [upload, persistence, auth]
+
+  - id: week2-multiformat-parser
+    title: "Week 2 — Multi-format parser: Android bracketless, multi-line messages, locale-aware date parsing"
+    priority: high
+    status: todo
+    quarter: "2026-Q2"
+    tags: [parser, android, locale]
+
+  - id: week3-summarisation
+    title: "Week 3 — Wire summarisation: POST /api/chat-export/:id/summarize, real SSE streaming, summary-cache LRU"
+    priority: high
+    status: todo
+    quarter: "2026-Q2"
+    tags: [summarization, sse, cache]
+
+  - id: week4-telegram-discord
+    title: "Week 4 — Telegram + Discord bots: grammy + discord.js apps, webhooks, command handlers"
+    priority: medium
+    status: todo
+    quarter: "2026-Q3"
+    tags: [telegram, discord, bots]
+
+  - id: post-launch-multi-llm
+    title: "Post-launch — Multi-LLM cost optimisation: route summarisation through sluice for per-call cost attribution in docket"
+    priority: medium
+    status: todo
+    quarter: "2026-Q3"
+    tags: [sluice, docket, cost-ops]
+
+  - id: org-transfer-cleanup
+    title: "Org transfer cleanup: update CI badges, federated creds, OIDC subjects after neuralliquid/convolens rename settles"
+    description: "Repo moved from JustAGhosT/whatssummarize to neuralliquid/convolens. Verify CI workflows, Azure federated creds, and any consumer references all use the new canonical name."
+    priority: medium
+    status: todo
+    quarter: "2026-Q2"
+    tags: [ci, federated-creds, neuralliquid]

--- a/.todo.yaml
+++ b/.todo.yaml
@@ -1,0 +1,48 @@
+version: "1.0"
+scope: todo
+repo: neuralliquid/convolens
+updated_at: 2026-05-11
+# Seeded from org-meta/roadmaps/convolens.md (Critical Gaps section).
+
+tasks:
+  - id: wire-summary-service
+    title: "Wire SummaryService to upload route — currently fully implemented but never called"
+    description: "SummaryService is complete (Azure → OpenAI → Anthropic → Mock cascade with retries) but no POST /api/chat-export/:id/summarize endpoint exists. Upload route returns raw parse counts without triggering summarisation."
+    priority: high
+    status: todo
+    tags: [api, summarization, gap]
+
+  - id: android-whatsapp-parser
+    title: "Add Android WhatsApp format parser — bracket-less format silently drops messages"
+    description: "Current regex uses bracket delimiters (^\\[…\\]) — iOS/desktop only. Android format (no brackets, e.g. 18/03/2026, 14:30 - Sender: message) silently drops all messages. Multi-line messages also silently discarded."
+    priority: high
+    status: todo
+    tags: [parser, android, gap]
+
+  - id: persist-parsed-data
+    title: "Persist parsed data to DB after upload"
+    description: "apps/api/src/routes/chat-export.routes.ts:54 has 'TODO: Store chatData in the database' — parsed data returned directly without saving."
+    priority: high
+    status: todo
+    tags: [database, persistence, gap]
+
+  - id: chrome-extension-route
+    title: "Implement POST /api/chat-export/extension — Chrome extension calls a 404 route"
+    description: "apps/chrome-extension/src/background.ts:119 calls a route that does not exist. Extension is fully built but the endpoint returns 404."
+    priority: high
+    status: todo
+    tags: [chrome-extension, api, gap]
+
+  - id: fix-session-accesstoken
+    title: "Fix non-standard session.accessToken usage in upload proxy"
+    description: "apps/web/src/app/api/chat-export/upload/route.ts uses session.accessToken which is not a standard NextAuth field. Replace with proper NextAuth/Supabase token extraction."
+    priority: medium
+    status: todo
+    tags: [auth, hygiene, gap]
+
+  - id: real-upload-progress
+    title: "Replace fake upload progress with real XHR progress events"
+    description: "apps/web/src/hooks/useFileUpload.ts has a progress state that never increments between 0 and 100 — replace with XMLHttpRequest upload.onprogress."
+    priority: low
+    status: todo
+    tags: [ui, hygiene]


### PR DESCRIPTION
## Summary

- Adds `.todo.yaml` and `.roadmap.yaml` at repo root so baton's `POST /:id/sync-yaml` can pull this repo's tasks into the shared task graph.
- Content seeded from `org-meta/roadmaps/convolens.md` (the technical roadmap mirror): the six critical gaps + a four-week plan.
- Schema matches the working pattern used by `phoenixvc/sluice` and `phoenixvc/docket`.

No code changes. Pure data files.

## Test plan

- [ ] `pnpm run typecheck` still passes (these files are not picked up by tsc).
- [ ] `pnpm run build` still passes.
- [ ] After merge, run baton's `sync_repo_yaml` against the convolens project — verify tasks land.