### PR TITLE
Grant dev Terraform CI access to Key Vault

### DIFF
--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -194,13 +194,26 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   secret_permissions = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
 }
 
+resource "azurerm_key_vault_access_policy" "ci_deployers" {
+  for_each = var.ci_deployer_object_ids
+
+  key_vault_id = azurerm_key_vault.kv.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = each.value
+
+  secret_permissions = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
+}
+
 resource "azurerm_key_vault_secret" "cosmos_endpoint" {
   count        = var.enable_cosmos ? 1 : 0
   name         = "cosmos-db-endpoint"
   value        = azurerm_cosmosdb_account.cosmos[0].endpoint
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "cosmos_key" {
@@ -209,7 +222,10 @@ resource "azurerm_key_vault_secret" "cosmos_key" {
   value        = azurerm_cosmosdb_account.cosmos[0].primary_key
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "cosmos_connection_string" {
@@ -218,7 +234,10 @@ resource "azurerm_key_vault_secret" "cosmos_connection_string" {
   value        = azurerm_cosmosdb_account.cosmos[0].primary_sql_connection_string
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "appinsights_connection_string" {
@@ -226,7 +245,10 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
   value        = azurerm_application_insights.ai.connection_string
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_key_vault_secret" "storage_connection_string" {
@@ -234,7 +256,10 @@ resource "azurerm_key_vault_secret" "storage_connection_string" {
   value        = azurerm_storage_account.st.primary_connection_string
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_redis_cache" "redis" {
@@ -255,7 +280,10 @@ resource "azurerm_key_vault_secret" "redis_password" {
   value        = azurerm_redis_cache.redis[0].primary_access_key
   key_vault_id = azurerm_key_vault.kv.id
 
-  depends_on = [azurerm_key_vault_access_policy.deployer]
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.ci_deployers,
+  ]
 }
 
 resource "azurerm_cognitive_account" "openai" {

--- a/infra/terraform/env/dev/terraform.tfvars
+++ b/infra/terraform/env/dev/terraform.tfvars
@@ -12,6 +12,10 @@ enable_container_apps = true
 enable_static_web_app = true
 enable_budget_alerts  = false
 
+ci_deployer_object_ids = [
+  "d487629d-0758-4192-bf00-dfd4f214a738", # GitHub Actions OIDC service principal
+]
+
 admin_email           = ""
 monthly_budget_amount = 100
 

--- a/infra/terraform/env/dev/variables.tf
+++ b/infra/terraform/env/dev/variables.tf
@@ -76,6 +76,12 @@ variable "enable_budget_alerts" {
   default     = true
 }
 
+variable "ci_deployer_object_ids" {
+  type        = set(string)
+  description = "Microsoft Entra object IDs for CI/CD principals that need Key Vault secret permissions during Terraform plan/apply."
+  default     = []
+}
+
 variable "admin_email" {
   type        = string
   description = "Email address that receives budget alerts. Empty disables budget alerts regardless of enable_budget_alerts."


### PR DESCRIPTION
## Summary
- add a managed dev Key Vault access policy for the GitHub Actions OIDC service principal
- keep existing secret resources dependent on both deployer and CI access policies
- record the CI object ID in dev tfvars so local applies preserve CI data-plane access

## Fixes
- Addresses the failed main Infrastructure run: https://github.com/neuralliquid/convolens/actions/runs/29586641397
- Root cause: Apply (dev) could authenticate with Azure, but the service principal lacked Key Vault secret get/list permissions for existing dev secrets before Terraform could refresh/apply them.

## Validation
- terraform fmt -recursive infra/terraform/env/dev
- git diff --check -- infra/terraform/env/dev/main.tf infra/terraform/env/dev/variables.tf infra/terraform/env/dev/terraform.tfvars

## Follow-up
- One-time bootstrap is still needed on nl-dev-convolens-kv if CI reruns before this policy has been applied by an actor that already has Key Vault data-plane access.