### PR TITLE
Bootstrap dev Key Vault access before Terraform apply

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -212,6 +212,23 @@ jobs:
           tenant-id: ${{ steps.azure-creds.outputs.tenant-id }}
           subscription-id: ${{ steps.azure-creds.outputs.subscription-id }}
 
+      - name: Bootstrap Dev Key Vault Access
+        if: matrix.environment == 'dev'
+        run: |
+          set -euo pipefail
+          DEPLOYER_OBJECT_ID=$(az ad sp show \
+            --id "${{ steps.azure-creds.outputs.client-id }}" \
+            --query id \
+            -o tsv)
+          if [ -z "$DEPLOYER_OBJECT_ID" ]; then
+            echo "Error: failed to resolve Azure service principal object ID" >&2
+            exit 1
+          fi
+          az keyvault set-policy \
+            --name nl-dev-convolens-kv \
+            --object-id "$DEPLOYER_OBJECT_ID" \
+            --secret-permissions get list set delete purge recover
+
       - name: Terraform Init
         env:
           ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}


### PR DESCRIPTION
## Summary
- add a dev-only pre-apply bootstrap step that grants the GitHub Actions OIDC principal Key Vault secret permissions
- run the bootstrap after Azure OIDC login and before Terraform init/apply, so Terraform can refresh existing Key Vault secrets

## Fixes
- Follow-up for failed Infrastructure run https://github.com/neuralliquid/convolens/actions/runs/29604080648
- Complements #83, which added the durable Terraform-managed Key Vault access policy.

## Validation
- git diff --check -- .github/workflows/infrastructure.yml