### PR TITLE
Import bootstrapped dev Key Vault policy before apply

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -213,6 +213,7 @@ jobs:
           subscription-id: ${{ steps.azure-creds.outputs.subscription-id }}
 
       - name: Bootstrap Dev Key Vault Access
+        id: bootstrap-dev-keyvault
         if: matrix.environment == 'dev'
         run: |
           set -euo pipefail
@@ -228,6 +229,7 @@ jobs:
             --name nl-dev-convolens-kv \
             --object-id "$DEPLOYER_OBJECT_ID" \
             --secret-permissions get list set delete purge recover
+          echo "deployer-object-id=$DEPLOYER_OBJECT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Terraform Init
         env:
@@ -235,6 +237,19 @@ jobs:
           ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
           ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} init -backend-config=backend.hcl
+
+      - name: Import Bootstrapped Dev Key Vault Access
+        if: matrix.environment == 'dev'
+        env:
+          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
+          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
+          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
+          DEPLOYER_OBJECT_ID: ${{ steps.bootstrap-dev-keyvault.outputs.deployer-object-id }}
+        run: |
+          set -euo pipefail
+          POLICY_ID="/subscriptions/$ARM_SUBSCRIPTION_ID/resourceGroups/nl-dev-convolens-rg/providers/Microsoft.KeyVault/vaults/nl-dev-convolens-kv/objectId/$DEPLOYER_OBJECT_ID"
+          terraform -chdir=infra/terraform/env/${{ matrix.environment }} state rm azurerm_key_vault_access_policy.deployer || true
+          terraform -chdir=infra/terraform/env/${{ matrix.environment }} import -input=false azurerm_key_vault_access_policy.deployer "$POLICY_ID"
 
       - name: Terraform Apply
         env:

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -195,7 +195,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
 }
 
 resource "azurerm_key_vault_access_policy" "ci_deployers" {
-  for_each = var.ci_deployer_object_ids
+  for_each = setsubtract(var.ci_deployer_object_ids, [data.azurerm_client_config.current.object_id])
 
   key_vault_id = azurerm_key_vault.kv.id
   tenant_id    = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
## Summary
- import the bootstrapped dev Key Vault access policy into the Terraform deployer state address before apply
- avoid creating a duplicate ci_deployers access policy for the current authenticated principal

## Fixes
- Follow-up for failed Infrastructure run https://github.com/neuralliquid/convolens/actions/runs/29608722191
- The previous bootstrap resolved the secret read 403, but Terraform then collided with the same pre-created access policy during apply.

## Validation
- terraform fmt -recursive infra/terraform/env/dev
- git diff --check -- infra/terraform/env/dev/main.tf .github/workflows/infrastructure.yml