### PR TITLE
Keep prod frontend on B1 for custom TLS

### DIFF
--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -365,8 +365,9 @@ resource "azurerm_service_plan" "frontend" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   os_type             = "Linux"
-  sku_name            = "F1"
-  tags                = local.tags
+  # B1 is the lowest App Service tier that supports managed certificates for custom domains.
+  sku_name = "B1"
+  tags     = local.tags
 }
 
 resource "azurerm_linux_web_app" "frontend" {


### PR DESCRIPTION
## Summary
- keep the prod frontend App Service plan on B1 instead of F1
- document that B1 is required for App Service managed certificates on the custom domain

## Context
- convolens.neuralliquid.ai was bound live and now serves HTTPS successfully.
- Azure blocks managed certificate creation on Free/Shared App Service plans, so B1 is the minimum SKU that keeps the custom-domain TLS path working.

## Validation
- terraform fmt -recursive infra/terraform/env/prod
- terraform validate in infra/terraform/env/prod
- git diff --check -- infra/terraform/env/prod/main.tf