### PR TITLE
fix: switch Azure workflows to OIDC

### DIFF
--- a/.azure/pipeline-setup.md
+++ b/.azure/pipeline-setup.md
@@ -1,0 +1,44 @@
+# Convolens Pipeline Auth Setup
+
+Convolens production CI/CD uses GitHub Actions OIDC against the existing Entra app registration `convolens-sp`.
+
+## Current Target
+
+- GitHub repo: `neuralliquid/convolens`
+- Azure tenant: `9530cd32-9e33-47f0-9247-ed964730b580`
+- Azure subscription: `bb4e3882-2079-4bab-8974-611bc0b8bb58`
+- Entra app/client id: `8f57a349-eb88-40fd-81eb-1065f84e668b`
+- Service principal object id: `d487629d-0758-4192-bf00-dfd4f214a738`
+
+## Required GitHub Variables
+
+Set these as repository variables:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+The values are non-secret identifiers. Do not use the stale `AZURE_CREDENTIALS` secret for deployment.
+
+## Required Federated Credentials
+
+The Entra app registration needs GitHub OIDC federated credentials for each GitHub environment used by deployment workflows:
+
+- `repo:neuralliquid/convolens:environment:dev`
+- `repo:neuralliquid/convolens:environment:prod`
+- `repo:neuralliquid/convolens:environment:Production`
+
+`prod` is used by the infrastructure workflow. `Production` is retained for the production deploy workflow while that GitHub environment exists.
+
+## Required RBAC
+
+The service principal must have deployment rights on the target subscription or narrowed resource groups. Current recovery uses `Contributor` on the Mystira subscription so Terraform can create/update the production resource group, state storage, ACR, Container App, and App Service resources.
+
+## Verification
+
+Before running production deploy:
+
+1. Confirm the GitHub variables exist with `gh variable list --repo neuralliquid/convolens`.
+2. Confirm federated credentials with `az ad app federated-credential list --id 8f57a349-eb88-40fd-81eb-1065f84e668b`.
+3. Run the infrastructure workflow with `environment=prod` and `action=plan`.
+4. Run production deploy only after the plan is reviewed.

--- a/.azure/setup-azure-auth-for-pipeline.ps1
+++ b/.azure/setup-azure-auth-for-pipeline.ps1
@@ -1,0 +1,37 @@
+param(
+  [string]$Repo = "neuralliquid/convolens",
+  [string]$AppId = "8f57a349-eb88-40fd-81eb-1065f84e668b",
+  [string]$TenantId = "9530cd32-9e33-47f0-9247-ed964730b580",
+  [string]$SubscriptionId = "bb4e3882-2079-4bab-8974-611bc0b8bb58"
+)
+
+$ErrorActionPreference = "Stop"
+
+gh variable set AZURE_CLIENT_ID --repo $Repo --body $AppId
+gh variable set AZURE_TENANT_ID --repo $Repo --body $TenantId
+gh variable set AZURE_SUBSCRIPTION_ID --repo $Repo --body $SubscriptionId
+
+$credentials = @(
+  @{ name = "github-actions-dev"; subject = "repo:${Repo}:environment:dev" },
+  @{ name = "github-actions-prod"; subject = "repo:${Repo}:environment:prod" },
+  @{ name = "github-actions-production"; subject = "repo:${Repo}:environment:Production" }
+)
+
+foreach ($credential in $credentials) {
+  $existing = az ad app federated-credential list --id $AppId `
+    --query "[?name=='$($credential.name)'] | length(@)" `
+    -o tsv
+
+  if ($existing -eq "0") {
+    $body = @{
+      name = $credential.name
+      issuer = "https://token.actions.githubusercontent.com"
+      subject = $credential.subject
+      audiences = @("api://AzureADTokenExchange")
+    } | ConvertTo-Json -Compress
+
+    $path = Join-Path $PSScriptRoot "$($credential.name).json"
+    Set-Content -Path $path -Value $body
+    az ad app federated-credential create --id $AppId --parameters $path
+  }
+}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,12 +5,17 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   TF_VERSION: '1.14.7'
   TF_IN_AUTOMATION: 'true'
   TF_INPUT: '0'
   ENVIRONMENT: prod
+  ARM_USE_OIDC: 'true'
+  ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+  ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
 jobs:
   deploy:
@@ -38,32 +43,22 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
 
-      - name: Parse Azure Credentials
-        id: azure-creds
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Verify Azure OIDC Configuration
         run: |
           set -euo pipefail
-          CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
-          CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
-          TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
-          SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
-          for v in "$CLIENT_ID" "$CLIENT_SECRET" "$TENANT_ID" "$SUBSCRIPTION_ID"; do
-            if [ "$v" = "null" ] || [ -z "$v" ]; then
-              echo "Error: AZURE_CREDENTIALS must include clientId/clientSecret/tenantId/subscriptionId for the temporary secret-based deploy path" >&2
+          for v in "$ARM_CLIENT_ID" "$ARM_TENANT_ID" "$ARM_SUBSCRIPTION_ID"; do
+            if [ -z "$v" ]; then
+              echo "Error: AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID repository variables are required for OIDC deploys." >&2
               exit 1
             fi
           done
-          echo "client-id=$CLIENT_ID" >> "$GITHUB_OUTPUT"
-          echo "::add-mask::$CLIENT_SECRET"
-          echo "client-secret=$CLIENT_SECRET" >> "$GITHUB_OUTPUT"
-          echo "tenant-id=$TENANT_ID" >> "$GITHUB_OUTPUT"
-          echo "subscription-id=$SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
 
       - name: Azure Login
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install dependencies
         timeout-minutes: 10
@@ -115,29 +110,15 @@ jobs:
             --fail-on-exist false
 
       - name: Terraform Init
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_CLIENT_SECRET: ${{ steps.azure-creds.outputs.client-secret }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: terraform -chdir=infra/terraform/env/prod init -backend-config=backend.hcl
 
       - name: Terraform Apply Base Infrastructure
         env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_CLIENT_SECRET: ${{ steps.azure-creds.outputs.client-secret }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
         run: terraform -chdir=infra/terraform/env/prod apply -auto-approve
 
       - name: Capture Terraform Outputs
         id: tf
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_CLIENT_SECRET: ${{ steps.azure-creds.outputs.client-secret }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: |
           terraform -chdir=infra/terraform/env/prod output -json > tf-outputs.json
           echo "resource-group=$(jq -r '.resource_group_name.value' tf-outputs.json)" >> "$GITHUB_OUTPUT"
@@ -170,10 +151,6 @@ jobs:
             -var "container_image_api=${{ steps.api-image.outputs.image }}" \
             -var "api_target_port=3001"
         env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_CLIENT_SECRET: ${{ steps.azure-creds.outputs.client-secret }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
 
       - name: Rebuild Web With Production API URL
@@ -199,13 +176,23 @@ jobs:
           zip -r ../web.zip .
 
       - name: Deploy Web App
+        env:
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          MYSTIRA_IDENTITY_CLIENT_SECRET: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_SECRET }}
         run: |
-          az webapp config appsettings set \
-            --resource-group "${{ steps.tf.outputs.resource-group }}" \
-            --name "${{ steps.tf.outputs.web-name }}" \
-            --settings \
-              NEXTAUTH_SECRET="${{ secrets.NEXTAUTH_SECRET }}" \
-              MYSTIRA_IDENTITY_CLIENT_SECRET="${{ secrets.MYSTIRA_IDENTITY_CLIENT_SECRET }}"
+          SETTINGS=()
+          if [ -n "$NEXTAUTH_SECRET" ]; then
+            SETTINGS+=(NEXTAUTH_SECRET="$NEXTAUTH_SECRET")
+          fi
+          if [ -n "$MYSTIRA_IDENTITY_CLIENT_SECRET" ]; then
+            SETTINGS+=(MYSTIRA_IDENTITY_CLIENT_SECRET="$MYSTIRA_IDENTITY_CLIENT_SECRET")
+          fi
+          if [ "${#SETTINGS[@]}" -gt 0 ]; then
+            az webapp config appsettings set \
+              --resource-group "${{ steps.tf.outputs.resource-group }}" \
+              --name "${{ steps.tf.outputs.web-name }}" \
+              --settings "${SETTINGS[@]}"
+          fi
           az webapp deploy \
             --resource-group "${{ steps.tf.outputs.resource-group }}" \
             --name "${{ steps.tf.outputs.web-name }}" \

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -44,6 +44,9 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_INPUT: '0'
   ARM_USE_OIDC: 'true'
+  ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+  ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
 jobs:
   # =============================================================================
@@ -95,45 +98,28 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Parse Azure Credentials
-        id: azure-creds
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Verify Azure OIDC Configuration
         run: |
           set -euo pipefail
-          CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
-          TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
-          SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
-          for v in "$CLIENT_ID" "$TENANT_ID" "$SUBSCRIPTION_ID"; do
-            if [ "$v" = "null" ] || [ -z "$v" ]; then
-              echo "Error: AZURE_CREDENTIALS missing clientId/tenantId/subscriptionId" >&2
+          for v in "$ARM_CLIENT_ID" "$ARM_TENANT_ID" "$ARM_SUBSCRIPTION_ID"; do
+            if [ -z "$v" ]; then
+              echo "Error: AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID repository variables are required for OIDC deploys." >&2
               exit 1
             fi
           done
-          echo "client-id=$CLIENT_ID" >> "$GITHUB_OUTPUT"
-          echo "tenant-id=$TENANT_ID" >> "$GITHUB_OUTPUT"
-          echo "subscription-id=$SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
 
       - name: Azure Login (OIDC)
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@v2
         with:
-          client-id: ${{ steps.azure-creds.outputs.client-id }}
-          tenant-id: ${{ steps.azure-creds.outputs.tenant-id }}
-          subscription-id: ${{ steps.azure-creds.outputs.subscription-id }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform Init
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} init -backend-config=backend.hcl
 
       - name: Terraform Plan
         id: plan
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: |
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} plan -no-color -out=tfplan | tee plan-output.txt
           {
@@ -188,31 +174,22 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
 
-      - name: Parse Azure Credentials
-        id: azure-creds
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Verify Azure OIDC Configuration
         run: |
           set -euo pipefail
-          CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
-          TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
-          SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
-          for v in "$CLIENT_ID" "$TENANT_ID" "$SUBSCRIPTION_ID"; do
-            if [ "$v" = "null" ] || [ -z "$v" ]; then
-              echo "Error: AZURE_CREDENTIALS missing clientId/tenantId/subscriptionId" >&2
+          for v in "$ARM_CLIENT_ID" "$ARM_TENANT_ID" "$ARM_SUBSCRIPTION_ID"; do
+            if [ -z "$v" ]; then
+              echo "Error: AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID repository variables are required for OIDC deploys." >&2
               exit 1
             fi
           done
-          echo "client-id=$CLIENT_ID" >> "$GITHUB_OUTPUT"
-          echo "tenant-id=$TENANT_ID" >> "$GITHUB_OUTPUT"
-          echo "subscription-id=$SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
 
       - name: Azure Login (OIDC)
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@v2
         with:
-          client-id: ${{ steps.azure-creds.outputs.client-id }}
-          tenant-id: ${{ steps.azure-creds.outputs.tenant-id }}
-          subscription-id: ${{ steps.azure-creds.outputs.subscription-id }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Bootstrap Dev Key Vault Access
         id: bootstrap-dev-keyvault
@@ -220,7 +197,7 @@ jobs:
         run: |
           set -euo pipefail
           DEPLOYER_OBJECT_ID=$(az ad sp show \
-            --id "${{ steps.azure-creds.outputs.client-id }}" \
+            --id "$ARM_CLIENT_ID" \
             --query id \
             -o tsv)
           if [ -z "$DEPLOYER_OBJECT_ID" ]; then
@@ -234,18 +211,11 @@ jobs:
           echo "deployer-object-id=$DEPLOYER_OBJECT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Terraform Init
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} init -backend-config=backend.hcl
 
       - name: Import Bootstrapped Dev Key Vault Access
         if: matrix.environment == 'dev'
         env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
           DEPLOYER_OBJECT_ID: ${{ steps.bootstrap-dev-keyvault.outputs.deployer-object-id }}
         run: |
           set -euo pipefail
@@ -254,18 +224,10 @@ jobs:
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} import -input=false azurerm_key_vault_access_policy.deployer "$POLICY_ID"
 
       - name: Terraform Apply
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} apply -auto-approve
 
       - name: Capture Outputs
         id: outputs
-        env:
-          ARM_CLIENT_ID: ${{ steps.azure-creds.outputs.client-id }}
-          ARM_TENANT_ID: ${{ steps.azure-creds.outputs.tenant-id }}
-          ARM_SUBSCRIPTION_ID: ${{ steps.azure-creds.outputs.subscription-id }}
         run: |
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} output -json > tf-outputs.json
           CONTAINER_APP_URL=$(jq -r '.container_app_url.value // ""' tf-outputs.json)

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -27,6 +27,12 @@ permissions:
   contents: read
   issues: write
 
+env:
+  ARM_USE_OIDC: 'true'
+  ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+  ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+  ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
 jobs:
   # =============================================================================
   # Validate Infrastructure Exists
@@ -48,39 +54,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Parse Azure Credentials
-        id: azure-creds
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Verify Azure OIDC Configuration
         run: |
           set -euo pipefail
-          CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
-          TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
-          SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
-          
-          # Validate that parsing succeeded
-          if [ "$CLIENT_ID" = "null" ] || [ -z "$CLIENT_ID" ]; then
-            echo "Error: Failed to parse clientId from AZURE_CREDENTIALS"
-            exit 1
-          fi
-          if [ "$TENANT_ID" = "null" ] || [ -z "$TENANT_ID" ]; then
-            echo "Error: Failed to parse tenantId from AZURE_CREDENTIALS"
-            exit 1
-          fi
-          if [ "$SUBSCRIPTION_ID" = "null" ] || [ -z "$SUBSCRIPTION_ID" ]; then
-            echo "Error: Failed to parse subscriptionId from AZURE_CREDENTIALS"
-            exit 1
-          fi
-          
-          echo "client-id=$CLIENT_ID" >> $GITHUB_OUTPUT
-          echo "tenant-id=$TENANT_ID" >> $GITHUB_OUTPUT
-          echo "subscription-id=$SUBSCRIPTION_ID" >> $GITHUB_OUTPUT
+          for v in "$ARM_CLIENT_ID" "$ARM_TENANT_ID" "$ARM_SUBSCRIPTION_ID"; do
+            if [ -z "$v" ]; then
+              echo "Error: AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID repository variables are required for OIDC validation." >&2
+              exit 1
+            fi
+          done
       - name: Azure Login
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@v2
         with:
-          client-id: ${{ steps.azure-creds.outputs.client-id }}
-          tenant-id: ${{ steps.azure-creds.outputs.tenant-id }}
-          subscription-id: ${{ steps.azure-creds.outputs.subscription-id }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ logs
 .cache
 .temp
 .tmp
+.aztmp/
 actionlint
 infra/bicep/*.json
 **/.terraform/


### PR DESCRIPTION
## Summary
- replace stale AZURE_CREDENTIALS workflow auth with GitHub OIDC repo variables
- add missing Entra federated credential setup documentation/script
- avoid blank-overwriting optional web secrets during production deploy

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/deploy-prod.yml .github/workflows/infrastructure.yml .github/workflows/release-validation.yml
- terraform -chdir=infra/terraform/env/dev fmt -check -recursive
- terraform -chdir=infra/terraform/env/prod fmt -check -recursive
- terraform -chdir=infra/terraform/env/dev init -backend=false
- terraform -chdir=infra/terraform/env/prod init -backend=false
- terraform -chdir=infra/terraform/env/dev validate
- terraform -chdir=infra/terraform/env/prod validate
- CI=true PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true pnpm run build

## Live setup performed
- added GitHub repo variables AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID for the Mystira subscription
- added Entra federated credentials for environment:Production and environment:prod on convolens-sp
