### PR TITLE
fix: use idempotent tfstate container create

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -113,8 +113,7 @@ jobs:
           az storage container create \
             --name tfstate \
             --account-name nltfstateconvolens \
-            --account-key "$ACCOUNT_KEY" \
-            --fail-on-exist false
+            --account-key "$ACCOUNT_KEY"
 
       - name: Terraform Init
         run: terraform -chdir=infra/terraform/env/prod init -backend-config=backend.hcl


### PR DESCRIPTION
## Summary
- remove unsupported Azure CLI boolean value from tfstate container creation

## Why
The production deploy reached backend bootstrap but failed with unrecognized arguments: false on az storage container create.

## Validation
- actionlint .github/workflows/deploy-prod.yml
- git diff --check
