### PR TITLE
fix: harden API Docker pnpm install

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:24-alpine AS builder
 
 WORKDIR /repo
-RUN corepack enable
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+RUN npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 20000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm install -g pnpm@8.15.4
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
 COPY apps ./apps


### PR DESCRIPTION
## Summary
- install pnpm in the API Docker builder via npm with retry settings
- carry Puppeteer browser-download skip flags into the Docker build

## Why
The production ACR build failed after infra apply because Corepack received HTTP 504 while fetching pnpm 8.15.4.

## Validation
- pnpm --filter @convolens/api build
- git diff --check

Note: local Docker image build was not run because Docker Desktop is not running on this machine.
