### PR TITLE
fix: preserve api runtime during prod base apply

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -118,10 +118,38 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=infra/terraform/env/prod init -backend-config=backend.hcl
 
+      - name: Resolve Base API Runtime
+        id: base-api
+        run: |
+          DEFAULT_IMAGE="mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+          DEFAULT_PORT="80"
+          CURRENT_IMAGE=$(az containerapp show \
+            --resource-group nl-prod-convolens-rg \
+            --name nl-prod-convolens-api \
+            --query 'properties.template.containers[0].image' \
+            -o tsv 2>/dev/null || true)
+          CURRENT_PORT=$(az containerapp show \
+            --resource-group nl-prod-convolens-rg \
+            --name nl-prod-convolens-api \
+            --query 'properties.configuration.ingress.targetPort' \
+            -o tsv 2>/dev/null || true)
+          if [ -z "$CURRENT_IMAGE" ]; then
+            CURRENT_IMAGE="$DEFAULT_IMAGE"
+          fi
+          if [ "$CURRENT_IMAGE" = "$DEFAULT_IMAGE" ] || [ -z "$CURRENT_PORT" ]; then
+            CURRENT_PORT="$DEFAULT_PORT"
+          fi
+          echo "image=$CURRENT_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "target-port=$CURRENT_PORT" >> "$GITHUB_OUTPUT"
+
       - name: Terraform Apply Base Infrastructure
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
-        run: terraform -chdir=infra/terraform/env/prod apply -auto-approve
+        run: |
+          terraform -chdir=infra/terraform/env/prod apply \
+            -auto-approve \
+            -var "container_image_api=${{ steps.base-api.outputs.image }}" \
+            -var "api_target_port=${{ steps.base-api.outputs.target-port }}"
 
       - name: Capture Terraform Outputs
         id: tf

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -202,6 +202,21 @@ resource "azurerm_container_registry" "acr" {
   tags                          = local.tags
 }
 
+resource "azurerm_user_assigned_identity" "api_acr_pull" {
+  count               = var.enable_container_registry ? 1 : 0
+  name                = "${local.api_name}-acr-pull-id"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "api_acr_pull" {
+  count                = var.enable_container_registry ? 1 : 0
+  scope                = azurerm_container_registry.acr[0].id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.api_acr_pull[0].principal_id
+}
+
 resource "azurerm_container_app_environment" "cae" {
   name                       = local.cae_name
   location                   = azurerm_resource_group.rg.location
@@ -218,7 +233,8 @@ resource "azurerm_container_app" "api" {
   tags                         = local.tags
 
   identity {
-    type = "SystemAssigned"
+    type         = var.enable_container_registry ? "SystemAssigned, UserAssigned" : "SystemAssigned"
+    identity_ids = var.enable_container_registry ? [azurerm_user_assigned_identity.api_acr_pull[0].id] : []
   }
 
   secret {
@@ -236,7 +252,7 @@ resource "azurerm_container_app" "api" {
 
     content {
       server   = registry.value.login_server
-      identity = "system"
+      identity = azurerm_user_assigned_identity.api_acr_pull[0].id
     }
   }
 
@@ -357,6 +373,10 @@ resource "azurerm_container_app" "api" {
       concurrent_requests = "100"
     }
   }
+
+  depends_on = [
+    azurerm_role_assignment.api_acr_pull
+  ]
 }
 
 resource "azurerm_service_plan" "frontend" {
@@ -435,13 +455,6 @@ resource "azurerm_role_assignment" "api_queue_contributor" {
 resource "azurerm_role_assignment" "api_key_vault_secrets_user" {
   scope                = azurerm_key_vault.kv.id
   role_definition_name = "Key Vault Secrets User"
-  principal_id         = azurerm_container_app.api.identity[0].principal_id
-}
-
-resource "azurerm_role_assignment" "api_acr_pull" {
-  count                = var.enable_container_registry ? 1 : 0
-  scope                = azurerm_container_registry.acr[0].id
-  role_definition_name = "AcrPull"
   principal_id         = azurerm_container_app.api.identity[0].principal_id
 }
 

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -83,7 +83,7 @@ variable "container_image_api" {
 variable "api_target_port" {
   type        = number
   description = "Container App ingress target port for the Convolens API image."
-  default     = 3001
+  default     = 80
 }
 
 variable "frontend_runtime_stack" {


### PR DESCRIPTION
Summary: preserve the current API image and port during the production base Terraform apply, fall back to placeholder port 80 when the placeholder image is active, and use a user-assigned identity with AcrPull for ACR pulls before Container App updates. Validation: terraform fmt check, terraform validate, actionlint, and live prod Terraform plan passed.