### PR TITLE
fix: harden prod startup and web package

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -199,12 +199,12 @@ jobs:
         run: |
           rm -rf deploy-web web.zip
           mkdir -p deploy-web
-          cp -R apps/web/.next/standalone/. deploy-web/
+          cp -RL apps/web/.next/standalone/. deploy-web/
           mkdir -p deploy-web/apps/web/.next/static
-          cp -R apps/web/.next/static/. deploy-web/apps/web/.next/static/
+          cp -RL apps/web/.next/static/. deploy-web/apps/web/.next/static/
           if [ -d apps/web/public ]; then
             mkdir -p deploy-web/apps/web/public
-            cp -R apps/web/public/. deploy-web/apps/web/public/
+            cp -RL apps/web/public/. deploy-web/apps/web/public/
           fi
           cd deploy-web
           zip -r ../web.zip .

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -360,6 +360,24 @@ resource "azurerm_container_app" "api" {
         name  = "AZURE_KEY_VAULT_NAME"
         value = azurerm_key_vault.kv.name
       }
+
+      startup_probe {
+        transport               = "HTTP"
+        port                    = var.api_target_port
+        path                    = "/health"
+        interval_seconds        = 10
+        timeout                 = 5
+        failure_count_threshold = 30
+      }
+
+      readiness_probe {
+        transport               = "HTTP"
+        port                    = var.api_target_port
+        path                    = "/health"
+        interval_seconds        = 10
+        timeout                 = 5
+        failure_count_threshold = 6
+      }
     }
 
     http_scale_rule {


### PR DESCRIPTION
Summary: dereference pnpm symlinks when packaging the standalone Next web app, and add explicit HTTP startup/readiness probes for the API so Container Apps does not kill it before it finishes initialization. Validation: terraform fmt check, terraform validate, actionlint, and live prod Terraform plan passed.