### PR TITLE
fix: repair production runtime startup

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -206,13 +206,19 @@ jobs:
             mkdir -p deploy-web/apps/web/public
             cp -R apps/web/public/. deploy-web/apps/web/public/
           fi
-          find deploy-web -type l -print0 | while IFS= read -r -d '' link; do
-            target=$(readlink -f "$link" || true)
-            rm "$link"
-            if [ -n "$target" ] && [ -e "$target" ]; then
-              cp -R "$target" "$link"
-            fi
+          while find deploy-web -type l -print -quit | grep -q .; do
+            find deploy-web -type l -print0 | while IFS= read -r -d '' link; do
+              target=$(readlink -f "$link" || true)
+              rm "$link"
+              if [ -n "$target" ] && [ -e "$target" ]; then
+                cp -R "$target" "$link"
+              fi
+            done
           done
+          SWC_HELPERS_DIR="$(dirname "$(node -e "process.stdout.write(require.resolve('@swc/helpers/package.json', { paths: [process.cwd() + '/apps/web'] }))")")"
+          mkdir -p deploy-web/apps/web/node_modules/@swc
+          rm -rf deploy-web/apps/web/node_modules/@swc/helpers
+          cp -R "$SWC_HELPERS_DIR" deploy-web/apps/web/node_modules/@swc/helpers
           cd deploy-web
           zip -r ../web.zip .
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@ import express, { Application, Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
-import { json, urlencoded } from 'body-parser';
+import bodyParser from 'body-parser';
 import { initializeDatabase } from './config/database.js';
 import authRoutes from './routes/auth.routes.js';
 import groupRoutes from './routes/group.routes.js';
@@ -13,6 +13,8 @@ import { correlationMiddleware } from './middleware/correlation.js';
 import { metricsMiddleware, metrics } from './services/metrics.service.js';
 import { idempotencyMiddleware, deduplicationService } from './services/deduplication.service.js';
 import { getAllCircuitBreakerStats } from './services/circuit-breaker.service.js';
+
+const { json, urlencoded } = bodyParser;
 
 export const createApp = (): Application => {
   const app = express();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
+    "@swc/helpers": "^0.5.15",
     "@supabase/ssr": "^0.7.0",
     "antd": "^5.26.5",
     "axios": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@supabase/ssr':
         specifier: ^0.7.0
         version: 0.7.0(@supabase/supabase-js@2.110.7)
+      '@swc/helpers':
+        specifier: ^0.5.15
+        version: 0.5.15
       antd:
         specifier: ^5.26.5
         version: 5.26.6(date-fns@4.1.0)(react-dom@19.2.7)(react@19.2.7)


### PR DESCRIPTION
## Summary
- use the CommonJS-compatible body-parser import so the API container can boot under ESM output
- include @swc/helpers as a direct web dependency for Next runtime resolution
- make web standalone packaging resolve nested symlinks and copy @swc/helpers into the deployed runtime tree

## Verification
- pnpm --filter @convolens/api build
- pnpm --filter @convolens/web build