### PR TITLE
fix: resolve web runtime package roots

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -216,7 +216,7 @@ jobs:
             done
           done
           for package in @next/env @swc/helpers baseline-browser-mapping caniuse-lite postcss styled-jsx; do
-            package_dir="$(dirname "$(node -e "const path = require('path'); const nextPackage = require.resolve('next/package.json', { paths: [process.cwd() + '/apps/web'] }); const nextModules = path.dirname(nextPackage).replace(/[\\/]next$/, ''); process.stdout.write(require.resolve(process.argv[1] + '/package.json', { paths: [nextModules, process.cwd() + '/apps/web'] }))" "$package")")"
+            package_dir="$(node -e "const fs = require('fs'); const path = require('path'); const nextPackage = require.resolve('next/package.json', { paths: [process.cwd() + '/apps/web'] }); const nextModules = path.dirname(nextPackage).replace(/[\\/]next$/, ''); const entry = require.resolve(process.argv[1], { paths: [nextModules, process.cwd() + '/apps/web'] }); let dir = path.dirname(entry); while (!fs.existsSync(path.join(dir, 'package.json'))) { const parent = path.dirname(dir); if (parent === dir) throw new Error('package root not found'); dir = parent; } process.stdout.write(dir)" "$package")"
             mkdir -p "deploy-web/apps/web/node_modules/$(dirname "$package")"
             rm -rf "deploy-web/apps/web/node_modules/$package"
             cp -R "$package_dir" "deploy-web/apps/web/node_modules/$package"


### PR DESCRIPTION
## Summary
- resolve runtime package directories from their entrypoints instead of package.json subpaths
- fixes the production packaging failure for packages with restricted exports, such as baseline-browser-mapping

## Verification
- local resolver finds baseline-browser-mapping package root through Next's module directory
- previous deploy failed in Package Web Standalone on ERR_PACKAGE_PATH_NOT_EXPORTED