### PR TITLE
fix: include web direct runtime deps

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -206,6 +206,10 @@ jobs:
             mkdir -p deploy-web/apps/web/public
             cp -R apps/web/public/. deploy-web/apps/web/public/
           fi
+          if [ -d apps/web/node_modules ]; then
+            mkdir -p deploy-web/apps/web/node_modules
+            cp -Rn apps/web/node_modules/. deploy-web/apps/web/node_modules/
+          fi
           while find deploy-web -type l -print -quit | grep -q .; do
             find deploy-web -type l -print0 | while IFS= read -r -d '' link; do
               target=$(readlink -f "$link" || true)


### PR DESCRIPTION
## Summary
- include the web workspace node_modules dependency layer in the App Service zip without clobbering standalone traced files
- keep symlink materialization and explicit Next runtime package copies

## Verification
- production startup after #103 resolved next and @next/env but failed on missing react
- this targets the direct runtime dependency layer required by Next's server runtime