### PR TITLE
fix: gate production runtime startup

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,6 +76,35 @@ jobs:
           NEXT_PUBLIC_API_URL: https://placeholder.invalid/api
           NEXT_PUBLIC_API_BASE_URL: https://placeholder.invalid
 
+      - name: Smoke Test API Build
+        timeout-minutes: 2
+        run: |
+          DB_PATH="${RUNNER_TEMP}/convolens-api-smoke.sqlite"
+          NODE_ENV=production \
+            PORT=3001 \
+            DB_TYPE=sqlite \
+            DATABASE_PATH="$DB_PATH" \
+            DB_MIGRATIONS_RUN=false \
+            node apps/api/dist/index.js > api-startup.log 2>&1 &
+          API_PID=$!
+          for attempt in {1..30}; do
+            if curl -fsS "http://127.0.0.1:3001/health" > /dev/null; then
+              kill "$API_PID"
+              wait "$API_PID" || true
+              exit 0
+            fi
+            if ! kill -0 "$API_PID" 2>/dev/null; then
+              cat api-startup.log
+              exit 1
+            fi
+            sleep 1
+          done
+          cat api-startup.log
+          kill "$API_PID"
+          wait "$API_PID" || true
+          echo "API build did not become ready within 30 seconds." >&2
+          exit 1
+
       - name: Ensure Terraform Backend
         run: |
           set -euo pipefail
@@ -225,7 +254,7 @@ jobs:
             rm -rf "deploy-web/apps/web/node_modules/$package"
             cp -R "$package_dir" "deploy-web/apps/web/node_modules/$package"
           done
-          PORT=8080 node deploy-web/apps/web/server.js > web-startup.log 2>&1 &
+          (cd deploy-web/apps/web && PORT=8080 node server.js) > web-startup.log 2>&1 &
           WEB_PID=$!
           for attempt in {1..30}; do
             if curl -fsS "http://127.0.0.1:8080" > /dev/null; then
@@ -276,6 +305,7 @@ jobs:
             --name "${{ steps.tf.outputs.web-name }}" \
             --src-path web.zip \
             --clean true \
+            --track-status false \
             --type zip
 
       - name: Smoke Test

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,7 +3,6 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
-import { initializeDatabase } from './config/database.js';
 import authRoutes from './routes/auth.routes.js';
 import groupRoutes from './routes/group.routes.js';
 import chatExportRoutes from './routes/chat-export.routes.js';
@@ -92,43 +91,5 @@ export const createApp = (): Application => {
 
   return app;
 };
-
-// Initialize database and start server if this file is run directly
-if (require.main === module) {
-  (async () => {
-    try {
-      await initializeDatabase();
-      const app = createApp();
-      const PORT = process.env.PORT || 3001;
-      
-      const server = app.listen(PORT, () => {
-        logger.info(`Server is running on port ${PORT}`);
-      });
-
-      // Set up WebSocket
-      const io = require('socket.io')(server, {
-        cors: {
-          origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-          methods: ['GET', 'POST']
-        }
-      });
-      
-      require('./sockets/whatsapp.socket').initializeSocket(io);
-      
-      // Handle graceful shutdown
-      process.on('SIGTERM', () => {
-        logger.info('SIGTERM received. Shutting down gracefully');
-        server.close(() => {
-          logger.info('Process terminated');
-          process.exit(0);
-        });
-      });
-
-    } catch (error) {
-      logger.error('Failed to start server:', error);
-      process.exit(1);
-    }
-  })();
-}
 
 export default createApp;

--- a/apps/api/src/db/entities/Group.ts
+++ b/apps/api/src/db/entities/Group.ts
@@ -46,10 +46,10 @@ export class Group {
   @Column({ type: 'varchar', nullable: true })
   avatarUrl?: string;
 
-  @Column({ default: true })
+  @Column({ type: 'boolean', default: true })
   isActive: boolean;
 
-  @Column({ default: false })
+  @Column({ type: 'boolean', default: false })
   isArchived: boolean;
 
   @ManyToOne(() => User, user => user.ownedGroups, { onDelete: 'SET NULL', nullable: true })
@@ -79,6 +79,6 @@ export class Group {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ nullable: true })
+  @Column({ type: 'datetime', nullable: true })
   archivedAt?: Date;
 }

--- a/apps/api/src/db/entities/Message.ts
+++ b/apps/api/src/db/entities/Message.ts
@@ -32,20 +32,20 @@ export class Message {
   @Column('text')
   content: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   senderName: string;
 
   @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'senderId' })
   sender: Relation<User>;
 
-  @Column({ nullable: true })
+  @Column({ type: 'uuid', nullable: true })
   senderId?: string;
 
-  @Column({ default: false })
+  @Column({ type: 'boolean', default: false })
   isMedia: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   mediaUrl?: string;
 
   @Column({ type: 'simple-json', nullable: true })
@@ -67,6 +67,6 @@ export class Message {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ nullable: true })
+  @Column({ type: 'datetime', nullable: true })
   deletedAt?: Date;
 }

--- a/apps/api/src/db/entities/User.ts
+++ b/apps/api/src/db/entities/User.ts
@@ -24,14 +24,14 @@ export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ unique: true })
+  @Column({ type: 'varchar', unique: true })
   email: string;
 
-  @Column()
+  @Column({ type: 'varchar' })
   @Exclude()
   password: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   name?: string;
 
   @Column({
@@ -41,10 +41,10 @@ export class User {
   })
   role: UserRole;
 
-  @Column({ default: true })
+  @Column({ type: 'boolean', default: true })
   isActive: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'datetime', nullable: true })
   lastLogin?: Date;
 
   @OneToMany(() => Group, group => group.owner)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,9 +1,11 @@
 import 'reflect-metadata';
 import dotenv from 'dotenv';
 import http from 'http';
+import { Server as SocketIOServer } from 'socket.io';
 import { createApp } from './app';
 import { logger } from './utils/logger';
 import { initializeDatabase } from './config/database';
+import { initializeSocket } from './sockets/whatsapp.socket';
 
 dotenv.config();
 
@@ -21,7 +23,7 @@ async function startServer() {
     const server = http.createServer(app);
     
     // Set up WebSocket
-    const io = require('socket.io')(server, {
+    const io = new SocketIOServer(server, {
       cors: {
         origin: process.env.FRONTEND_URL || 'http://localhost:3000',
         methods: ['GET', 'POST']
@@ -29,7 +31,7 @@ async function startServer() {
     });
     
     // Initialize WebSocket handlers
-    require('./sockets/whatsapp.socket').initializeSocket(io);
+    initializeSocket(io);
     
     // Start server
     server.listen(PORT, () => {
@@ -51,9 +53,6 @@ async function startServer() {
   }
 }
 
-// Start the server if this file is run directly
-if (require.main === module) {
-  startServer();
-}
+startServer();
 
 export { startServer };

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -411,7 +411,7 @@ resource "azurerm_linux_web_app" "frontend" {
 
   site_config {
     always_on        = false
-    app_command_line = "node apps/web/server.js"
+    app_command_line = "cd apps/web && node server.js"
 
     application_stack {
       node_version = var.frontend_runtime_stack
@@ -428,7 +428,7 @@ resource "azurerm_linux_web_app" "frontend" {
     MYSTIRA_IDENTITY_WELL_KNOWN           = var.mystira_identity_well_known
     MYSTIRA_IDENTITY_SCOPE                = var.mystira_identity_scope
     SCM_DO_BUILD_DURING_DEPLOYMENT        = "false"
-    WEBSITE_RUN_FROM_PACKAGE              = "1"
+    WEBSITE_RUN_FROM_PACKAGE              = "0"
     CONVOLENS_CANONICAL_HOSTNAME          = var.custom_hostname
     }, var.mystira_identity_client_id != "" ? {
     MYSTIRA_IDENTITY_CLIENT_ID = var.mystira_identity_client_id


### PR DESCRIPTION
## Summary
- fix API production startup under bundled ESM output by removing CommonJS self-start code and using explicit TypeORM column types
- keep App Service Terraform settings aligned with clean zip deployment and start Next from the standalone app directory
- add API build startup smoke and keep deploy status tracking out of the web zip upload so the workflow smoke test owns readiness

## Verification
- pnpm --filter @convolens/api build
- pnpm --filter @convolens/web build
- terraform -chdir=infra/terraform/env/prod fmt -check