### PR TITLE
fix: provide production api jwt secret

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -78,9 +78,16 @@ jobs:
 
       - name: Smoke Test API Build
         timeout-minutes: 2
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
         run: |
+          if [ -z "$JWT_SECRET" ]; then
+            echo "Error: JWT_SECRET or NEXTAUTH_SECRET repository secret is required for production API startup." >&2
+            exit 1
+          fi
           DB_PATH="${RUNNER_TEMP}/convolens-api-smoke.sqlite"
           NODE_ENV=production \
+            JWT_SECRET="$JWT_SECRET" \
             PORT=3001 \
             DB_TYPE=sqlite \
             DATABASE_PATH="$DB_PATH" \
@@ -174,6 +181,7 @@ jobs:
       - name: Terraform Apply Base Infrastructure
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
+          TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
         run: |
           terraform -chdir=infra/terraform/env/prod apply \
             -auto-approve \
@@ -215,6 +223,7 @@ jobs:
             -var "api_target_port=3001"
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
+          TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
 
       - name: Rebuild Web With Production API URL
         timeout-minutes: 15

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -231,6 +231,11 @@ resource "azurerm_container_app" "api" {
     value = random_password.postgres_admin.result
   }
 
+  secret {
+    name  = "jwt-secret"
+    value = var.api_jwt_secret
+  }
+
   dynamic "secret" {
     for_each = var.enable_container_registry ? [azurerm_container_registry.acr[0]] : []
 
@@ -283,6 +288,10 @@ resource "azurerm_container_app" "api" {
       env {
         name  = "NODE_ENV"
         value = "production"
+      }
+      env {
+        name        = "JWT_SECRET"
+        secret_name = "jwt-secret"
       }
       env {
         name  = "PORT"

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -86,6 +86,17 @@ variable "api_target_port" {
   default     = 80
 }
 
+variable "api_jwt_secret" {
+  type        = string
+  description = "JWT signing secret for the production API."
+  sensitive   = true
+
+  validation {
+    condition     = length(var.api_jwt_secret) >= 32
+    error_message = "api_jwt_secret must be at least 32 characters."
+  }
+}
+
 variable "frontend_runtime_stack" {
   type        = string
   description = "Linux App Service runtime stack for the Next.js frontend."


### PR DESCRIPTION
## Summary
- pass a production JWT secret into the API build smoke test
- store the API JWT secret as a Container App secret via Terraform
- feed Terraform from secrets.JWT_SECRET with NEXTAUTH_SECRET as the existing fallback

## Verification
- pnpm --filter @convolens/api build
- terraform -chdir=infra/terraform/env/prod fmt -check