### PR TITLE
fix: keep web deploy run from package

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -308,12 +308,11 @@ jobs:
           az webapp config appsettings set \
             --resource-group "${{ steps.tf.outputs.resource-group }}" \
             --name "${{ steps.tf.outputs.web-name }}" \
-            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false WEBSITE_RUN_FROM_PACKAGE=0
+            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false WEBSITE_RUN_FROM_PACKAGE=1
           az webapp deploy \
             --resource-group "${{ steps.tf.outputs.resource-group }}" \
             --name "${{ steps.tf.outputs.web-name }}" \
             --src-path web.zip \
-            --clean true \
             --track-status false \
             --type zip
 

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -437,7 +437,7 @@ resource "azurerm_linux_web_app" "frontend" {
     MYSTIRA_IDENTITY_WELL_KNOWN           = var.mystira_identity_well_known
     MYSTIRA_IDENTITY_SCOPE                = var.mystira_identity_scope
     SCM_DO_BUILD_DURING_DEPLOYMENT        = "false"
-    WEBSITE_RUN_FROM_PACKAGE              = "0"
+    WEBSITE_RUN_FROM_PACKAGE              = "1"
     CONVOLENS_CANONICAL_HOSTNAME          = var.custom_hostname
     }, var.mystira_identity_client_id != "" ? {
     MYSTIRA_IDENTITY_CLIENT_ID = var.mystira_identity_client_id


### PR DESCRIPTION
## Summary
- keep production App Service aligned with run-from-package deployment
- remove clean extraction from web zip deploy because the Linux App Service package mount is the working runtime mode

## Verification
- pnpm --filter @convolens/web build
- terraform -chdir=infra/terraform/env/prod fmt -check
- live frontend recovered with WEBSITE_RUN_FROM_PACKAGE=1 after restart