### PR TITLE
Fix production routes, auth errors, and extension config

### DIFF
--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -79,7 +79,7 @@ The extension supports custom API endpoints via the settings page. Environment-a
 | Environment | API URL | Dashboard URL |
 |------------|---------|---------------|
 | Development | `http://localhost:3001` | `http://localhost:3000` |
-| Production | `https://api.convolens.com` | `https://app.convolens.com` |
+| Production | `https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io` | `https://convolens.neuralliquid.ai` |
 
 ## Development
 

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -15,6 +15,8 @@
     "https://web.whatsapp.com/*",
     "https://api.convolens.com/*",
     "https://api.convolens.neuralliquid.ai/*",
+    "https://convolens.neuralliquid.ai/*",
+    "https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io/*",
     "http://localhost:3001/*"
   ],
 

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -12,9 +12,9 @@ const isDevelopment = !chrome.runtime.getManifest().update_url;
 export const API_CONFIG = {
   // Production URLs (updated during build)
   production: {
-    apiUrl: 'https://api.convolens.com',
-    wsUrl: 'wss://api.convolens.com/ws',
-    dashboardUrl: 'https://app.convolens.com',
+    apiUrl: 'https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io',
+    wsUrl: 'wss://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io/ws',
+    dashboardUrl: 'https://convolens.neuralliquid.ai',
   },
   // Development URLs
   development: {

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Chrome, ExternalLink, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -47,9 +49,7 @@ export default function ImportChatPage() {
         >
           <TabsList className="grid w-full grid-cols-2 max-w-md mb-8">
             <TabsTrigger value="file">File Upload</TabsTrigger>
-            <TabsTrigger value="whatsapp" disabled>
-              WhatsApp Web (Coming Soon)
-            </TabsTrigger>
+            <TabsTrigger value="whatsapp">WhatsApp Web</TabsTrigger>
           </TabsList>
 
           <TabsContent value="file">
@@ -107,33 +107,48 @@ export default function ImportChatPage() {
               <CardHeader>
                 <CardTitle>Connect WhatsApp Web</CardTitle>
                 <CardDescription>
-                  Connect directly to WhatsApp Web to import your chats
+                  Use the ConvoLens browser extension to extract the open WhatsApp Web chat.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-col items-center justify-center py-12">
-                <div className="text-center max-w-md">
-                  <div className="bg-muted p-4 rounded-lg mb-6 inline-block">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="48"
-                      height="48"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      className="text-muted-foreground"
-                    >
-                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                    </svg>
+              <CardContent className="space-y-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="rounded-lg border p-4">
+                    <div className="mb-3 flex items-center gap-2 font-medium">
+                      <Chrome className="h-5 w-5 text-primary" />
+                      Install
+                    </div>
+                    <ol className="list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
+                      <li>Build the extension from <code>apps/chrome-extension</code>.</li>
+                      <li>Open <code>chrome://extensions</code> and enable Developer mode.</li>
+                      <li>Choose Load unpacked and select the extension folder.</li>
+                    </ol>
                   </div>
-                  <h3 className="text-xl font-semibold mb-2">Coming Soon</h3>
-                  <p className="text-muted-foreground mb-4">
-                    Direct WhatsApp Web integration is under development. For now, please use the file upload option.
-                  </p>
-                  <Button onClick={() => setActiveTab('file')}>
-                    Go to File Upload
+                  <div className="rounded-lg border p-4">
+                    <div className="mb-3 flex items-center gap-2 font-medium">
+                      <Settings className="h-5 w-5 text-primary" />
+                      Configure
+                    </div>
+                    <dl className="space-y-2 text-sm text-muted-foreground">
+                      <div>
+                        <dt className="font-medium text-foreground">API endpoint</dt>
+                        <dd className="break-all">https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-foreground">Dashboard</dt>
+                        <dd>https://convolens.neuralliquid.ai</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Button asChild variant="primary">
+                    <Link href="https://web.whatsapp.com" target="_blank" rel="noreferrer">
+                      Open WhatsApp Web
+                      <ExternalLink className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                  <Button variant="outline" onClick={() => setActiveTab('file')}>
+                    Use file upload
                   </Button>
                 </div>
               </CardContent>

--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link';
+import { BarChart3, Bot, Chrome, GitBranch, MessageSquareText, ShieldCheck } from 'lucide-react';
+import PageWrapper from '../page-wrapper';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const features = [
+  {
+    title: 'WhatsApp import',
+    description: 'Bring in exported chat files today, or use the Chrome extension flow for WhatsApp Web extraction.',
+    icon: MessageSquareText,
+    href: '/dashboard/import',
+  },
+  {
+    title: 'Conversation analysis',
+    description: 'Summarize long threads, surface key topics, and turn message history into structured insight.',
+    icon: Bot,
+    href: '/dashboard',
+  },
+  {
+    title: 'Visual analytics',
+    description: 'Scan message activity, participation, and trend patterns without reading every message manually.',
+    icon: BarChart3,
+    href: '/dashboard',
+  },
+  {
+    title: 'Cross-platform groups',
+    description: 'Connect related conversations and compare behavior across channels and group contexts.',
+    icon: GitBranch,
+    href: '/cross-platform-groups',
+  },
+  {
+    title: 'Browser connector',
+    description: 'Install the ConvoLens Chrome extension from this repo and point it at the production API.',
+    icon: Chrome,
+    href: '/dashboard/import',
+  },
+  {
+    title: 'Privacy controls',
+    description: 'Keep imports explicit, authenticated, and traceable through the ConvoLens account boundary.',
+    icon: ShieldCheck,
+    href: '/settings',
+  },
+];
+
+export default function FeaturesPage() {
+  return (
+    <PageWrapper>
+      <main className="container py-12">
+        <section className="mx-auto max-w-5xl">
+          <div className="max-w-3xl">
+            <p className="text-sm font-medium uppercase tracking-wide text-primary">ConvoLens features</p>
+            <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+              Analyze WhatsApp conversations without losing context.
+            </h1>
+            <p className="mt-5 text-lg text-muted-foreground">
+              Import chats, extract messages from WhatsApp Web, summarize conversations, and organize the resulting
+              insight into dashboards and groups.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button asChild variant="primary">
+                <Link href="/login">Sign in</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/dashboard/import">Import a chat</Link>
+              </Button>
+            </div>
+          </div>
+
+          <div className="mt-12 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {features.map((feature) => {
+              const Icon = feature.icon;
+              return (
+                <Card key={feature.title} className="h-full">
+                  <CardHeader>
+                    <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-md bg-primary/10 text-primary">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <CardTitle className="text-xl">{feature.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <p className="text-sm leading-6 text-muted-foreground">{feature.description}</p>
+                    <Link className="text-sm font-medium text-primary hover:underline" href={feature.href}>
+                      Open
+                    </Link>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      </main>
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { signIn } from 'next-auth/react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
 import PageWrapper from '../page-wrapper';
@@ -10,12 +11,23 @@ import PageWrapper from '../page-wrapper';
 function LoginPageContent() {
   const searchParams = useSearchParams();
   const [isSigningIn, setIsSigningIn] = useState(false);
+  const authError = searchParams.get('error');
+
+  const authErrorMessage =
+    authError === 'mystira' || authError === 'OAuthSignin' || authError === 'OAuthCallback'
+      ? 'Mystira Identity could not start. This production environment is missing or rejecting its OAuth client configuration.'
+      : authError
+        ? 'Sign in failed. Please try again or contact support if this keeps happening.'
+        : null;
 
   const handleMystiraSignIn = async () => {
     setIsSigningIn(true);
     const callbackUrl = searchParams.get('redirectTo') || '/dashboard';
-    await signIn('mystira', { callbackUrl });
-    setIsSigningIn(false);
+    try {
+      await signIn('mystira', { callbackUrl });
+    } finally {
+      setIsSigningIn(false);
+    }
   };
 
   return (
@@ -38,6 +50,12 @@ function LoginPageContent() {
         </CardHeader>
         
         <CardContent className="space-y-6 px-6 pb-6">
+          {authErrorMessage ? (
+            <Alert variant="destructive">
+              <AlertTitle>Sign in is not available</AlertTitle>
+              <AlertDescription>{authErrorMessage}</AlertDescription>
+            </Alert>
+          ) : null}
           <Button
             type="button"
             variant="primary"

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { Compass, Home, Upload } from 'lucide-react';
+import PageWrapper from './page-wrapper';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <PageWrapper>
+      <main className="container flex min-h-[70vh] items-center py-16">
+        <section className="mx-auto max-w-2xl text-center">
+          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Compass className="h-8 w-8" />
+          </div>
+          <p className="text-sm font-medium uppercase tracking-wide text-primary">404</p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground">That page is not available.</h1>
+          <p className="mt-4 text-muted-foreground">
+            The route may have moved, or the link may be pointing at a feature that has not been published yet.
+          </p>
+          <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+            <Button asChild variant="primary">
+              <Link href="/">
+                <Home className="mr-2 h-4 w-4" />
+                Home
+              </Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/dashboard/import">
+                <Upload className="mr-2 h-4 w-4" />
+                Import chat
+              </Link>
+            </Button>
+          </div>
+        </section>
+      </main>
+    </PageWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- add the missing /features route and a branded app 404 page
- surface Mystira sign-in failures on the login page instead of silently returning to login
- expose WhatsApp Web extension setup on the import page and point the extension at the current production deployment

## Validation
- pnpm --filter @convolens/web build
- pnpm --filter @convolens/chrome-extension build

## Operational note
Live sign-in still needs production Mystira OAuth values set as GitHub/App Service configuration: MYSTIRA_IDENTITY_CLIENT_ID and MYSTIRA_IDENTITY_CLIENT_SECRET.