### PR TITLE
Assert production auth smoke

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -343,3 +343,10 @@ jobs:
 
           smoke "" "${{ steps.tf.outputs.api-url }}/health"
           smoke "-I" "${{ steps.tf.outputs.web-url }}"
+          for attempt in {1..12}; do
+            if curl -fsS --max-time 30 "${{ steps.tf.outputs.web-url }}/api/runtime/auth-status" | jq -e '.mystiraConfigured == true' >/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          curl -fsS --max-time 30 "${{ steps.tf.outputs.web-url }}/api/runtime/auth-status" | jq -e '.mystiraConfigured == true' >/dev/null


### PR DESCRIPTION
## Summary
- require the production deploy smoke to verify /api/runtime/auth-status returns mystiraConfigured=true
- keep the existing API and web availability smoke checks

## Validation
- git diff --check
- live /api/runtime/auth-status returned mystiraConfigured=true
- browser sign-in reached Mystira Identity with client_id=neuralliquid-convolens-web