### PR TITLE
Harden production extension delivery and document recovery

### DIFF
--- a/apps/chrome-extension/.gitignore
+++ b/apps/chrome-extension/.gitignore
@@ -1,0 +1,1 @@
+convolens-extension.zip

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -18,12 +18,14 @@ Production-ready Chrome extension for WhatsApp Web integration, enabling AI-powe
 ### Development
 
 1. Install dependencies:
+
    ```bash
    cd apps/chrome-extension
    npm install
    ```
 
 2. Build the extension:
+
    ```bash
    npm run build
    ```
@@ -40,6 +42,10 @@ Production-ready Chrome extension for WhatsApp Web integration, enabling AI-powe
 npm run build:prod
 npm run package  # Creates convolens-extension.zip
 ```
+
+To install a packaged release, extract `convolens-extension.zip` first, then
+use Chrome's **Load unpacked** action to select the extracted directory. The ZIP
+contains the manifest, compiled scripts, popup, settings page, and icons.
 
 ## Usage
 
@@ -69,17 +75,18 @@ apps/chrome-extension/
 │   ├── content.ts         # WhatsApp Web content script
 │   └── content.css        # Content script styles
 ├── dist/                  # Compiled TypeScript output
-└── icons/                 # Extension icons (16, 32, 48, 128px)
 ```
 
 ## Configuration
 
-The extension supports custom API endpoints via the settings page. Environment-aware configuration:
+The extension defaults to the production ConvoLens endpoints, including when it
+is loaded unpacked. A custom API endpoint can be set in the settings page for a
+local or non-production development environment.
 
-| Environment | API URL | Dashboard URL |
-|------------|---------|---------------|
-| Development | `http://localhost:3001` | `http://localhost:3000` |
-| Production | `https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io` | `https://convolens.neuralliquid.ai` |
+| Environment                | API URL                                                                                  | Dashboard URL                        |
+| -------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------ |
+| Default                    | `https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io` | `https://convolens.neuralliquid.ai`  |
+| Local development override | `http://localhost:3001`                                                                  | configured in the local source build |
 
 ## Development
 
@@ -106,12 +113,12 @@ The extension uses data-testid selectors (most stable) with fallback class selec
 
 ```typescript
 // Primary (stable)
-'[data-testid="msg-container"]'
-'[data-testid="msg-text"]'
+'[data-testid="msg-container"]';
+'[data-testid="msg-text"]';
 
 // Fallback (less stable)
-'.message-in, .message-out'
-'.selectable-text span[dir="ltr"]'
+".message-in, .message-out";
+'.selectable-text span[dir="ltr"]';
 ```
 
 ## Security

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -4,12 +4,7 @@
   "version": "1.0.0",
   "description": "ConvoLens: See Your Conversations Clearly. Extract and analyze your WhatsApp Web conversations with AI-powered summaries. Get instant insights, key topics, and intelligent summaries.",
 
-  "permissions": [
-    "storage",
-    "activeTab",
-    "alarms",
-    "notifications"
-  ],
+  "permissions": ["storage", "activeTab", "alarms", "notifications"],
 
   "host_permissions": [
     "https://web.whatsapp.com/*",
@@ -22,27 +17,14 @@
 
   "action": {
     "default_popup": "popup/popup.html",
-    "default_icon": {
-      "16": "icons/icon16.png",
-      "32": "icons/icon32.png",
-      "48": "icons/icon48.png",
-      "128": "icons/icon128.png"
-    },
     "default_title": "ConvoLens"
-  },
-
-  "icons": {
-    "16": "icons/icon16.png",
-    "32": "icons/icon32.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
   },
 
   "content_scripts": [
     {
       "matches": ["https://web.whatsapp.com/*"],
       "js": ["dist/content.js"],
-      "css": ["src/content.css"],
+      "css": ["dist/content.css"],
       "run_at": "document_idle"
     }
   ],
@@ -53,13 +35,6 @@
   },
 
   "options_page": "options/options.html",
-
-  "web_accessible_resources": [
-    {
-      "resources": ["icons/*", "assets/*"],
-      "matches": ["https://web.whatsapp.com/*"]
-    }
-  ],
 
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/apps/chrome-extension/options/options.js
+++ b/apps/chrome-extension/options/options.js
@@ -4,11 +4,11 @@
 
 // Storage keys (must match config.ts)
 const STORAGE_KEYS = {
-  authToken: 'authToken',
-  user: 'user',
-  settings: 'settings',
-  extractionHistory: 'extractionHistory',
-  pendingUploads: 'pendingUploads',
+  authToken: "authToken",
+  user: "user",
+  settings: "settings",
+  extractionHistory: "extractionHistory",
+  pendingUploads: "pendingUploads",
 };
 
 // Default settings
@@ -17,43 +17,45 @@ const DEFAULT_SETTINGS = {
   showNotifications: true,
   extractMediaMetadata: true,
   maxStoredExtractions: 50,
-  theme: 'auto',
-  apiEndpoint: '',
+  theme: "auto",
+  apiEndpoint: "",
 };
+
+const DASHBOARD_URL = "https://convolens.neuralliquid.ai";
 
 // DOM Elements
 const elements = {
   // Account
-  loggedOut: document.getElementById('loggedOut'),
-  loggedIn: document.getElementById('loggedIn'),
-  userEmail: document.getElementById('userEmail'),
-  loginBtn: document.getElementById('loginBtn'),
-  logoutBtn: document.getElementById('logoutBtn'),
+  loggedOut: document.getElementById("loggedOut"),
+  loggedIn: document.getElementById("loggedIn"),
+  userEmail: document.getElementById("userEmail"),
+  loginBtn: document.getElementById("loginBtn"),
+  logoutBtn: document.getElementById("logoutBtn"),
 
   // Settings
-  showNotifications: document.getElementById('showNotifications'),
-  extractMediaMetadata: document.getElementById('extractMediaMetadata'),
-  theme: document.getElementById('theme'),
-  apiEndpoint: document.getElementById('apiEndpoint'),
-  maxStoredExtractions: document.getElementById('maxStoredExtractions'),
+  showNotifications: document.getElementById("showNotifications"),
+  extractMediaMetadata: document.getElementById("extractMediaMetadata"),
+  theme: document.getElementById("theme"),
+  apiEndpoint: document.getElementById("apiEndpoint"),
+  maxStoredExtractions: document.getElementById("maxStoredExtractions"),
 
   // Stats
-  totalExtractions: document.getElementById('totalExtractions'),
-  pendingUploads: document.getElementById('pendingUploads'),
-  totalMessages: document.getElementById('totalMessages'),
+  totalExtractions: document.getElementById("totalExtractions"),
+  pendingUploads: document.getElementById("pendingUploads"),
+  totalMessages: document.getElementById("totalMessages"),
 
   // History
-  historyList: document.getElementById('historyList'),
+  historyList: document.getElementById("historyList"),
 
   // Actions
-  retryPending: document.getElementById('retryPending'),
-  clearData: document.getElementById('clearData'),
-  statusMessage: document.getElementById('statusMessage'),
+  retryPending: document.getElementById("retryPending"),
+  clearData: document.getElementById("clearData"),
+  statusMessage: document.getElementById("statusMessage"),
 
   // Footer
-  version: document.getElementById('version'),
-  helpLink: document.getElementById('helpLink'),
-  privacyLink: document.getElementById('privacyLink'),
+  version: document.getElementById("version"),
+  helpLink: document.getElementById("helpLink"),
+  privacyLink: document.getElementById("privacyLink"),
 };
 
 // =============================================================================
@@ -74,27 +76,25 @@ async function init() {
   setupEventListeners();
 
   // Set up links
-  const isDev = !chrome.runtime.getManifest().update_url;
-  const baseUrl = isDev ? 'http://localhost:3000' : 'https://app.convolens.com';
-  elements.helpLink.href = `${baseUrl}/help`;
-  elements.privacyLink.href = `${baseUrl}/privacy`;
+  elements.helpLink.href = `${DASHBOARD_URL}/help`;
+  elements.privacyLink.href = `${DASHBOARD_URL}/privacy`;
 }
 
 function setupEventListeners() {
   // Auth buttons
-  elements.loginBtn.addEventListener('click', handleLogin);
-  elements.logoutBtn.addEventListener('click', handleLogout);
+  elements.loginBtn.addEventListener("click", handleLogin);
+  elements.logoutBtn.addEventListener("click", handleLogout);
 
   // Settings changes
-  elements.showNotifications.addEventListener('change', saveSettings);
-  elements.extractMediaMetadata.addEventListener('change', saveSettings);
-  elements.theme.addEventListener('change', saveSettings);
-  elements.apiEndpoint.addEventListener('blur', saveSettings);
-  elements.maxStoredExtractions.addEventListener('change', saveSettings);
+  elements.showNotifications.addEventListener("change", saveSettings);
+  elements.extractMediaMetadata.addEventListener("change", saveSettings);
+  elements.theme.addEventListener("change", saveSettings);
+  elements.apiEndpoint.addEventListener("blur", saveSettings);
+  elements.maxStoredExtractions.addEventListener("change", saveSettings);
 
   // Actions
-  elements.retryPending.addEventListener('click', handleRetryPending);
-  elements.clearData.addEventListener('click', handleClearData);
+  elements.retryPending.addEventListener("click", handleRetryPending);
+  elements.clearData.addEventListener("click", handleClearData);
 }
 
 // =============================================================================
@@ -102,28 +102,28 @@ function setupEventListeners() {
 // =============================================================================
 
 async function loadAuthStatus() {
-  const response = await chrome.runtime.sendMessage({ action: 'GET_AUTH_STATUS' });
+  const response = await chrome.runtime.sendMessage({
+    action: "GET_AUTH_STATUS",
+  });
 
   if (response.data?.isAuthenticated) {
-    elements.loggedOut.style.display = 'none';
-    elements.loggedIn.style.display = 'block';
-    elements.userEmail.textContent = response.data.user?.email || 'Connected';
+    elements.loggedOut.style.display = "none";
+    elements.loggedIn.style.display = "block";
+    elements.userEmail.textContent = response.data.user?.email || "Connected";
   } else {
-    elements.loggedOut.style.display = 'block';
-    elements.loggedIn.style.display = 'none';
+    elements.loggedOut.style.display = "block";
+    elements.loggedIn.style.display = "none";
   }
 }
 
 function handleLogin() {
-  const isDev = !chrome.runtime.getManifest().update_url;
-  const baseUrl = isDev ? 'http://localhost:3000' : 'https://app.convolens.com';
-  chrome.tabs.create({ url: `${baseUrl}/login?extension=true` });
+  chrome.tabs.create({ url: `${DASHBOARD_URL}/login?extension=true` });
 }
 
 async function handleLogout() {
-  await chrome.runtime.sendMessage({ action: 'LOGOUT' });
+  await chrome.runtime.sendMessage({ action: "LOGOUT" });
   await loadAuthStatus();
-  showStatus('Logged out successfully', 'success');
+  showStatus("Logged out successfully", "success");
 }
 
 // =============================================================================
@@ -131,14 +131,15 @@ async function handleLogout() {
 // =============================================================================
 
 async function loadSettings() {
-  const response = await chrome.runtime.sendMessage({ action: 'GET_SETTINGS' });
+  const response = await chrome.runtime.sendMessage({ action: "GET_SETTINGS" });
   const settings = response.data || DEFAULT_SETTINGS;
 
   elements.showNotifications.checked = settings.showNotifications;
   elements.extractMediaMetadata.checked = settings.extractMediaMetadata;
   elements.theme.value = settings.theme;
-  elements.apiEndpoint.value = settings.apiEndpoint || '';
-  elements.maxStoredExtractions.value = settings.maxStoredExtractions.toString();
+  elements.apiEndpoint.value = settings.apiEndpoint || "";
+  elements.maxStoredExtractions.value =
+    settings.maxStoredExtractions.toString();
 }
 
 async function saveSettings() {
@@ -151,14 +152,14 @@ async function saveSettings() {
   };
 
   const response = await chrome.runtime.sendMessage({
-    action: 'UPDATE_SETTINGS',
+    action: "UPDATE_SETTINGS",
     settings,
   });
 
   if (response.success) {
-    showStatus('Settings saved', 'success');
+    showStatus("Settings saved", "success");
   } else {
-    showStatus('Failed to save settings', 'error');
+    showStatus("Failed to save settings", "error");
   }
 }
 
@@ -179,16 +180,19 @@ async function loadStats() {
   elements.pendingUploads.textContent = pending.length.toString();
 
   // Calculate total messages
-  const totalMessages = history.reduce((sum, item) => sum + (item.messageCount || 0), 0);
+  const totalMessages = history.reduce(
+    (sum, item) => sum + (item.messageCount || 0),
+    0,
+  );
   elements.totalMessages.textContent = formatNumber(totalMessages);
 }
 
 function formatNumber(num) {
   if (num >= 1000000) {
-    return (num / 1000000).toFixed(1) + 'M';
+    return (num / 1000000).toFixed(1) + "M";
   }
   if (num >= 1000) {
-    return (num / 1000).toFixed(1) + 'K';
+    return (num / 1000).toFixed(1) + "K";
   }
   return num.toString();
 }
@@ -198,7 +202,9 @@ function formatNumber(num) {
 // =============================================================================
 
 async function loadHistory() {
-  const stored = await chrome.storage.local.get([STORAGE_KEYS.extractionHistory]);
+  const stored = await chrome.storage.local.get([
+    STORAGE_KEYS.extractionHistory,
+  ]);
   const history = stored[STORAGE_KEYS.extractionHistory] || [];
 
   if (history.length === 0) {
@@ -210,7 +216,8 @@ async function loadHistory() {
 
   elements.historyList.innerHTML = history
     .slice(0, 20)
-    .map(item => `
+    .map(
+      (item) => `
       <div class="history-item">
         <div>
           <div class="history-name">${escapeHtml(item.chatName)}</div>
@@ -218,12 +225,13 @@ async function loadHistory() {
         </div>
         <div class="history-meta">${formatDate(item.extractedAt)}</div>
       </div>
-    `)
-    .join('');
+    `,
+    )
+    .join("");
 }
 
 function escapeHtml(text) {
-  const div = document.createElement('div');
+  const div = document.createElement("div");
   div.textContent = text;
   return div.innerHTML;
 }
@@ -236,7 +244,7 @@ function formatDate(isoString) {
   const diffHours = Math.floor(diffMins / 60);
   const diffDays = Math.floor(diffHours / 24);
 
-  if (diffMins < 1) return 'Just now';
+  if (diffMins < 1) return "Just now";
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
@@ -250,31 +258,37 @@ function formatDate(isoString) {
 
 async function handleRetryPending() {
   elements.retryPending.disabled = true;
-  elements.retryPending.textContent = 'Retrying...';
+  elements.retryPending.textContent = "Retrying...";
 
   try {
-    const response = await chrome.runtime.sendMessage({ action: 'RETRY_PENDING_UPLOADS' });
+    const response = await chrome.runtime.sendMessage({
+      action: "RETRY_PENDING_UPLOADS",
+    });
 
     if (response.success) {
       const { processed, failed, remaining } = response.data;
       showStatus(
         `Processed: ${processed}, Failed: ${failed}, Remaining: ${remaining}`,
-        processed > 0 ? 'success' : 'error'
+        processed > 0 ? "success" : "error",
       );
       await loadStats();
     } else {
-      showStatus(response.error || 'Failed to retry uploads', 'error');
+      showStatus(response.error || "Failed to retry uploads", "error");
     }
   } catch (error) {
-    showStatus('Error: ' + error.message, 'error');
+    showStatus("Error: " + error.message, "error");
   } finally {
     elements.retryPending.disabled = false;
-    elements.retryPending.textContent = 'Retry Pending Uploads';
+    elements.retryPending.textContent = "Retry Pending Uploads";
   }
 }
 
 async function handleClearData() {
-  if (!confirm('Are you sure you want to clear all extension data? This cannot be undone.')) {
+  if (
+    !confirm(
+      "Are you sure you want to clear all extension data? This cannot be undone.",
+    )
+  ) {
     return;
   }
 
@@ -288,12 +302,12 @@ async function handleClearData() {
       [STORAGE_KEYS.extractionHistory]: [],
     });
 
-    showStatus('All data cleared', 'success');
+    showStatus("All data cleared", "success");
     await loadAuthStatus();
     await loadStats();
     await loadHistory();
   } catch (error) {
-    showStatus('Error: ' + error.message, 'error');
+    showStatus("Error: " + error.message, "error");
   }
 }
 
@@ -306,7 +320,7 @@ function showStatus(message, type) {
   elements.statusMessage.className = `status show ${type}`;
 
   setTimeout(() => {
-    elements.statusMessage.classList.remove('show');
+    elements.statusMessage.classList.remove("show");
   }, 3000);
 }
 

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -5,10 +5,10 @@
   "description": "ConvoLens Chrome Extension for WhatsApp Web",
   "scripts": {
     "build": "tsc && npm run copy-assets",
-    "build:prod": "NODE_ENV=production tsc && npm run copy-assets",
+    "build:prod": "tsc && npm run copy-assets",
     "watch": "tsc --watch",
     "copy-assets": "node -e \"const fs=require('fs');const p=require('path');try{fs.mkdirSync('dist',{recursive:true});fs.readdirSync('src').filter(f=>f.endsWith('.css')).forEach(f=>fs.copyFileSync(p.join('src',f),p.join('dist',f)))}catch(e){}\"",
-    "package": "npm run build:prod && cd dist && zip -r ../convolens-extension.zip .",
+    "package": "npm run build:prod && node scripts/package-extension.mjs",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },
@@ -16,6 +16,7 @@
     "@anthropic-ai/sdk": "^0.18.0",
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@types/chrome": "^0.0.260",
+    "archiver": "^8.0.0",
     "typescript": "^5.3.0"
   }
 }

--- a/apps/chrome-extension/scripts/package-extension.mjs
+++ b/apps/chrome-extension/scripts/package-extension.mjs
@@ -1,0 +1,28 @@
+import { createWriteStream } from "node:fs";
+import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { ZipArchive } from "archiver";
+
+const outputPath = resolve("convolens-extension.zip");
+
+await rm(outputPath, { force: true });
+
+const output = createWriteStream(outputPath);
+const archive = new ZipArchive({ zlib: { level: 9 } });
+
+const completion = new Promise((resolveCompletion, rejectCompletion) => {
+  output.on("close", resolveCompletion);
+  output.on("error", rejectCompletion);
+  archive.on("warning", rejectCompletion);
+  archive.on("error", rejectCompletion);
+});
+
+archive.pipe(output);
+archive.file("manifest.json", { name: "manifest.json" });
+archive.directory("dist", "dist");
+archive.directory("popup", "popup");
+archive.directory("options", "options");
+await archive.finalize();
+await completion;
+
+console.log(`Created ${outputPath}`);

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -5,28 +5,29 @@
  * Supports both development and production environments.
  */
 
-// Environment detection
-const isDevelopment = !chrome.runtime.getManifest().update_url;
-
 // API Configuration
 export const API_CONFIG = {
   // Production URLs (updated during build)
   production: {
-    apiUrl: 'https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io',
-    wsUrl: 'wss://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io/ws',
-    dashboardUrl: 'https://convolens.neuralliquid.ai',
+    apiUrl:
+      "https://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io",
+    wsUrl:
+      "wss://nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io/ws",
+    dashboardUrl: "https://convolens.neuralliquid.ai",
   },
   // Development URLs
   development: {
-    apiUrl: 'http://localhost:3001',
-    wsUrl: 'ws://localhost:3001/ws',
-    dashboardUrl: 'http://localhost:3000',
+    apiUrl: "http://localhost:3001",
+    wsUrl: "ws://localhost:3001/ws",
+    dashboardUrl: "http://localhost:3000",
   },
 };
 
-// Get current environment config
+// Chrome does not expose a reliable runtime distinction between an unpacked
+// production install and an unpacked developer build. Use production by default
+// so the documented "Load unpacked" path works for operators.
 export function getConfig() {
-  return isDevelopment ? API_CONFIG.development : API_CONFIG.production;
+  return API_CONFIG.production;
 }
 
 // WhatsApp Web DOM Selectors
@@ -47,14 +48,14 @@ export const SELECTORS = {
   // Fallback selectors (class-based - less stable)
   fallback: {
     chatList: '.copyable-area [role="listitem"]',
-    messageList: '.message-list',
-    messageContainer: '.message-in, .message-out',
+    messageList: ".message-list",
+    messageContainer: ".message-in, .message-out",
     messageText: '.selectable-text span[dir="ltr"]',
     messageTime: '.copyable-text span[dir="auto"]',
     senderName: 'span[dir="auto"]._ahxt',
-    chatHeader: 'header._ao8g',
+    chatHeader: "header._ao8g",
     contactName: 'span[dir="auto"]._ao3e',
-    scrollableMessageList: '._asmz',
+    scrollableMessageList: "._asmz",
   },
 };
 
@@ -83,11 +84,11 @@ export const RATE_LIMIT_CONFIG = {
 
 // Storage keys
 export const STORAGE_KEYS = {
-  authToken: 'authToken',
-  user: 'user',
-  settings: 'settings',
-  extractionHistory: 'extractionHistory',
-  pendingUploads: 'pendingUploads',
+  authToken: "authToken",
+  user: "user",
+  settings: "settings",
+  extractionHistory: "extractionHistory",
+  pendingUploads: "pendingUploads",
 };
 
 // =============================================================================
@@ -108,9 +109,9 @@ export function generateCorrelationId(): string {
  */
 export function getTracingHeaders(): Record<string, string> {
   return {
-    'x-correlation-id': generateCorrelationId(),
-    'x-source': 'chrome-extension',
-    'x-extension-version': chrome.runtime.getManifest().version,
+    "x-correlation-id": generateCorrelationId(),
+    "x-source": "chrome-extension",
+    "x-extension-version": chrome.runtime.getManifest().version,
   };
 }
 
@@ -120,7 +121,7 @@ export interface ExtensionSettings {
   showNotifications: boolean;
   extractMediaMetadata: boolean;
   maxStoredExtractions: number;
-  theme: 'light' | 'dark' | 'auto';
+  theme: "light" | "dark" | "auto";
   apiEndpoint: string;
 }
 
@@ -129,27 +130,27 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   showNotifications: true,
   extractMediaMetadata: true,
   maxStoredExtractions: 50,
-  theme: 'auto',
-  apiEndpoint: '',
+  theme: "auto",
+  apiEndpoint: "",
 };
 
 // Message types for extension communication - Discriminated union for type safety
 
 export interface GetCurrentChatMessage {
-  action: 'GET_CURRENT_CHAT';
+  action: "GET_CURRENT_CHAT";
 }
 
 export interface CheckStatusMessage {
-  action: 'CHECK_STATUS';
+  action: "CHECK_STATUS";
 }
 
 export interface SetAuthTokenMessage {
-  action: 'SET_AUTH_TOKEN';
+  action: "SET_AUTH_TOKEN";
   token: string | null;
 }
 
 export interface SendChatDataMessage {
-  action: 'SEND_CHAT_DATA';
+  action: "SEND_CHAT_DATA";
   data: {
     chatName: string;
     chatId: string;
@@ -162,49 +163,49 @@ export interface SendChatDataMessage {
       timestamp: string;
       isOutgoing: boolean;
       isMedia: boolean;
-      mediaType?: 'image' | 'video' | 'audio' | 'document' | 'sticker';
+      mediaType?: "image" | "video" | "audio" | "document" | "sticker";
       replyTo?: string;
     }>;
-    source: 'chrome-extension';
+    source: "chrome-extension";
     version: string;
     isGroup: boolean;
   };
 }
 
 export interface OpenDashboardMessage {
-  action: 'OPEN_DASHBOARD';
+  action: "OPEN_DASHBOARD";
   path?: string;
 }
 
 export interface GetAuthStatusMessage {
-  action: 'GET_AUTH_STATUS';
+  action: "GET_AUTH_STATUS";
 }
 
 export interface LoginMessage {
-  action: 'LOGIN';
+  action: "LOGIN";
   email: string;
   password: string;
 }
 
 export interface LogoutMessage {
-  action: 'LOGOUT';
+  action: "LOGOUT";
 }
 
 export interface GetSettingsMessage {
-  action: 'GET_SETTINGS';
+  action: "GET_SETTINGS";
 }
 
 export interface UpdateSettingsMessage {
-  action: 'UPDATE_SETTINGS';
+  action: "UPDATE_SETTINGS";
   settings: Partial<ExtensionSettings>;
 }
 
 export interface ClearPendingUploadsMessage {
-  action: 'CLEAR_PENDING_UPLOADS';
+  action: "CLEAR_PENDING_UPLOADS";
 }
 
 export interface RetryPendingUploadsMessage {
-  action: 'RETRY_PENDING_UPLOADS';
+  action: "RETRY_PENDING_UPLOADS";
 }
 
 // Union type of all message types
@@ -223,7 +224,7 @@ export type ExtensionMessage =
   | RetryPendingUploadsMessage;
 
 // Helper type to extract action names
-export type MessageAction = ExtensionMessage['action'];
+export type MessageAction = ExtensionMessage["action"];
 
 // Response types with proper typing
 export interface SuccessResponse<T = unknown> {

--- a/docs/HANDOFF-2026-07-24.md
+++ b/docs/HANDOFF-2026-07-24.md
@@ -1,0 +1,104 @@
+# ConvoLens Production Handoff - 2026-07-24
+
+Detailed chronology and validation evidence are recorded in
+`docs/TRACE-2026-07-24.md`.
+
+```yaml
+status: completed
+product: convolens
+launch_gate: production web, Mystira Identity sign-in configuration, and extension production endpoints are live
+work_completed:
+  - Restored the production `/features` route and replaced the generic 404 page.
+  - Added a visible login error state and a runtime auth-configuration check outside the NextAuth catch-all route.
+  - Configured the ConvoLens Mystira Identity OIDC client and its callback/logout URLs.
+  - Updated Chrome extension production API, WebSocket, and dashboard URLs.
+  - Made production the extension default for unpacked installs and added a cross-platform package command that produces a manifest-complete ZIP.
+  - Hardened the production deployment smoke test with App Service restart/retry and an asserted Mystira auth configuration check.
+evidence:
+  - `https://convolens.neuralliquid.ai/features` returned HTTP 200 on 2026-07-24.
+  - `https://convolens.neuralliquid.ai/api/runtime/auth-status` returned `{"mystiraConfigured":true}` on 2026-07-24.
+  - GitHub Actions production deploy run 30089028236 completed successfully for commit 3dae808.
+files_changed:
+  - apps/web/src/app/features/page.tsx
+  - apps/web/src/app/not-found.tsx
+  - apps/web/src/app/dashboard/import/page.tsx
+  - apps/web/src/app/api/runtime/auth-status/route.ts
+  - apps/web/src/app/login/page.tsx
+  - apps/chrome-extension/src/config.ts
+  - apps/chrome-extension/manifest.json
+  - apps/chrome-extension/README.md
+  - apps/chrome-extension/options/options.js
+  - apps/chrome-extension/scripts/package-extension.mjs
+  - apps/chrome-extension/.gitignore
+  - .github/workflows/deploy-prod.yml
+tickets_updated:
+  - ConvoLens PRs #110 through #114 merged.
+  - Draft continuation PR #115 opened from `agent/production-extension-handoff`.
+  - Mystira infrastructure PR phoenixvc/mystira-workspace#3381 merged.
+tests_run:
+  - Production route and auth-status HTTP smoke checks.
+  - Browser sign-in flow reached Mystira Identity with the expected client ID and callback URL.
+  - Chrome extension typecheck, production build, and extracted package manifest-resource check passed.
+  - Terraform formatting, validate, and CI plan checks passed for the Mystira OIDC codification.
+deployment:
+  - Production remains a manual GitHub Actions workflow_dispatch deployment.
+  - Successful deploy run: 30089028236.
+privacy_checks:
+  - No credentials or client secret values are recorded in this handoff.
+blockers: []
+risks:
+  - The Chrome extension must be loaded unpacked, either from `apps/chrome-extension` after a build or from an extracted release ZIP; it is not browser-store distributed.
+  - The WhatsApp browser integration is an operator-assisted import path, not an unattended production intake service.
+  - Mystira Terraform was codified but no autonomous production apply was performed; scheduled infrastructure convergence must retain the existing secret.
+next_action: run a normal manual production dispatch after meaningful release changes and verify the two public smoke endpoints
+funding_impact: none
+```
+
+## Current production contract
+
+- Web: `https://convolens.neuralliquid.ai`
+- Features: `https://convolens.neuralliquid.ai/features`
+- Runtime auth check: `https://convolens.neuralliquid.ai/api/runtime/auth-status`
+- OAuth callback: `https://convolens.neuralliquid.ai/api/auth/callback/mystira`
+- Mystira OAuth client ID: `neuralliquid-convolens-web`
+
+The production smoke in `.github/workflows/deploy-prod.yml` requires the web
+endpoint, API health, and `mystiraConfigured == true`. Keep diagnostics outside
+`/api/auth`, which is handled by the NextAuth catch-all route.
+
+## CI/CD operation
+
+Production deployment is deliberately manual: run the `Production Deploy`
+workflow using `workflow_dispatch`. It deploys Terraform-managed infrastructure,
+the API, and the web app, then restarts the App Service and retries the public
+smoke tests to account for startup time. A successful build alone is not the
+release signal; retain the public endpoint and semantic auth smoke checks.
+
+Required GitHub/production configuration is already present. Do not rotate or
+print these values as part of routine diagnostics:
+
+- `MYSTIRA_IDENTITY_CLIENT_ID`
+- `MYSTIRA_IDENTITY_CLIENT_SECRET`
+- `NEXTAUTH_SECRET`
+
+## WhatsApp browser integration
+
+The operator path is Dashboard -> Import -> WhatsApp Web. The page explains how
+to install the unpacked extension and configure it. The extension defaults to
+the deployed ConvoLens API and dashboard, including when loaded unpacked. Run
+`npm run package` to produce a release ZIP, extract it, and use Chrome's Load
+unpacked action on the extracted directory. The operator still selects and
+imports conversation data through the supported flow. No hosted extension
+installation or autonomous WhatsApp ingestion is currently in scope.
+
+## Mystira infrastructure convergence
+
+The live Convolens Identity client was codified in
+`phoenixvc/mystira-workspace#3381` (merge commit `fd34c73`). It adds the
+Convolens client settings, Key Vault secret reference, redirect/logout URLs,
+and CORS origin in the Mystira Identity production Terraform configuration.
+
+Do not run a production Terraform apply merely to complete this handoff. The
+next approved Mystira infrastructure apply should review the plan, preserve the
+existing `convolens-client-secret`, and confirm the active Identity revision
+continues to serve the same client configuration.

--- a/docs/TRACE-2026-07-24.md
+++ b/docs/TRACE-2026-07-24.md
@@ -1,0 +1,66 @@
+# ConvoLens Production Recovery Trace - 2026-07-24
+
+## Scope
+
+This trace records the production recovery, Mystira Identity wiring, and
+WhatsApp browser-extension hardening completed before the associated pull
+request. It complements the operational summary in
+`docs/HANDOFF-2026-07-24.md`.
+
+Associated continuation PR: `neuralliquid/convolens#115` on branch
+`agent/production-extension-handoff`.
+
+## Timeline
+
+1. Restored the missing `/features` route and replaced the generic 404 with the
+   product-specific not-found page.
+2. Moved the auth diagnostic endpoint from `/api/auth/status` to
+   `/api/runtime/auth-status` because NextAuth owns the `/api/auth` catch-all.
+3. Provisioned the ConvoLens Mystira Identity OIDC client with the production
+   callback and logout URLs, then verified the web login flow reaches Mystira
+   Identity.
+4. Hardened the manual production deployment workflow with an App Service
+   restart, retrying smoke checks, and an assertion that
+   `mystiraConfigured == true`.
+5. Updated the Chrome extension's production API, WebSocket, and dashboard
+   targets.
+6. Corrected the extension's unpacked-install behavior: Chrome does not expose
+   a reliable way to distinguish an unpacked production install from a local
+   development build, so the runtime now defaults to production.
+7. Replaced the incomplete, shell-dependent extension ZIP command with a
+   cross-platform packager that includes every manifest resource.
+8. Replaced the obsolete Supabase-based runbook with the current Azure delivery
+   and recovery procedure.
+
+## Production evidence
+
+- Deployment workflow run `30089028236` completed successfully for commit
+  `3dae808`.
+- `https://convolens.neuralliquid.ai/features` returned HTTP 200.
+- `https://convolens.neuralliquid.ai/api/runtime/auth-status` returned
+  `{"mystiraConfigured":true}`.
+- The public API health check retried successfully with HTTP 200 after one
+  transient client/ingress timeout.
+- Azure Container App `nl-prod-convolens-api` revision
+  `nl-prod-convolens-api--0000021` was healthy, running, and serving 100% of
+  traffic. Readiness probes and recent `/health` requests returned 200.
+
+## Extension validation
+
+- `npm run typecheck` passed in `apps/chrome-extension`.
+- `npm run package` passed on Windows.
+- The generated ZIP was extracted and verified against `manifest.json`; the
+  popup, options page, background worker, content script, and stylesheet all
+  exist at their declared paths.
+
+## Boundaries for the next session
+
+- Production deployment remains manual through the GitHub Actions
+  `Deploy Production` workflow and requires the `Production` environment
+  approval.
+- Do not print or rotate Mystira or NextAuth secrets during routine triage.
+- Mystira Identity Terraform was codified separately; no autonomous production
+  apply was performed in this workstream.
+- The extension is load-unpacked only. It has no browser-store distribution and
+  currently uses Chrome's default icon because no extension icon asset exists
+  in the repository.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,162 +1,134 @@
-# ConvoLens - Runbook
-
-## Table of Contents
-- [Overview](#overview)
-- [Prerequisites](#prerequisites)
-- [Common Tasks](#common-tasks)
-- [Monitoring](#monitoring)
-- [Troubleshooting](#troubleshooting)
-- [Backup and Recovery](#backup-and-recovery)
-- [Scaling](#scaling)
-- [Security](#security)
+# ConvoLens Production Runbook
 
 ## Overview
-This runbook contains operational procedures for the ConvoLens application.
 
-## Prerequisites
-- Access to Supabase dashboard
-- Node.js 18+ installed
-- pnpm installed
-- Supabase CLI installed
+ConvoLens production is hosted in Azure. The web application runs in App
+Service, the API runs in Azure Container Apps, and the production deployment is
+executed by the `Deploy Production` GitHub Actions workflow.
 
-## Common Tasks
+Production deployment is intentionally approval-gated and manually dispatched.
+Once approved, the workflow builds, applies the ConvoLens Terraform, deploys
+the API image and web package, restarts the web app, and verifies the public
+runtime.
 
-### Local Development Setup
-```bash
-# Clone the repository
-git clone https://github.com/neuralliquid/convolens.git
-cd convolens
+## Production contract
 
-# Install dependencies
-pnpm install
+| Component              | Endpoint                                                      |
+| ---------------------- | ------------------------------------------------------------- |
+| Web                    | `https://convolens.neuralliquid.ai`                           |
+| Features               | `https://convolens.neuralliquid.ai/features`                  |
+| Web auth configuration | `https://convolens.neuralliquid.ai/api/runtime/auth-status`   |
+| API health             | Azure Container Apps API hostname + `/health`                 |
+| OAuth callback         | `https://convolens.neuralliquid.ai/api/auth/callback/mystira` |
 
-# Set up environment variables
-cp .env.example .env.local
-# Edit .env.local with your Supabase credentials
+The auth configuration endpoint must return `{"mystiraConfigured":true}`.
+It is intentionally under `/api/runtime`, not `/api/auth`, because NextAuth
+handles the `/api/auth` namespace.
 
-# Start development server
-pnpm dev
+## Access prerequisites
+
+- GitHub access to run the `Deploy Production` workflow and approve the
+  `Production` environment.
+- Azure access to the configured production subscription through the
+  repository's OIDC deployment identity.
+- Access to the GitHub repository variables `AZURE_CLIENT_ID`,
+  `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`.
+- Access to the required production secrets. Never print secret values in logs,
+  issues, pull requests, or handoffs.
+
+## Production deployment
+
+1. Confirm the target commit has passed its normal CI checks.
+2. In GitHub Actions, select `Deploy Production` and run it with
+   `workflow_dispatch`.
+3. Approve the `Production` environment when GitHub requests it.
+4. Wait for the deployment job to complete. It builds the API and web app,
+   applies `infra/terraform/env/prod`, pushes the API image to ACR, deploys the
+   web package, restarts App Service, then executes public smoke tests.
+5. Confirm the final workflow smoke step succeeds. A green build is not enough
+   if the web, API, or semantic auth smoke fails.
+
+The workflow provisions the Terraform backend if it is missing. Do not run an
+ad hoc production Terraform apply outside the deployment workflow unless an
+approved infrastructure change explicitly requires it.
+
+## Post-deploy verification
+
+Run these checks from a network with public access:
+
+```powershell
+curl.exe -fsS https://convolens.neuralliquid.ai/features
+curl.exe -fsS https://convolens.neuralliquid.ai/api/runtime/auth-status
 ```
 
-### Production Deployment
-```bash
-# Build the application
-pnpm build
+The features request must return HTTP 200 and the auth-status response must
+contain `mystiraConfigured: true`. For sign-in verification, use the web login
+button and confirm it navigates to Mystira Identity with the callback URL shown
+above.
 
-# Start production server
-pnpm start
+## WhatsApp browser integration
 
-# (Deployment process to be defined)
-```
+The current integration is an operator-assisted Chrome extension path:
 
-### Database Migrations
-```bash
-# Create new migration
-supabase migration new migration_name
+1. Build the extension in `apps/chrome-extension`.
+2. Open `chrome://extensions`, enable Developer mode, and choose Load unpacked.
+3. Select the extension directory or its built output according to the extension
+   README.
+4. In ConvoLens, open Dashboard -> Import -> WhatsApp Web and complete the
+   import flow.
 
-# Apply migrations
-supabase db push
+The extension targets the production API and dashboard through
+`apps/chrome-extension/src/config.ts`. There is no browser-store release or
+unattended WhatsApp ingestion service at present.
 
-# Reset database (development only)
-supabase db reset
-```
+## Monitoring and diagnostics
 
-## Monitoring
-
-### Key Metrics to Monitor
-- **API Response Time**: Should be < 500ms for 95% of requests
-- **Error Rate**: Should be < 1% of total requests
-- **Database Connections**: Monitor for connection leaks
-- **Storage Usage**: Keep below 80% of allocated space
-
-### Logging
-- Frontend errors are logged to Sentry
-- Backend logs are available in Supabase dashboard
-- Application logs are streamed to LogDNA
+- API readiness: request the Container Apps `/health` endpoint.
+- API metrics: request `/metrics` only through an authorized operational path;
+  it exposes process-local runtime metrics.
+- Web startup or deployment failures: inspect the failed GitHub Actions run and
+  the App Service logs.
+- API startup or revision failures: inspect the Container App revision and its
+  logs in Azure.
+- Authentication failures: inspect the web auth-status endpoint first, then the
+  Mystira Identity client callback and allowed origins. Do not log OAuth client
+  secrets.
 
 ## Troubleshooting
 
-### Common Issues
+### Web reports "Application Error" after deploy
 
-#### High CPU Usage
-1. Check current processes: `top` or `htop`
-2. Identify problematic process
-3. Check application logs for errors
-4. Restart service if needed
+The deployment workflow restarts App Service and retries the web smoke test to
+cover package startup delay. If the issue persists, inspect the failed workflow
+run and App Service logs, then restart the web app only after confirming the
+deployed package and required app settings are present. Re-run the two public
+verification checks after recovery.
 
-#### Database Connection Issues
-1. Check Supabase status page
-2. Verify database credentials in environment variables
-3. Check connection pool limits
-4. Look for long-running queries
+### `/features` returns a generic 404
 
-#### Authentication Failures
-1. Verify JWT secret matches between frontend and backend
-2. Check token expiration time
-3. Verify OAuth provider configurations
+The route is implemented by `apps/web/src/app/features/page.tsx`. Verify that
+the deployed commit contains the route, rerun the production workflow, and
+check the public endpoint after App Service has started.
 
-## Backup and Recovery
+### Sign-in does not start or returns a provider error
 
-### Database Backups
-- Automated daily backups in Supabase
-- Manual backup: `supabase db dump --db-url $DATABASE_URL > backup.sql`
+Check `/api/runtime/auth-status`. If it does not report
+`mystiraConfigured: true`, restore the required app settings and GitHub secrets
+through the approved secret-management path. If it is configured, verify the
+Mystira client callback and allowed CORS origin. The expected callback is the
+production contract above.
 
-### File Storage Backups
-- Enable versioning in Supabase Storage
-- Regular exports to cloud storage
+### Deployment cannot log in to Azure
 
-### Recovery Procedure
-1. Restore latest database backup
-2. Restore file storage from backup
-3. Verify data integrity
-4. Update application configuration if needed
+Confirm the three Azure repository variables target the enabled production
+subscription and that the deployment identity has the GitHub `Production`
+environment federated credential. A disabled or stale subscription credential
+produces `ReadOnlyDisabledSubscription`.
 
-## Scaling
+## Recovery boundaries
 
-### Vertical Scaling
-- Upgrade Supabase instance size
-- Increase CPU/RAM allocation
-
-### Horizontal Scaling
-- Add more application instances
-- Configure load balancer
-- Enable database read replicas
-
-## Security
-
-### Regular Tasks
-- Rotate API keys quarterly
-- Update dependencies weekly
-- Review access logs monthly
-- Conduct security audits quarterly
-
-### Incident Response
-1. Identify the incident
-2. Contain the impact
-3. Eradicate the cause
-4. Recover systems
-5. Document the incident
-6. Review and improve
-
-## Maintenance Schedule
-
-### Daily
-- Check application health
-- Review error logs
-- Monitor resource usage
-
-### Weekly
-- Apply security updates
-- Rotate logs
-- Verify backups
-
-### Monthly
-- Review access logs
-- Update documentation
-- Test recovery procedures
-
-## Contact Information
-- **Primary On-call**: [Name] - [Phone] - [Email]
-- **Secondary On-call**: [Name] - [Phone] - [Email]
-- **Infrastructure Team**: infra@convolens.com
-- **Security Team**: security@convolens.com
+- Preserve the existing Mystira client secret when applying its Terraform.
+- Keep operational diagnostics outside `/api/auth`.
+- Do not claim the WhatsApp extension is store-installed or autonomous.
+- Record production deploy run IDs and public smoke results in the release or
+  handoff note.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.260
         version: 0.0.260
+      archiver:
+        specifier: ^8.0.0
+        version: 8.0.0
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -6317,6 +6320,23 @@ packages:
     dev: false
     optional: true
 
+  /archiver@8.0.0:
+    resolution: {integrity: sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==}
+    engines: {node: '>=18'}
+    dependencies:
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      is-stream: 4.0.1
+      lazystream: 1.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 3.0.0
+      tar-stream: 3.1.7
+      zip-stream: 7.0.5
+    transitivePeerDependencies:
+      - bare-abort-controller
+    dev: true
+
   /are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -6534,7 +6554,6 @@ packages:
 
   /b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
-    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.29.7):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -6650,7 +6669,6 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
-    dev: false
     optional: true
 
   /base-64@0.1.0:
@@ -6810,6 +6828,11 @@ packages:
   /buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: false
+
+  /buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+    dev: true
 
   /buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -7198,6 +7221,17 @@ packages:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
     dev: true
 
+  /compress-commons@7.0.1:
+    resolution: {integrity: sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 7.0.1
+      is-stream: 4.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+    dev: true
+
   /compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
     dev: false
@@ -7274,6 +7308,10 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
+  /core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: true
+
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -7297,6 +7335,20 @@ packages:
       parse-json: 5.2.0
       typescript: 5.8.3
     dev: false
+
+  /crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+    dev: true
+
+  /crc32-stream@7.0.1:
+    resolution: {integrity: sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==}
+    engines: {node: '>=18'}
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
+    dev: true
 
   /create-jest@29.7.0(@types/node@18.19.120):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -8878,6 +8930,11 @@ packages:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: true
 
+  /events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: true
+
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -9016,7 +9073,6 @@ packages:
 
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-    dev: false
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -10101,6 +10157,11 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+    dev: true
+
   /is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -10148,6 +10209,10 @@ packages:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  /isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -11062,6 +11127,13 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       language-subtag-registry: 0.3.23
+
+  /lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+    dependencies:
+      readable-stream: 2.3.8
+    dev: true
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -12575,6 +12647,15 @@ packages:
       react-is: 18.3.1
     dev: true
 
+  /process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    dev: true
+
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+    dev: true
+
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -13449,6 +13530,18 @@ packages:
     dependencies:
       pify: 2.3.0
 
+  /readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: true
+
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -13456,6 +13549,24 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  /readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+    dev: true
+
+  /readdir-glob@3.0.0:
+    resolution: {integrity: sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==}
+    engines: {node: '>=18'}
+    dependencies:
+      minimatch: 10.2.3
+    dev: true
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -13706,7 +13817,6 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: false
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -14205,7 +14315,6 @@ packages:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
-    dev: false
 
   /string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -14318,6 +14427,12 @@ packages:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  /string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -14572,7 +14687,6 @@ packages:
       streamx: 2.22.1
     transitivePeerDependencies:
       - bare-abort-controller
-    dev: false
 
   /tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -14599,7 +14713,6 @@ packages:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
     dependencies:
       b4a: 1.6.7
-    dev: false
 
   /text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -15971,6 +16084,15 @@ packages:
   /yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+    dev: true
+
+  /zip-stream@7.0.5:
+    resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
+    engines: {node: '>=18'}
+    dependencies:
+      compress-commons: 7.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
     dev: true
 
   /zod-validation-error@4.0.2(zod@4.4.3):


### PR DESCRIPTION
## What changed

- Made the Chrome extension default to the production ConvoLens endpoints when loaded unpacked.
- Replaced the incomplete shell-specific extension archive command with a cross-platform package step that includes the manifest and all declared resources.
- Updated the production runbook and added dated handoff and trace records for the recovery, Mystira Identity wiring, and operational boundaries.

## Why

Chrome does not reliably distinguish an unpacked production extension from an unpacked local build, so the previous detection sent the documented operator install path to localhost. The previous package command also created a ZIP containing only compiled files, without the manifest, popup, options page, or other install resources.

## Validation

- `npm run typecheck` in `apps/chrome-extension`
- `npm run package` in `apps/chrome-extension`
- Extracted-package check: every resource declared by `manifest.json` exists in the generated ZIP
- Prettier check and `git diff --check`
- Live checks: web features route and Mystira auth-status endpoint; API health returned HTTP 200 after retry

## Operational note

Production deployment remains manual and approval-gated through the `Deploy Production` workflow. The extension remains load-unpacked only; no browser-store release is included.