### PR TITLE
Fix Chrome extension runtime authentication

### DIFF
--- a/apps/api/src/routes/auth.routes.ts
+++ b/apps/api/src/routes/auth.routes.ts
@@ -1,4 +1,7 @@
 import { Router } from 'express';
+import { authRateLimit } from '../middleware/rate-limit.js';
+import { exchangeMystiraIdToken } from '../services/mystira-auth.service.js';
+import { logger } from '../utils/logger.js';
 
 const router = Router();
 
@@ -9,6 +12,23 @@ router.post('/login', (req, res) => {
 
 router.post('/register', (req, res) => {
   res.json({ message: 'Register endpoint' });
+});
+
+router.post('/mystira/exchange', authRateLimit, async (req, res) => {
+  const idToken = req.body?.idToken;
+  if (typeof idToken !== 'string' || !idToken) {
+    return res.status(400).json({ error: 'Mystira Identity ID token is required' });
+  }
+
+  try {
+    const result = await exchangeMystiraIdToken(idToken);
+    return res.json(result);
+  } catch (error) {
+    logger.warn('Mystira extension token exchange failed', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    return res.status(401).json({ error: 'Unable to authenticate the Mystira Identity session' });
+  }
 });
 
 export { router as default };

--- a/apps/api/src/services/__tests__/mystira-auth.service.test.ts
+++ b/apps/api/src/services/__tests__/mystira-auth.service.test.ts
@@ -1,0 +1,142 @@
+import { generateKeyPairSync } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../../config/constants';
+import { exchangeMystiraIdToken, resetMystiraDiscoveryCache } from '../mystira-auth.service';
+
+describe('Mystira extension authentication', () => {
+  const originalWellKnown = process.env.MYSTIRA_IDENTITY_WELL_KNOWN;
+  const originalClientId = process.env.MYSTIRA_IDENTITY_CLIENT_ID;
+  const issuer = 'https://identity.example';
+  const clientId = 'convolens-client';
+  const keyId = 'mystira-signing-key';
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+  });
+  const publicJwk = {
+    ...publicKey.export({ format: 'jwk' }),
+    kid: keyId,
+    use: 'sig',
+    alg: 'RS256',
+  };
+
+  beforeEach(() => {
+    process.env.MYSTIRA_IDENTITY_WELL_KNOWN =
+      'https://identity.example/.well-known/openid-configuration';
+    process.env.MYSTIRA_IDENTITY_CLIENT_ID = clientId;
+    resetMystiraDiscoveryCache();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env.MYSTIRA_IDENTITY_WELL_KNOWN = originalWellKnown;
+    process.env.MYSTIRA_IDENTITY_CLIENT_ID = originalClientId;
+    jest.restoreAllMocks();
+  });
+
+  function createIdToken(overrides: Record<string, unknown> = {}): string {
+    return jwt.sign(
+      {
+        sub: 'mystira-user-123',
+        email: 'operator@example.com',
+        name: 'Operator',
+        ...overrides,
+      },
+      privateKey,
+      {
+        algorithm: 'RS256',
+        issuer,
+        audience: clientId,
+        keyid: keyId,
+        expiresIn: '5m',
+      }
+    );
+  }
+
+  function mockDiscoveryAndKeys(): jest.MockedFunction<typeof fetch> {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            issuer,
+            jwks_uri: 'https://identity.example/.well-known/jwks',
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ keys: [publicJwk] }), {
+          status: 200,
+        })
+      );
+    return fetchMock;
+  }
+
+  it('validates the Mystira ID token and returns a short-lived API token', async () => {
+    mockDiscoveryAndKeys();
+
+    const result = await exchangeMystiraIdToken(createIdToken());
+    const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(result.user).toEqual({
+      id: 'mystira-user-123',
+      email: 'operator@example.com',
+      name: 'Operator',
+    });
+    expect(result.expiresIn).toBe(900);
+    expect(claims).toMatchObject({
+      id: 'mystira-user-123',
+      userId: 'mystira-user-123',
+      email: 'operator@example.com',
+      role: 'user',
+      authProvider: 'mystira',
+      sub: 'mystira-user-123',
+    });
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    mockDiscoveryAndKeys();
+
+    await expect(
+      exchangeMystiraIdToken(
+        jwt.sign(
+          {
+            sub: 'mystira-user-123',
+            email: 'operator@example.com',
+          },
+          privateKey,
+          {
+            algorithm: 'RS256',
+            issuer,
+            audience: 'different-client',
+            keyid: keyId,
+            expiresIn: '5m',
+          }
+        )
+      )
+    ).rejects.toThrow('jwt audience invalid');
+  });
+
+  it('rejects a token whose signing key is not published by Mystira', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            issuer,
+            jwks_uri: 'https://identity.example/.well-known/jwks',
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ keys: [] }), {
+          status: 200,
+        })
+      );
+
+    await expect(exchangeMystiraIdToken(createIdToken())).rejects.toThrow(
+      'Mystira Identity signing key was not found'
+    );
+  });
+});

--- a/apps/api/src/services/mystira-auth.service.ts
+++ b/apps/api/src/services/mystira-auth.service.ts
@@ -1,0 +1,145 @@
+import { createPublicKey } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../config/constants';
+
+type MystiraDiscovery = {
+  issuer?: string;
+  jwks_uri?: string;
+};
+
+type MystiraIdTokenClaims = jwt.JwtPayload & {
+  sub?: string;
+  email?: string;
+  name?: string;
+  preferred_username?: string;
+};
+
+type JsonWebKeySet = {
+  keys?: Array<Record<string, unknown> & { kid?: string }>;
+};
+
+export type ExtensionIdentity = {
+  id: string;
+  email: string;
+  name?: string;
+};
+
+const DISCOVERY_CACHE_TTL_MS = 60 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+let cachedDiscovery:
+  | {
+      expiresAt: number;
+      value: MystiraDiscovery;
+    }
+  | undefined;
+
+async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Mystira Identity request failed with HTTP ${response.status}`);
+    }
+
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getDiscovery(): Promise<MystiraDiscovery> {
+  if (cachedDiscovery && cachedDiscovery.expiresAt > Date.now()) {
+    return cachedDiscovery.value;
+  }
+
+  const wellKnownUrl = process.env.MYSTIRA_IDENTITY_WELL_KNOWN;
+  if (!wellKnownUrl) {
+    throw new Error('Mystira Identity discovery is not configured');
+  }
+
+  const discovery = (await fetchJson(wellKnownUrl)) as MystiraDiscovery;
+  if (!discovery.issuer || !discovery.jwks_uri) {
+    throw new Error('Mystira Identity discovery is missing issuer or jwks_uri');
+  }
+
+  cachedDiscovery = {
+    expiresAt: Date.now() + DISCOVERY_CACHE_TTL_MS,
+    value: discovery,
+  };
+
+  return discovery;
+}
+
+export async function exchangeMystiraIdToken(
+  idToken: string
+): Promise<{ token: string; user: ExtensionIdentity; expiresIn: number }> {
+  if (!idToken) {
+    throw new Error('Mystira Identity ID token is required');
+  }
+
+  const discovery = await getDiscovery();
+  const clientId = process.env.MYSTIRA_IDENTITY_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('Mystira Identity client ID is not configured');
+  }
+
+  const decoded = jwt.decode(idToken, { complete: true });
+  if (!decoded || decoded.header.alg !== 'RS256' || typeof decoded.header.kid !== 'string') {
+    throw new Error('Mystira Identity ID token has an unsupported signing header');
+  }
+
+  const jwks = (await fetchJson(discovery.jwks_uri!)) as JsonWebKeySet;
+  const jwk = jwks.keys?.find((key) => key.kid === decoded.header.kid);
+  if (!jwk) {
+    throw new Error('Mystira Identity signing key was not found');
+  }
+
+  const signingKey = createPublicKey({
+    key: jwk,
+    format: 'jwk',
+  } as Parameters<typeof createPublicKey>[0]);
+  const profile = jwt.verify(idToken, signingKey, {
+    algorithms: ['RS256'],
+    issuer: discovery.issuer,
+    audience: clientId,
+  }) as MystiraIdTokenClaims;
+
+  const email = profile.email || profile.preferred_username;
+  if (!profile.sub || !email) {
+    throw new Error('Mystira Identity profile is missing a stable subject or email');
+  }
+
+  const user: ExtensionIdentity = {
+    id: profile.sub,
+    email,
+    name: profile.name,
+  };
+  const expiresIn = 15 * 60;
+  const token = jwt.sign(
+    {
+      id: user.id,
+      userId: user.id,
+      email: user.email,
+      role: 'user',
+      authProvider: 'mystira',
+    },
+    JWT_SECRET,
+    {
+      expiresIn,
+      subject: user.id,
+    }
+  );
+
+  return { token, user, expiresIn };
+}
+
+export function resetMystiraDiscoveryCache(): void {
+  cachedDiscovery = undefined;
+}

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "ConvoLens Chrome Extension for WhatsApp Web",
   "scripts": {
-    "build": "tsc && npm run copy-assets",
-    "build:prod": "tsc && npm run copy-assets",
+    "build": "npm run typecheck && node scripts/build-extension.mjs",
+    "build:prod": "npm run build",
     "watch": "tsc --watch",
     "copy-assets": "node -e \"const fs=require('fs');const p=require('path');try{fs.mkdirSync('dist',{recursive:true});fs.readdirSync('src').filter(f=>f.endsWith('.css')).forEach(f=>fs.copyFileSync(p.join('src',f),p.join('dist',f)))}catch(e){}\"",
     "package": "npm run build:prod && node scripts/package-extension.mjs",
@@ -17,6 +17,7 @@
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@types/chrome": "^0.0.260",
     "archiver": "^8.0.0",
+    "esbuild": "^0.27.7",
     "typescript": "^5.3.0"
   }
 }

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -1,255 +1,268 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ConvoLens</title>
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ConvoLens</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-    body {
-      width: 320px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: linear-gradient(135deg, #f0fdf4 0%, #ffffff 50%, #f0fdf4 100%);
-    }
+      body {
+        width: 320px;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: linear-gradient(
+          135deg,
+          #f0fdf4 0%,
+          #ffffff 50%,
+          #f0fdf4 100%
+        );
+      }
 
-    .header {
-      background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-      padding: 20px;
-      color: white;
-      text-align: center;
-    }
+      .header {
+        background: linear-gradient(135deg, #25d366 0%, #128c7e 100%);
+        padding: 20px;
+        color: white;
+        text-align: center;
+      }
 
-    .header h1 {
-      font-size: 18px;
-      font-weight: 700;
-    }
+      .header h1 {
+        font-size: 18px;
+        font-weight: 700;
+      }
 
-    .header p {
-      font-size: 12px;
-      opacity: 0.9;
-      margin-top: 4px;
-    }
+      .header p {
+        font-size: 12px;
+        opacity: 0.9;
+        margin-top: 4px;
+      }
 
-    .content {
-      padding: 20px;
-    }
+      .content {
+        padding: 20px;
+      }
 
-    .status-card {
-      background: white;
-      border-radius: 12px;
-      padding: 16px;
-      margin-bottom: 16px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    }
+      .status-card {
+        background: white;
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 16px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
 
-    .status-card h3 {
-      font-size: 14px;
-      color: #333;
-      margin-bottom: 8px;
-    }
+      .status-card h3 {
+        font-size: 14px;
+        color: #333;
+        margin-bottom: 8px;
+      }
 
-    .status-indicator {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
+      .status-indicator {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
 
-    .status-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: #dc2626;
-    }
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #dc2626;
+      }
 
-    .status-dot.connected {
-      background: #25D366;
-    }
+      .status-dot.connected {
+        background: #25d366;
+      }
 
-    .actions {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
 
-    button {
-      width: 100%;
-      padding: 12px 16px;
-      border: none;
-      border-radius: 8px;
-      font-size: 14px;
-      font-weight: 600;
-      cursor: pointer;
-      transition: all 0.2s ease;
-    }
+      button {
+        width: 100%;
+        padding: 12px 16px;
+        border: none;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
 
-    .btn-primary {
-      background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-      color: white;
-    }
+      .btn-primary {
+        background: linear-gradient(135deg, #25d366 0%, #128c7e 100%);
+        color: white;
+      }
 
-    .btn-primary:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(37, 211, 102, 0.3);
-    }
+      .btn-primary:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(37, 211, 102, 0.3);
+      }
 
-    .btn-secondary {
-      background: white;
-      color: #333;
-      border: 1px solid #e5e7eb;
-    }
+      .btn-secondary {
+        background: white;
+        color: #333;
+        border: 1px solid #e5e7eb;
+      }
 
-    .btn-secondary:hover {
-      background: #f9fafb;
-    }
+      .btn-secondary:hover {
+        background: #f9fafb;
+      }
 
-    .login-form {
-      display: none;
-    }
+      .login-form {
+        display: none;
+      }
 
-    .login-form.show {
-      display: block;
-    }
+      .login-form.show {
+        display: block;
+      }
 
-    .form-group {
-      margin-bottom: 12px;
-    }
+      .form-group {
+        margin-bottom: 12px;
+      }
 
-    .form-group label {
-      display: block;
-      font-size: 12px;
-      color: #666;
-      margin-bottom: 4px;
-    }
+      .form-group label {
+        display: block;
+        font-size: 12px;
+        color: #666;
+        margin-bottom: 4px;
+      }
 
-    .form-group input {
-      width: 100%;
-      padding: 10px 12px;
-      border: 1px solid #e5e7eb;
-      border-radius: 8px;
-      font-size: 14px;
-    }
+      .form-group input {
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        font-size: 14px;
+      }
 
-    .form-group input:focus {
-      outline: none;
-      border-color: #25D366;
-      box-shadow: 0 0 0 3px rgba(37, 211, 102, 0.1);
-    }
+      .form-group input:focus {
+        outline: none;
+        border-color: #25d366;
+        box-shadow: 0 0 0 3px rgba(37, 211, 102, 0.1);
+      }
 
-    .error {
-      color: #dc2626;
-      font-size: 12px;
-      margin-top: 8px;
-    }
+      .error {
+        color: #dc2626;
+        font-size: 12px;
+        margin-top: 8px;
+      }
 
-    .user-info {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px;
-      background: #f0fdf4;
-      border-radius: 8px;
-      margin-bottom: 16px;
-    }
+      .user-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px;
+        background: #f0fdf4;
+        border-radius: 8px;
+        margin-bottom: 16px;
+      }
 
-    .user-avatar {
-      width: 40px;
-      height: 40px;
-      background: #25D366;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: white;
-      font-weight: 600;
-    }
+      .user-avatar {
+        width: 40px;
+        height: 40px;
+        background: #25d366;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-weight: 600;
+      }
 
-    .user-details h4 {
-      font-size: 14px;
-      color: #333;
-    }
+      .user-details h4 {
+        font-size: 14px;
+        color: #333;
+      }
 
-    .user-details p {
-      font-size: 12px;
-      color: #666;
-    }
+      .user-details p {
+        font-size: 12px;
+        color: #666;
+      }
 
-    .footer {
-      padding: 12px 20px;
-      text-align: center;
-      font-size: 11px;
-      color: #999;
-      border-top: 1px solid #f0f0f0;
-    }
+      .footer {
+        padding: 12px 20px;
+        text-align: center;
+        font-size: 11px;
+        color: #999;
+        border-top: 1px solid #f0f0f0;
+      }
 
-    .footer a {
-      color: #25D366;
-      text-decoration: none;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>ConvoLens</h1>
-    <p>WhatsApp Chat Analyzer</p>
-  </div>
-
-  <div class="content">
-    <div class="status-card">
-      <h3>Connection Status</h3>
-      <div class="status-indicator">
-        <span class="status-dot" id="statusDot"></span>
-        <span id="statusText">Checking...</span>
-      </div>
+      .footer a {
+        color: #25d366;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>ConvoLens</h1>
+      <p>WhatsApp Chat Analyzer</p>
     </div>
 
-    <div id="authSection">
-      <!-- Logged out state -->
-      <div id="loggedOut" style="display: none;">
-        <div class="login-form show">
-          <div class="form-group">
-            <label>Email</label>
-            <input type="email" id="email" placeholder="your@email.com">
+    <div class="content">
+      <div class="status-card">
+        <h3>Connection Status</h3>
+        <div class="status-indicator">
+          <span class="status-dot" id="statusDot"></span>
+          <span id="statusText">Checking...</span>
+        </div>
+      </div>
+
+      <div id="authSection">
+        <!-- Logged out state -->
+        <div id="loggedOut" style="display: none">
+          <div class="login-form show">
+            <p style="font-size: 13px; color: #666; margin-bottom: 12px">
+              Sign in through ConvoLens with Mystira Identity, then reopen this
+              popup to connect the extension.
+            </p>
+            <div class="error" id="loginError"></div>
+            <div class="actions">
+              <button class="btn-primary" id="loginBtn">
+                Connect Mystira Session
+              </button>
+              <button class="btn-secondary" id="signupBtn">
+                Open ConvoLens Sign In
+              </button>
+            </div>
           </div>
-          <div class="form-group">
-            <label>Password</label>
-            <input type="password" id="password" placeholder="Password">
+        </div>
+
+        <!-- Logged in state -->
+        <div id="loggedIn" style="display: none">
+          <div class="user-info">
+            <div class="user-avatar" id="userAvatar">U</div>
+            <div class="user-details">
+              <h4 id="userName">User</h4>
+              <p id="userEmail">user@example.com</p>
+            </div>
           </div>
-          <div class="error" id="loginError"></div>
           <div class="actions">
-            <button class="btn-primary" id="loginBtn">Sign In</button>
-            <button class="btn-secondary" id="signupBtn">Create Account</button>
+            <button class="btn-primary" id="openDashboard">
+              Open Dashboard
+            </button>
+            <button class="btn-secondary" id="extractBtn">
+              Extract Current Chat
+            </button>
+            <button class="btn-secondary" id="logoutBtn">Sign Out</button>
           </div>
-        </div>
-      </div>
-
-      <!-- Logged in state -->
-      <div id="loggedIn" style="display: none;">
-        <div class="user-info">
-          <div class="user-avatar" id="userAvatar">U</div>
-          <div class="user-details">
-            <h4 id="userName">User</h4>
-            <p id="userEmail">user@example.com</p>
-          </div>
-        </div>
-        <div class="actions">
-          <button class="btn-primary" id="openDashboard">Open Dashboard</button>
-          <button class="btn-secondary" id="extractBtn">Extract Current Chat</button>
-          <button class="btn-secondary" id="logoutBtn">Sign Out</button>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="footer">
-    <a href="http://localhost:3000" target="_blank">convolens.com</a> |
-    <a href="http://localhost:3000/help" target="_blank">Help</a>
-  </div>
+    <div class="footer">
+      <a href="https://convolens.neuralliquid.ai" target="_blank">ConvoLens</a>
+      |
+      <a href="https://convolens.neuralliquid.ai/features" target="_blank"
+        >Features</a
+      >
+    </div>
 
-  <script src="popup.js"></script>
-</body>
+    <script src="popup.js"></script>
+  </body>
 </html>

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -2,30 +2,32 @@
  * ConvoLens Chrome Extension - Popup Script
  */
 
+const DASHBOARD_URL = "https://convolens.neuralliquid.ai";
+
 // DOM Elements
-const statusDot = document.getElementById('statusDot');
-const statusText = document.getElementById('statusText');
-const loggedOutSection = document.getElementById('loggedOut');
-const loggedInSection = document.getElementById('loggedIn');
-const loginBtn = document.getElementById('loginBtn');
-const signupBtn = document.getElementById('signupBtn');
-const logoutBtn = document.getElementById('logoutBtn');
-const extractBtn = document.getElementById('extractBtn');
-const openDashboard = document.getElementById('openDashboard');
-const loginError = document.getElementById('loginError');
-const emailInput = document.getElementById('email');
-const passwordInput = document.getElementById('password');
-const userName = document.getElementById('userName');
-const userEmail = document.getElementById('userEmail');
-const userAvatar = document.getElementById('userAvatar');
+const statusDot = document.getElementById("statusDot");
+const statusText = document.getElementById("statusText");
+const loggedOutSection = document.getElementById("loggedOut");
+const loggedInSection = document.getElementById("loggedIn");
+const loginBtn = document.getElementById("loginBtn");
+const signupBtn = document.getElementById("signupBtn");
+const logoutBtn = document.getElementById("logoutBtn");
+const extractBtn = document.getElementById("extractBtn");
+const openDashboard = document.getElementById("openDashboard");
+const loginError = document.getElementById("loginError");
+const userName = document.getElementById("userName");
+const userEmail = document.getElementById("userEmail");
+const userAvatar = document.getElementById("userAvatar");
 
 // Initialize popup
 async function init() {
   // Check auth status
-  const authStatus = await chrome.runtime.sendMessage({ action: 'GET_AUTH_STATUS' });
+  const authStatus = await chrome.runtime.sendMessage({
+    action: "GET_AUTH_STATUS",
+  });
 
-  if (authStatus.isAuthenticated) {
-    showLoggedIn(authStatus.user);
+  if (authStatus.data?.isAuthenticated) {
+    showLoggedIn(authStatus.data.user);
   } else {
     showLoggedOut();
   }
@@ -36,128 +38,129 @@ async function init() {
 
 // Show logged in state
 function showLoggedIn(user) {
-  loggedOutSection.style.display = 'none';
-  loggedInSection.style.display = 'block';
+  loggedOutSection.style.display = "none";
+  loggedInSection.style.display = "block";
 
   if (user) {
-    userName.textContent = user.name || user.email.split('@')[0];
-    userEmail.textContent = user.email;
-    userAvatar.textContent = (user.name || user.email)[0].toUpperCase();
+    const email = user.email || "";
+    userName.textContent = user.name || email.split("@")[0] || "Mystira User";
+    userEmail.textContent = email;
+    userAvatar.textContent = (user.name || email || "U")[0].toUpperCase();
   }
 }
 
 // Show logged out state
 function showLoggedOut() {
-  loggedOutSection.style.display = 'block';
-  loggedInSection.style.display = 'none';
+  loggedOutSection.style.display = "block";
+  loggedInSection.style.display = "none";
 }
 
 // Check WhatsApp Web status
 async function checkWhatsAppStatus() {
   try {
-    const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
+    const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
 
     if (tabs.length > 0) {
-      const response = await chrome.tabs.sendMessage(tabs[0].id, { action: 'CHECK_STATUS' });
+      const response = await chrome.tabs.sendMessage(tabs[0].id, {
+        action: "CHECK_STATUS",
+      });
 
       if (response.isWhatsAppWeb && response.isLoggedIn) {
-        statusDot.classList.add('connected');
-        statusText.textContent = 'Connected to WhatsApp Web';
+        statusDot.classList.add("connected");
+        statusText.textContent = "Connected to WhatsApp Web";
       } else {
-        statusText.textContent = 'WhatsApp Web not logged in';
+        statusText.textContent = "WhatsApp Web not logged in";
       }
     } else {
-      statusText.textContent = 'Open WhatsApp Web to start';
+      statusText.textContent = "Open WhatsApp Web to start";
     }
   } catch (error) {
-    statusText.textContent = 'Open WhatsApp Web to start';
+    statusText.textContent = "Open WhatsApp Web to start";
   }
 }
 
 // Event Listeners
-loginBtn.addEventListener('click', async () => {
-  const email = emailInput.value.trim();
-  const password = passwordInput.value;
-
-  if (!email || !password) {
-    loginError.textContent = 'Please enter email and password';
-    return;
-  }
-
-  loginBtn.textContent = 'Signing in...';
+loginBtn.addEventListener("click", async () => {
+  loginBtn.textContent = "Connecting...";
   loginBtn.disabled = true;
 
   const result = await chrome.runtime.sendMessage({
-    action: 'LOGIN',
-    email,
-    password
+    action: "SYNC_MYSTIRA_AUTH",
   });
 
-  loginBtn.textContent = 'Sign In';
+  loginBtn.textContent = "Connect Mystira Session";
   loginBtn.disabled = false;
 
   if (result.success) {
-    showLoggedIn(result.user);
-    loginError.textContent = '';
+    showLoggedIn(result.data?.user);
+    loginError.textContent = "";
   } else {
-    loginError.textContent = result.error || 'Login failed';
+    loginError.textContent =
+      result.error || "Complete sign in, then try again.";
+    chrome.tabs.create({
+      url: `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
+    });
   }
 });
 
-signupBtn.addEventListener('click', () => {
-  chrome.tabs.create({ url: 'http://localhost:3000/signup' });
+signupBtn.addEventListener("click", () => {
+  chrome.tabs.create({
+    url: `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
+  });
 });
 
-logoutBtn.addEventListener('click', async () => {
-  await chrome.runtime.sendMessage({ action: 'LOGOUT' });
+logoutBtn.addEventListener("click", async () => {
+  await chrome.runtime.sendMessage({ action: "LOGOUT" });
   showLoggedOut();
 });
 
-extractBtn.addEventListener('click', async () => {
+extractBtn.addEventListener("click", async () => {
   try {
-    const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
+    const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
 
     if (tabs.length === 0) {
-      alert('Please open WhatsApp Web first');
+      alert("Please open WhatsApp Web first");
       return;
     }
 
-    extractBtn.textContent = 'Extracting...';
+    extractBtn.textContent = "Extracting...";
     extractBtn.disabled = true;
 
-    const response = await chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_CURRENT_CHAT' });
+    const response = await chrome.tabs.sendMessage(tabs[0].id, {
+      action: "GET_CURRENT_CHAT",
+    });
 
     if (response.success) {
       const sendResult = await chrome.runtime.sendMessage({
-        action: 'SEND_CHAT_DATA',
-        data: response.data
+        action: "SEND_CHAT_DATA",
+        data: response.data,
       });
 
       if (sendResult.success) {
-        extractBtn.textContent = 'Sent!';
+        extractBtn.textContent = "Sent!";
         setTimeout(() => {
-          extractBtn.textContent = 'Extract Current Chat';
+          extractBtn.textContent = "Extract Current Chat";
           extractBtn.disabled = false;
         }, 2000);
       } else {
-        alert('Failed to send: ' + sendResult.error);
-        extractBtn.textContent = 'Extract Current Chat';
+        alert("Failed to send: " + sendResult.error);
+        extractBtn.textContent = "Extract Current Chat";
         extractBtn.disabled = false;
       }
     } else {
-      alert('Failed to extract: ' + response.error);
-      extractBtn.textContent = 'Extract Current Chat';
+      alert("Failed to extract: " + response.error);
+      extractBtn.textContent = "Extract Current Chat";
       extractBtn.disabled = false;
     }
   } catch (error) {
-    alert('Error: ' + error.message);
-    extractBtn.textContent = 'Extract Current Chat';
+    alert("Error: " + error.message);
+    extractBtn.textContent = "Extract Current Chat";
     extractBtn.disabled = false;
   }
 });
 
-openDashboard.addEventListener('click', () => {
-  chrome.tabs.create({ url: 'http://localhost:3000/dashboard' });
+openDashboard.addEventListener("click", () => {
+  chrome.tabs.create({ url: `${DASHBOARD_URL}/dashboard/import` });
 });
 
 // Initialize

--- a/apps/chrome-extension/scripts/build-extension.mjs
+++ b/apps/chrome-extension/scripts/build-extension.mjs
@@ -1,0 +1,30 @@
+import { copyFile, mkdir, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { build } from "esbuild";
+
+const distDir = resolve("dist");
+
+await rm(distDir, { force: true, recursive: true });
+await mkdir(distDir, { recursive: true });
+
+await Promise.all([
+  build({
+    entryPoints: ["./src/content.ts"],
+    bundle: true,
+    outfile: "./dist/content.js",
+    format: "iife",
+    platform: "browser",
+    target: "chrome102",
+  }),
+  build({
+    entryPoints: ["./src/background.ts"],
+    bundle: true,
+    outfile: "./dist/background.js",
+    format: "esm",
+    platform: "browser",
+    target: "chrome102",
+  }),
+  copyFile(resolve("src/content.css"), resolve("dist/content.css")),
+]);
+
+console.log(`Built extension runtime in ${distDir}`);

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -22,8 +22,7 @@ import {
   type UpdateSettingsMessage,
   type SendChatDataMessage,
   type OpenDashboardMessage,
-  type SetAuthTokenMessage,
-} from './config';
+} from "./config";
 
 // =============================================================================
 // Types
@@ -41,75 +40,85 @@ interface RateLimitState {
 }
 
 // Storage key for persistent rate limiting
-const RATE_LIMIT_STORAGE_KEY = 'ws_rate_limit_state';
+const RATE_LIMIT_STORAGE_KEY = "ws_rate_limit_state";
 
 // =============================================================================
 // Message Handler
 // =============================================================================
 
 chrome.runtime.onMessage.addListener(
-  (message: ExtensionMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: ExtensionResponse) => void) => {
+  (
+    message: ExtensionMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: ExtensionResponse) => void,
+  ) => {
     handleMessage(message, sender)
       .then(sendResponse)
-      .catch(error => sendResponse({ success: false, error: error.message }));
+      .catch((error) => sendResponse({ success: false, error: error.message }));
     return true; // Indicates async response
-  }
+  },
 );
 
-async function handleMessage(message: ExtensionMessage, sender: chrome.runtime.MessageSender): Promise<ExtensionResponse> {
-  console.log('[Background] Received message:', message.action);
+async function handleMessage(
+  message: ExtensionMessage,
+  _sender: chrome.runtime.MessageSender,
+): Promise<ExtensionResponse> {
+  console.log("[Background] Received message:", message.action);
 
   switch (message.action) {
-    case 'SEND_CHAT_DATA': {
+    case "SEND_CHAT_DATA": {
       const typedMessage = message as SendChatDataMessage;
       return await sendChatData(typedMessage.data);
     }
 
-    case 'OPEN_DASHBOARD': {
+    case "OPEN_DASHBOARD": {
       const typedMessage = message as OpenDashboardMessage;
       return await openDashboard(typedMessage.path);
     }
 
-    case 'GET_AUTH_STATUS':
+    case "GET_AUTH_STATUS":
       return await getAuthStatus();
 
-    case 'LOGIN': {
+    case "SYNC_MYSTIRA_AUTH":
+      return await syncMystiraSession();
+
+    case "LOGIN": {
       const typedMessage = message as LoginMessage;
       // Validate required fields
       if (!typedMessage.email || !typedMessage.password) {
-        return { success: false, error: 'Email and password are required' };
+        return { success: false, error: "Email and password are required" };
       }
       return await handleLogin(typedMessage.email, typedMessage.password);
     }
 
-    case 'LOGOUT':
+    case "LOGOUT":
       return await handleLogout();
 
-    case 'GET_SETTINGS':
+    case "GET_SETTINGS":
       return await getSettings();
 
-    case 'UPDATE_SETTINGS': {
+    case "UPDATE_SETTINGS": {
       const typedMessage = message as UpdateSettingsMessage;
-      if (!typedMessage.settings || typeof typedMessage.settings !== 'object') {
-        return { success: false, error: 'Settings object is required' };
+      if (!typedMessage.settings || typeof typedMessage.settings !== "object") {
+        return { success: false, error: "Settings object is required" };
       }
       return await updateSettings(typedMessage.settings);
     }
 
-    case 'RETRY_PENDING_UPLOADS':
+    case "RETRY_PENDING_UPLOADS":
       return await retryPendingUploads();
 
-    case 'CLEAR_PENDING_UPLOADS':
+    case "CLEAR_PENDING_UPLOADS":
       return await clearPendingUploads();
 
-    case 'GET_CURRENT_CHAT':
-    case 'CHECK_STATUS':
-    case 'SET_AUTH_TOKEN':
+    case "GET_CURRENT_CHAT":
+    case "CHECK_STATUS":
+    case "SET_AUTH_TOKEN":
       // These are handled by content script, not background
-      return { success: false, error: 'Action handled by content script' };
+      return { success: false, error: "Action handled by content script" };
 
     default:
-      return { success: false, error: 'Unknown action' };
+      return { success: false, error: "Unknown action" };
   }
 }
 
@@ -122,10 +131,20 @@ async function handleMessage(message: ExtensionMessage, sender: chrome.runtime.M
  */
 async function sendChatData(chatData: any): Promise<ExtensionResponse> {
   try {
-    // Check authentication
-    const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
-    if (!stored[STORAGE_KEYS.authToken]) {
-      return { success: false, error: 'Not authenticated. Please log in first.' };
+    let stored = await chrome.storage.local.get([
+      STORAGE_KEYS.authToken,
+      STORAGE_KEYS.authTokenExpiresAt,
+    ]);
+    const expiresAt = Number(stored[STORAGE_KEYS.authTokenExpiresAt] || 0);
+    if (
+      !stored[STORAGE_KEYS.authToken] ||
+      (expiresAt > 0 && expiresAt <= Date.now() + 30_000)
+    ) {
+      const syncResult = await syncMystiraSession();
+      if (!syncResult.success) {
+        return syncResult;
+      }
+      stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
     }
 
     // Check rate limiting (persistent across service worker restarts)
@@ -133,32 +152,35 @@ async function sendChatData(chatData: any): Promise<ExtensionResponse> {
     if (!canProceed) {
       // Queue for later
       await queuePendingUpload(chatData);
-      return { success: false, error: 'Rate limited. Queued for later.' };
+      return { success: false, error: "Rate limited. Queued for later." };
     }
 
     // Send with retry (include tracing headers for distributed tracing)
     const config = await getApiConfig();
-    const result = await fetchWithRetry(`${config.apiUrl}/api/chat-export/extension`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${stored[STORAGE_KEYS.authToken]}`,
-        ...getTracingHeaders(),
+    const result = await fetchWithRetry(
+      `${config.apiUrl}/api/chat-export/extension`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${stored[STORAGE_KEYS.authToken]}`,
+          ...getTracingHeaders(),
+        },
+        body: JSON.stringify(chatData),
       },
-      body: JSON.stringify(chatData),
-    });
+    );
 
     // Track successful upload in history
     await trackExtractionHistory(chatData);
 
     return { success: true, data: result };
   } catch (error) {
-    console.error('[Background] Send error:', error);
+    console.error("[Background] Send error:", error);
 
     // Queue for offline sync if network error
     if (isNetworkError(error)) {
       await queuePendingUpload(chatData);
-      return { success: false, error: 'Network error. Saved for later sync.' };
+      return { success: false, error: "Network error. Saved for later sync." };
     }
 
     return { success: false, error: (error as Error).message };
@@ -168,7 +190,11 @@ async function sendChatData(chatData: any): Promise<ExtensionResponse> {
 /**
  * Fetch with retry and exponential backoff
  */
-async function fetchWithRetry(url: string, options: RequestInit, maxRetries: number = 3): Promise<any> {
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  maxRetries: number = 3,
+): Promise<any> {
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -187,20 +213,30 @@ async function fetchWithRetry(url: string, options: RequestInit, maxRetries: num
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ message: `HTTP ${response.status}` }));
+        const errorData = await response
+          .json()
+          .catch(() => ({ message: `HTTP ${response.status}` }));
 
         // Don't retry on auth errors
         if (response.status === 401 || response.status === 403) {
           await handleLogout();
-          throw new Error('Authentication expired. Please log in again.');
+          throw new Error("Authentication expired. Please log in again.");
         }
 
         // Don't retry on client errors (except rate limiting)
-        if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-          throw new Error(errorData.message || `Request failed: ${response.status}`);
+        if (
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 429
+        ) {
+          throw new Error(
+            errorData.message || `Request failed: ${response.status}`,
+          );
         }
 
-        throw new Error(errorData.message || `Request failed: ${response.status}`);
+        throw new Error(
+          errorData.message || `Request failed: ${response.status}`,
+        );
       }
 
       return await response.json();
@@ -209,25 +245,30 @@ async function fetchWithRetry(url: string, options: RequestInit, maxRetries: num
       console.warn(`[Background] Fetch attempt ${attempt + 1} failed:`, error);
 
       // Don't retry on abort or auth errors
-      if ((error as Error).name === 'AbortError' || (error as Error).message.includes('Authentication')) {
+      if (
+        (error as Error).name === "AbortError" ||
+        (error as Error).message.includes("Authentication")
+      ) {
         throw error;
       }
 
       if (attempt < maxRetries - 1) {
         const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
   }
 
-  throw lastError || new Error('Request failed after all retries');
+  throw lastError || new Error("Request failed after all retries");
 }
 
 function isNetworkError(error: any): boolean {
-  return error.name === 'TypeError' ||
-         error.message?.includes('fetch') ||
-         error.message?.includes('network') ||
-         error.message?.includes('offline');
+  return (
+    error.name === "TypeError" ||
+    error.message?.includes("fetch") ||
+    error.message?.includes("network") ||
+    error.message?.includes("offline")
+  );
 }
 
 // =============================================================================
@@ -235,7 +276,23 @@ function isNetworkError(error: any): boolean {
 // =============================================================================
 
 async function getAuthStatus(): Promise<ExtensionResponse> {
-  const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken, STORAGE_KEYS.user]);
+  let stored = await chrome.storage.local.get([
+    STORAGE_KEYS.authToken,
+    STORAGE_KEYS.authTokenExpiresAt,
+    STORAGE_KEYS.user,
+  ]);
+  const expiresAt = Number(stored[STORAGE_KEYS.authTokenExpiresAt] || 0);
+  if (
+    !stored[STORAGE_KEYS.authToken] ||
+    (expiresAt > 0 && expiresAt <= Date.now() + 30_000)
+  ) {
+    await syncMystiraSession();
+    stored = await chrome.storage.local.get([
+      STORAGE_KEYS.authToken,
+      STORAGE_KEYS.user,
+    ]);
+  }
+
   return {
     success: true,
     data: {
@@ -245,18 +302,120 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
   };
 }
 
-async function handleLogin(email: string, password: string): Promise<ExtensionResponse> {
+async function syncMystiraSession(): Promise<ExtensionResponse> {
+  try {
+    const config = getConfig();
+    const sessionResponse = await fetch(
+      `${config.dashboardUrl}/api/auth/session`,
+      {
+        credentials: "include",
+        cache: "no-store",
+      },
+    );
+
+    if (!sessionResponse.ok) {
+      return {
+        success: false,
+        error: "Could not read the ConvoLens sign-in session.",
+      };
+    }
+
+    const session = await sessionResponse.json();
+    if (!session?.user || typeof session.idToken !== "string") {
+      return {
+        success: false,
+        error:
+          "Not authenticated. Sign in to ConvoLens with Mystira Identity first.",
+      };
+    }
+
+    const apiConfig = await getApiConfig();
+    const exchangeResponse = await fetch(
+      `${apiConfig.apiUrl}/api/auth/mystira/exchange`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...getTracingHeaders(),
+        },
+        body: JSON.stringify({ idToken: session.idToken }),
+      },
+    );
+
+    if (!exchangeResponse.ok) {
+      return {
+        success: false,
+        error: "ConvoLens could not authorize the Mystira Identity session.",
+      };
+    }
+
+    const exchanged = await exchangeResponse.json();
+    if (
+      typeof exchanged.token !== "string" ||
+      typeof exchanged.expiresIn !== "number" ||
+      !exchanged.user
+    ) {
+      return {
+        success: false,
+        error: "ConvoLens returned an invalid extension session.",
+      };
+    }
+
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.authToken]: exchanged.token,
+      [STORAGE_KEYS.authTokenExpiresAt]:
+        Date.now() + exchanged.expiresIn * 1000,
+      [STORAGE_KEYS.user]: exchanged.user,
+    });
+    await notifyContentScripts(exchanged.token);
+
+    return {
+      success: true,
+      data: {
+        isAuthenticated: true,
+        user: exchanged.user,
+      },
+    };
+  } catch (error) {
+    console.error("[Background] Mystira session sync failed:", error);
+    return {
+      success: false,
+      error:
+        "Unable to connect the extension to the ConvoLens sign-in session.",
+    };
+  }
+}
+
+async function notifyContentScripts(token: string | null): Promise<void> {
+  const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
+  await Promise.all(
+    tabs.map((tab) =>
+      tab.id
+        ? chrome.tabs
+            .sendMessage(tab.id, { action: "SET_AUTH_TOKEN", token })
+            .catch(() => undefined)
+        : Promise.resolve(),
+    ),
+  );
+}
+
+async function handleLogin(
+  email: string,
+  password: string,
+): Promise<ExtensionResponse> {
   try {
     const config = await getApiConfig();
 
     const response = await fetch(`${config.apiUrl}/api/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, password }),
     });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ message: 'Login failed' }));
+      const error = await response
+        .json()
+        .catch(() => ({ message: "Login failed" }));
       return { success: false, error: error.message };
     }
 
@@ -267,13 +426,7 @@ async function handleLogin(email: string, password: string): Promise<ExtensionRe
       [STORAGE_KEYS.user]: user,
     });
 
-    // Notify content scripts
-    const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
-    for (const tab of tabs) {
-      if (tab.id) {
-        chrome.tabs.sendMessage(tab.id, { action: 'SET_AUTH_TOKEN', token }).catch(() => {});
-      }
-    }
+    await notifyContentScripts(token);
 
     // Process any pending uploads
     retryPendingUploads().catch(console.error);
@@ -285,15 +438,12 @@ async function handleLogin(email: string, password: string): Promise<ExtensionRe
 }
 
 async function handleLogout(): Promise<ExtensionResponse> {
-  await chrome.storage.local.remove([STORAGE_KEYS.authToken, STORAGE_KEYS.user]);
-
-  // Notify content scripts
-  const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
-  for (const tab of tabs) {
-    if (tab.id) {
-      chrome.tabs.sendMessage(tab.id, { action: 'SET_AUTH_TOKEN', token: null }).catch(() => {});
-    }
-  }
+  await chrome.storage.local.remove([
+    STORAGE_KEYS.authToken,
+    STORAGE_KEYS.authTokenExpiresAt,
+    STORAGE_KEYS.user,
+  ]);
+  await notifyContentScripts(null);
 
   return { success: true };
 }
@@ -308,9 +458,15 @@ async function getSettings(): Promise<ExtensionResponse> {
   return { success: true, data: settings };
 }
 
-async function updateSettings(newSettings: Partial<ExtensionSettings>): Promise<ExtensionResponse> {
+async function updateSettings(
+  newSettings: Partial<ExtensionSettings>,
+): Promise<ExtensionResponse> {
   const stored = await chrome.storage.local.get([STORAGE_KEYS.settings]);
-  const settings = { ...DEFAULT_SETTINGS, ...stored[STORAGE_KEYS.settings], ...newSettings };
+  const settings = {
+    ...DEFAULT_SETTINGS,
+    ...stored[STORAGE_KEYS.settings],
+    ...newSettings,
+  };
   await chrome.storage.local.set({ [STORAGE_KEYS.settings]: settings });
   return { success: true, data: settings };
 }
@@ -350,18 +506,23 @@ async function queuePendingUpload(data: any): Promise<void> {
   }
 
   if (dropped > 0) {
-    console.warn(`[Background] Queue full. Dropped ${dropped} oldest upload(s) to make room.`);
+    console.warn(
+      `[Background] Queue full. Dropped ${dropped} oldest upload(s) to make room.`,
+    );
   }
 
   await chrome.storage.local.set({ [STORAGE_KEYS.pendingUploads]: pending });
-  console.log('[Background] Queued pending upload. Total:', pending.length);
+  console.log("[Background] Queued pending upload. Total:", pending.length);
 }
 
 async function retryPendingUploads(): Promise<ExtensionResponse> {
-  const stored = await chrome.storage.local.get([STORAGE_KEYS.pendingUploads, STORAGE_KEYS.authToken]);
+  const stored = await chrome.storage.local.get([
+    STORAGE_KEYS.pendingUploads,
+    STORAGE_KEYS.authToken,
+  ]);
 
   if (!stored[STORAGE_KEYS.authToken]) {
-    return { success: false, error: 'Not authenticated' };
+    return { success: false, error: "Not authenticated" };
   }
 
   const pending: PendingUpload[] = stored[STORAGE_KEYS.pendingUploads] || [];
@@ -376,7 +537,7 @@ async function retryPendingUploads(): Promise<ExtensionResponse> {
   for (const upload of pending) {
     // Skip if too many attempts
     if (upload.attempts >= 5) {
-      console.warn('[Background] Dropping upload after max attempts');
+      console.warn("[Background] Dropping upload after max attempts");
       continue;
     }
 
@@ -396,7 +557,7 @@ async function retryPendingUploads(): Promise<ExtensionResponse> {
     }
 
     // Small delay between retries
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
   await chrome.storage.local.set({ [STORAGE_KEYS.pendingUploads]: remaining });
@@ -418,7 +579,9 @@ async function clearPendingUploads(): Promise<ExtensionResponse> {
 
 async function trackExtractionHistory(chatData: any): Promise<void> {
   try {
-    const stored = await chrome.storage.local.get([STORAGE_KEYS.extractionHistory]);
+    const stored = await chrome.storage.local.get([
+      STORAGE_KEYS.extractionHistory,
+    ]);
     const history = stored[STORAGE_KEYS.extractionHistory] || [];
 
     history.unshift({
@@ -432,9 +595,11 @@ async function trackExtractionHistory(chatData: any): Promise<void> {
       history.pop();
     }
 
-    await chrome.storage.local.set({ [STORAGE_KEYS.extractionHistory]: history });
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.extractionHistory]: history,
+    });
   } catch (error) {
-    console.error('[Background] Failed to track history:', error);
+    console.error("[Background] Failed to track history:", error);
   }
 }
 
@@ -486,7 +651,7 @@ async function checkApiRateLimit(): Promise<boolean> {
 
 async function openDashboard(path?: string): Promise<ExtensionResponse> {
   const config = await getApiConfig();
-  const url = `${config.dashboardUrl}${path || '/dashboard'}`;
+  const url = `${config.dashboardUrl}${path || "/dashboard"}`;
   await chrome.tabs.create({ url });
   return { success: true };
 }
@@ -496,9 +661,9 @@ async function openDashboard(path?: string): Promise<ExtensionResponse> {
 // =============================================================================
 
 chrome.runtime.onInstalled.addListener(async (details) => {
-  console.log('[Background] Extension installed:', details.reason);
+  console.log("[Background] Extension installed:", details.reason);
 
-  if (details.reason === 'install') {
+  if (details.reason === "install") {
     // Initialize default settings
     await chrome.storage.local.set({
       [STORAGE_KEYS.settings]: DEFAULT_SETTINGS,
@@ -508,28 +673,30 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
     // Open welcome page
     const config = getConfig();
-    await chrome.tabs.create({ url: `${config.dashboardUrl}/extension-welcome` });
+    await chrome.tabs.create({
+      url: `${config.dashboardUrl}/extension-welcome`,
+    });
   }
 
-  if (details.reason === 'update') {
+  if (details.reason === "update") {
     // Process any pending uploads after update
     setTimeout(() => retryPendingUploads().catch(console.error), 5000);
   }
 });
 
 // Periodic sync of pending uploads
-chrome.alarms.create('syncPendingUploads', { periodInMinutes: 5 });
+chrome.alarms.create("syncPendingUploads", { periodInMinutes: 5 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === 'syncPendingUploads') {
+  if (alarm.name === "syncPendingUploads") {
     retryPendingUploads().catch(console.error);
   }
 });
 
 // Listen for network status changes
-self.addEventListener('online', () => {
-  console.log('[Background] Back online, syncing pending uploads');
+self.addEventListener("online", () => {
+  console.log("[Background] Back online, syncing pending uploads");
   retryPendingUploads().catch(console.error);
 });
 
-console.log('[Background] Service worker initialized');
+console.log("[Background] Service worker initialized");

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -50,7 +50,7 @@ export const SELECTORS = {
     chatList: '.copyable-area [role="listitem"]',
     messageList: ".message-list",
     messageContainer: ".message-in, .message-out",
-    messageText: '.selectable-text span[dir="ltr"]',
+    messageText: ".selectable-text.copyable-text[dir]",
     messageTime: '.copyable-text span[dir="auto"]',
     senderName: 'span[dir="auto"]._ahxt',
     chatHeader: "header._ao8g",
@@ -85,6 +85,7 @@ export const RATE_LIMIT_CONFIG = {
 // Storage keys
 export const STORAGE_KEYS = {
   authToken: "authToken",
+  authTokenExpiresAt: "authTokenExpiresAt",
   user: "user",
   settings: "settings",
   extractionHistory: "extractionHistory",
@@ -181,6 +182,10 @@ export interface GetAuthStatusMessage {
   action: "GET_AUTH_STATUS";
 }
 
+export interface SyncMystiraAuthMessage {
+  action: "SYNC_MYSTIRA_AUTH";
+}
+
 export interface LoginMessage {
   action: "LOGIN";
   email: string;
@@ -216,6 +221,7 @@ export type ExtensionMessage =
   | SendChatDataMessage
   | OpenDashboardMessage
   | GetAuthStatusMessage
+  | SyncMystiraAuthMessage
   | LoginMessage
   | LogoutMessage
   | GetSettingsMessage

--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,89 @@
+import { refreshMystiraToken } from "../auth";
+
+describe("Mystira Identity token refresh", () => {
+  const originalWellKnown = process.env.MYSTIRA_IDENTITY_WELL_KNOWN;
+  const originalClientId = process.env.MYSTIRA_IDENTITY_CLIENT_ID;
+  const originalClientSecret = process.env.MYSTIRA_IDENTITY_CLIENT_SECRET;
+
+  beforeEach(() => {
+    process.env.MYSTIRA_IDENTITY_WELL_KNOWN =
+      "https://identity.example/.well-known/openid-configuration";
+    process.env.MYSTIRA_IDENTITY_CLIENT_ID = "convolens-client";
+    process.env.MYSTIRA_IDENTITY_CLIENT_SECRET = "client-secret";
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env.MYSTIRA_IDENTITY_WELL_KNOWN = originalWellKnown;
+    process.env.MYSTIRA_IDENTITY_CLIENT_ID = originalClientId;
+    process.env.MYSTIRA_IDENTITY_CLIENT_SECRET = originalClientSecret;
+    jest.restoreAllMocks();
+  });
+
+  it("rotates the refresh token and ID token", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    const idToken = [
+      Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url"),
+      Buffer.from(JSON.stringify({ exp: expiresAt })).toString("base64url"),
+      "signature",
+    ].join(".");
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token_endpoint: "https://identity.example/connect/token",
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: "access-2",
+          id_token: idToken,
+          refresh_token: "refresh-2",
+          expires_in: 3600,
+        }),
+      } as Response);
+
+    const result = await refreshMystiraToken({
+      accessToken: "access-1",
+      idToken: "expired-id-token",
+      refreshToken: "refresh-1",
+    });
+
+    expect(result).toMatchObject({
+      accessToken: "access-2",
+      idToken,
+      idTokenExpiresAt: expiresAt * 1000,
+      refreshToken: "refresh-2",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://identity.example/connect/token",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(URLSearchParams),
+      }),
+    );
+    expect(
+      (fetchMock.mock.calls[1][1]?.body as URLSearchParams).toString(),
+    ).toContain("grant_type=refresh_token");
+  });
+
+  it("does not expose an expired ID token when refresh is unavailable", async () => {
+    delete process.env.MYSTIRA_IDENTITY_CLIENT_SECRET;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = await refreshMystiraToken({
+      idToken: "expired-id-token",
+      refreshToken: "refresh-1",
+    });
+
+    expect(result.idToken).toBeUndefined();
+    expect(result.refreshError).toBe("RefreshAccessTokenError");
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { NextAuthOptions } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 import type { OAuthConfig } from "next-auth/providers/oauth";
 
 type MystiraProfile = {
@@ -9,6 +10,95 @@ type MystiraProfile = {
   picture?: string;
 };
 
+type MystiraDiscovery = {
+  token_endpoint?: string;
+};
+
+type MystiraTokenResponse = {
+  access_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  refresh_token?: string;
+};
+
+function getIdTokenExpiry(idToken?: string): number | undefined {
+  if (!idToken) {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(idToken.split(".")[1], "base64url").toString("utf8"),
+    ) as { exp?: number };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function refreshMystiraToken(token: JWT): Promise<JWT> {
+  try {
+    const wellKnown = process.env.MYSTIRA_IDENTITY_WELL_KNOWN;
+    const clientId = process.env.MYSTIRA_IDENTITY_CLIENT_ID;
+    const clientSecret = process.env.MYSTIRA_IDENTITY_CLIENT_SECRET;
+    if (!wellKnown || !clientId || !clientSecret || !token.refreshToken) {
+      throw new Error("Mystira Identity refresh is not configured");
+    }
+
+    const discoveryResponse = await fetch(wellKnown, { cache: "no-store" });
+    if (!discoveryResponse.ok) {
+      throw new Error(
+        `Mystira Identity discovery failed with HTTP ${discoveryResponse.status}`,
+      );
+    }
+
+    const discovery = (await discoveryResponse.json()) as MystiraDiscovery;
+    if (!discovery.token_endpoint) {
+      throw new Error("Mystira Identity discovery is missing token_endpoint");
+    }
+
+    const tokenResponse = await fetch(discovery.token_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: token.refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+      cache: "no-store",
+    });
+    if (!tokenResponse.ok) {
+      throw new Error(
+        `Mystira Identity token refresh failed with HTTP ${tokenResponse.status}`,
+      );
+    }
+
+    const refreshed = (await tokenResponse.json()) as MystiraTokenResponse;
+    if (!refreshed.id_token) {
+      throw new Error("Mystira Identity refresh did not return an ID token");
+    }
+
+    return {
+      ...token,
+      accessToken: refreshed.access_token || token.accessToken,
+      idToken: refreshed.id_token,
+      idTokenExpiresAt:
+        getIdTokenExpiry(refreshed.id_token) ||
+        Date.now() + (refreshed.expires_in || 3600) * 1000,
+      refreshToken: refreshed.refresh_token || token.refreshToken,
+      refreshError: undefined,
+    };
+  } catch (error) {
+    console.error("Unable to refresh the Mystira Identity session", error);
+    return {
+      ...token,
+      idToken: undefined,
+      refreshError: "RefreshAccessTokenError",
+    };
+  }
+}
+
 const mystiraIdentityProvider = (): OAuthConfig<MystiraProfile> => ({
   id: "mystira",
   name: "Mystira Identity",
@@ -16,7 +106,9 @@ const mystiraIdentityProvider = (): OAuthConfig<MystiraProfile> => ({
   wellKnown: process.env.MYSTIRA_IDENTITY_WELL_KNOWN,
   authorization: {
     params: {
-      scope: process.env.MYSTIRA_IDENTITY_SCOPE || "openid profile email",
+      scope:
+        process.env.MYSTIRA_IDENTITY_SCOPE ||
+        "openid profile email offline_access",
     },
   },
   idToken: true,
@@ -26,7 +118,11 @@ const mystiraIdentityProvider = (): OAuthConfig<MystiraProfile> => ({
   profile(profile) {
     return {
       id: profile.sub,
-      name: profile.name || profile.preferred_username || profile.email || "Mystira User",
+      name:
+        profile.name ||
+        profile.preferred_username ||
+        profile.email ||
+        "Mystira User",
       email: profile.email,
       image: profile.picture,
     };
@@ -43,13 +139,29 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     async jwt({ token, account }) {
-      if (account?.access_token) {
+      if (account) {
         token.accessToken = account.access_token;
+        token.idToken = account.id_token;
+        token.idTokenExpiresAt =
+          getIdTokenExpiry(account.id_token) ||
+          (account.expires_at ? account.expires_at * 1000 : undefined);
+        token.refreshToken = account.refresh_token;
+        token.refreshError = undefined;
+        return token;
       }
-      return token;
+
+      const expiresAt = token.idTokenExpiresAt as number | undefined;
+      if (token.idToken && expiresAt && Date.now() < expiresAt - 30_000) {
+        return token;
+      }
+
+      return refreshMystiraToken(token);
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken as string | undefined;
+      session.idToken = token.refreshError
+        ? undefined
+        : (token.idToken as string | undefined);
       return session;
     },
   },

--- a/apps/web/src/types/next-auth.d.ts
+++ b/apps/web/src/types/next-auth.d.ts
@@ -4,11 +4,16 @@ import "next-auth/jwt";
 declare module "next-auth" {
   interface Session {
     accessToken?: string;
+    idToken?: string;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
     accessToken?: string;
+    idToken?: string;
+    idTokenExpiresAt?: number;
+    refreshError?: "RefreshAccessTokenError";
+    refreshToken?: string;
   }
 }

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -306,6 +306,14 @@ resource "azurerm_container_app" "api" {
         value = var.allowed_origin
       }
       env {
+        name  = "MYSTIRA_IDENTITY_WELL_KNOWN"
+        value = var.mystira_identity_well_known
+      }
+      env {
+        name  = "MYSTIRA_IDENTITY_CLIENT_ID"
+        value = var.mystira_identity_client_id
+      }
+      env {
         name  = "DB_TYPE"
         value = var.enable_postgres ? "postgres" : "sqlite"
       }

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -130,7 +130,7 @@ variable "mystira_identity_client_id" {
 variable "mystira_identity_scope" {
   type        = string
   description = "Mystira Identity OIDC scopes requested by Convolens."
-  default     = "openid profile email"
+  default     = "openid profile email offline_access"
 }
 
 variable "admin_email" {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       archiver:
         specifier: ^8.0.0
         version: 8.0.0
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       typescript:
         specifier: ^5.3.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- bundle the Chrome extension content and background scripts into Chrome-compatible runtime artifacts
- update WhatsApp message extraction for the current DOM fallback selector
- replace the popup's placeholder email/password flow with Mystira Identity session connection
- validate Mystira RS256 ID tokens through OIDC discovery/JWKS and exchange them for short-lived ConvoLens API JWTs
- rotate Mystira refresh and ID tokens for durable extension sessions
- wire Mystira discovery, client ID, and `offline_access` scope into production Terraform

## Why

The unpacked extension previously failed before API receipt: Chrome rejected unbundled imports, the old WhatsApp selector extracted no messages, and the popup called a placeholder login endpoint. The production NextAuth session is now bridged to the API without accepting an opaque access token as a Mystira userinfo token.

## Impact

Operators can connect an authenticated Mystira session from the extension and submit a selected WhatsApp chat to the protected ConvoLens extension endpoint. The current endpoint acknowledges, deduplicates, and records metrics; durable persistence and AI summarization remain follow-up work.

## Validation

- `pnpm --dir apps/api exec jest --config=jest.config.js --runInBand src/services/__tests__/mystira-auth.service.test.ts` (3 passed)
- `pnpm --dir apps/web exec jest --config=jest.config.js --runInBand src/lib/__tests__/auth.test.ts` (2 passed)
- `pnpm --filter @convolens/api build`
- `pnpm --filter @convolens/web build`
- `npm run package` in `apps/chrome-extension`
- `terraform -chdir=infra/terraform/env/prod validate`
- targeted Prettier, Terraform fmt, ESLint, and `git diff --check`

A standalone full web `tsc --noEmit` remains blocked by pre-existing missing test type declarations and unrelated baseline type errors; the production Next.js build passes.