### PR TITLE
Preserve production web secrets in Terraform

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -1,6 +1,7 @@
 # Convolens Mystira Azure Go-Live Plan
 
-Status: Draft - pending approval
+Status: Validated — deployment blocked on credential rotation
+Recipe: Terraform
 Date: 2026-07-16
 Target subscription: bb4e3882-2079-4bab-8974-611bc0b8bb58
 Target tenant: 9530cd32-9e33-47f0-9247-ed964730b580
@@ -167,6 +168,20 @@ Minimal go-live slice for WhatsApp-to-Baton:
 Do not rely on the Puppeteer WhatsApp Web client for production go-live unless a separate security/session/runbook decision is made. The Chrome extension path is the recommended first-class ingestion path; manual export is the fallback.
 
 ## 7. Security and Compliance
+
+### Validation Proof — 2026-07-24
+
+- Approved subscription `bb4e3882-2079-4bab-8974-611bc0b8bb58` and tenant `9530cd32-9e33-47f0-9247-ed964730b580` were confirmed enabled through Azure CLI and Azure MCP.
+- `terraform -chdir=infra/terraform/env/prod init -backend-config=backend.hcl -input=false` succeeded against the production remote backend.
+- `terraform -chdir=infra/terraform/env/prod fmt -check -recursive` and `terraform -chdir=infra/terraform/env/prod validate` passed with Terraform 1.14.7, matching the production workflow.
+- `terraform -chdir=infra/terraform/env/prod state list` returned the expected production App Service, Container App, storage, Key Vault, telemetry, registry, queue, and role-assignment resources.
+- Azure Policy assignment validation found only the default Defender for Cloud audit initiative and no deny assignment blocking the deployment.
+- A final no-refresh production plan using the current API image and port reported `0 to add, 2 to change, 0 to destroy`. The expected in-place changes add the Mystira API validation settings, Key Vault references, and `offline_access` for web token refresh.
+- An earlier live-refresh validation rendered the two protected web values into transient local output. Its saved plan was securely deleted, and a targeted remote-state inspection confirmed neither value is stored in Terraform state.
+- Rotate `NEXTAUTH_SECRET` and the Mystira Identity client secret through their approved owners, then update the protected GitHub production environment before deployment.
+- App Service uses non-secret Key Vault references for the protected web settings. The deployment workflow writes their values directly from the protected GitHub environment into Key Vault, keeping the values out of Terraform configuration, plan output, and state.
+- Main CI run `30115398626` passed for merge commit `f267b0e`; focused API auth tests, web token-refresh tests, API/web builds, extension packaging, Prettier, targeted lint, and `git diff --check` also passed.
+- Pre-deployment public checks returned HTTP 200 for `/features`, `/api/runtime/auth-status` with `mystiraConfigured: true`, and the production API `/health`.
 
 Production requirements:
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,11 +8,11 @@ permissions:
   id-token: write
 
 env:
-  TF_VERSION: '1.14.7'
-  TF_IN_AUTOMATION: 'true'
-  TF_INPUT: '0'
+  TF_VERSION: "1.14.7"
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "0"
   ENVIRONMENT: prod
-  ARM_USE_OIDC: 'true'
+  ARM_USE_OIDC: "true"
   ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
   ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -64,15 +64,15 @@ jobs:
         timeout-minutes: 10
         run: pnpm install --frozen-lockfile --reporter=append-only
         env:
-          CI: 'true'
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+          CI: "true"
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
 
       - name: Build API and Web
         timeout-minutes: 15
         run: pnpm run build
         env:
-          CI: 'true'
+          CI: "true"
           NEXT_PUBLIC_API_URL: https://placeholder.invalid/api
           NEXT_PUBLIC_API_BASE_URL: https://placeholder.invalid
 
@@ -178,6 +178,43 @@ jobs:
           echo "image=$CURRENT_IMAGE" >> "$GITHUB_OUTPUT"
           echo "target-port=$CURRENT_PORT" >> "$GITHUB_OUTPUT"
 
+      - name: Preload Web Secrets Into Existing Key Vault
+        env:
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          MYSTIRA_IDENTITY_CLIENT_SECRET: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if ! az keyvault show --name nl-prod-convolens-kv --only-show-errors >/dev/null 2>&1; then
+            echo "Key Vault is not provisioned yet; the base Terraform apply will create it."
+            exit 0
+          fi
+          if [ -z "$NEXTAUTH_SECRET" ] || [ -z "$MYSTIRA_IDENTITY_CLIENT_SECRET" ]; then
+            echo "Error: NEXTAUTH_SECRET and MYSTIRA_IDENTITY_CLIENT_SECRET are required." >&2
+            exit 1
+          fi
+          az keyvault secret set \
+            --vault-name nl-prod-convolens-kv \
+            --name nextauth-secret \
+            --value "$NEXTAUTH_SECRET" \
+            --output none
+          az keyvault secret set \
+            --vault-name nl-prod-convolens-kv \
+            --name mystira-identity-client-secret \
+            --value "$MYSTIRA_IDENTITY_CLIENT_SECRET" \
+            --output none
+          if az webapp show \
+            --resource-group nl-prod-convolens-rg \
+            --name nl-prod-convolens-web \
+            --only-show-errors >/dev/null 2>&1; then
+            az webapp config appsettings set \
+              --resource-group nl-prod-convolens-rg \
+              --name nl-prod-convolens-web \
+              --settings \
+                'NEXTAUTH_SECRET=@Microsoft.KeyVault(VaultName=nl-prod-convolens-kv;SecretName=nextauth-secret)' \
+                'MYSTIRA_IDENTITY_CLIENT_SECRET=@Microsoft.KeyVault(VaultName=nl-prod-convolens-kv;SecretName=mystira-identity-client-secret)' \
+              --output none
+          fi
+
       - name: Terraform Apply Base Infrastructure
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
@@ -187,6 +224,27 @@ jobs:
             -auto-approve \
             -var "container_image_api=${{ steps.base-api.outputs.image }}" \
             -var "api_target_port=${{ steps.base-api.outputs.target-port }}"
+
+      - name: Ensure Web Secrets In Key Vault
+        env:
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          MYSTIRA_IDENTITY_CLIENT_SECRET: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NEXTAUTH_SECRET" ] || [ -z "$MYSTIRA_IDENTITY_CLIENT_SECRET" ]; then
+            echo "Error: NEXTAUTH_SECRET and MYSTIRA_IDENTITY_CLIENT_SECRET are required." >&2
+            exit 1
+          fi
+          az keyvault secret set \
+            --vault-name nl-prod-convolens-kv \
+            --name nextauth-secret \
+            --value "$NEXTAUTH_SECRET" \
+            --output none
+          az keyvault secret set \
+            --vault-name nl-prod-convolens-kv \
+            --name mystira-identity-client-secret \
+            --value "$MYSTIRA_IDENTITY_CLIENT_SECRET" \
+            --output none
 
       - name: Capture Terraform Outputs
         id: tf
@@ -229,7 +287,7 @@ jobs:
         timeout-minutes: 15
         run: pnpm --filter @convolens/web... build
         env:
-          CI: 'true'
+          CI: "true"
           NEXT_PUBLIC_API_URL: ${{ steps.tf.outputs.api-url }}/api
           NEXT_PUBLIC_API_BASE_URL: ${{ steps.tf.outputs.api-url }}
 
@@ -288,23 +346,7 @@ jobs:
           zip -r ../web.zip .
 
       - name: Deploy Web App
-        env:
-          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-          MYSTIRA_IDENTITY_CLIENT_SECRET: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_SECRET }}
         run: |
-          SETTINGS=()
-          if [ -n "$NEXTAUTH_SECRET" ]; then
-            SETTINGS+=(NEXTAUTH_SECRET="$NEXTAUTH_SECRET")
-          fi
-          if [ -n "$MYSTIRA_IDENTITY_CLIENT_SECRET" ]; then
-            SETTINGS+=(MYSTIRA_IDENTITY_CLIENT_SECRET="$MYSTIRA_IDENTITY_CLIENT_SECRET")
-          fi
-          if [ "${#SETTINGS[@]}" -gt 0 ]; then
-            az webapp config appsettings set \
-              --resource-group "${{ steps.tf.outputs.resource-group }}" \
-              --name "${{ steps.tf.outputs.web-name }}" \
-              --settings "${SETTINGS[@]}"
-          fi
           az webapp config appsettings set \
             --resource-group "${{ steps.tf.outputs.resource-group }}" \
             --name "${{ steps.tf.outputs.web-name }}" \

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -442,8 +442,10 @@ resource "azurerm_linux_web_app" "frontend" {
     APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.ai.connection_string
     AZURE_APP_INSIGHTS_CONNECTION_STRING  = azurerm_application_insights.ai.connection_string
     NEXTAUTH_URL                          = var.allowed_origin
+    NEXTAUTH_SECRET                       = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.kv.name};SecretName=nextauth-secret)"
     MYSTIRA_IDENTITY_WELL_KNOWN           = var.mystira_identity_well_known
     MYSTIRA_IDENTITY_SCOPE                = var.mystira_identity_scope
+    MYSTIRA_IDENTITY_CLIENT_SECRET        = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.kv.name};SecretName=mystira-identity-client-secret)"
     SCM_DO_BUILD_DURING_DEPLOYMENT        = "false"
     WEBSITE_RUN_FROM_PACKAGE              = "1"
     CONVOLENS_CANONICAL_HOSTNAME          = var.custom_hostname


### PR DESCRIPTION
## Summary

- store `NEXTAUTH_SECRET` and `MYSTIRA_IDENTITY_CLIENT_SECRET` in the existing production Key Vault
- configure App Service with versionless Key Vault references instead of raw protected values
- preload those references before Terraform reconciliation so refresh/apply cannot carry the protected values into plan output or state
- record the production validation proof and the credential-rotation deployment gate

## Root cause

The production workflow injected the two web secrets directly into App Service after Terraform ran, while Terraform managed the rest of the `app_settings` map. A live refresh could therefore read those out-of-band values into Terraform plan/state handling. `ignore_changes` suppresses a diff but is not a secret boundary.

## Impact

Terraform now manages only non-secret Key Vault reference strings. The protected GitHub production environment values are written directly to Key Vault by the deployment workflow, and the frontend's existing managed identity resolves them at runtime through its `Key Vault Secrets User` assignment.

## Validation

- `terraform -chdir=infra/terraform/env/prod fmt -check -recursive`
- `terraform -chdir=infra/terraform/env/prod validate`
- `pnpm exec prettier --check .github/workflows/deploy-prod.yml .azure/plan.md`
- `git diff --check`
- targeted remote-state inspection confirmed neither protected key is stored in Terraform state
- no-refresh production plan using the current API image and port: `0 to add, 2 to change, 0 to destroy`
- the temporary saved validation plan was securely deleted

## Deployment gate

Rotate `NEXTAUTH_SECRET` and the Mystira Identity client secret through their approved owners, then update the protected GitHub production environment before triggering the manual production workflow.