### PR TITLE
Make conversation intake durable

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -1,6 +1,6 @@
 # Convolens Mystira Azure Go-Live Plan
 
-Status: Deployed — operator extension smoke pending
+Status: Validated — durable intake deployment pending
 Recipe: Terraform
 Date: 2026-07-16
 Target subscription: bb4e3882-2079-4bab-8974-611bc0b8bb58
@@ -182,6 +182,16 @@ Do not rely on the Puppeteer WhatsApp Web client for production go-live unless a
 - App Service uses non-secret Key Vault references for the protected web settings. The deployment workflow writes their values directly from the protected GitHub environment into Key Vault, keeping the values out of Terraform configuration, plan output, and state.
 - Main CI run `30115398626` passed for merge commit `f267b0e`; focused API auth tests, web token-refresh tests, API/web builds, extension packaging, Prettier, targeted lint, and `git diff --check` also passed.
 - Pre-deployment public checks returned HTTP 200 for `/features`, `/api/runtime/auth-status` with `mystiraConfigured: true`, and the production API `/health`.
+
+### Durable Intake Validation Proof — 2026-07-25
+
+- Production target remains the approved subscription `bb4e3882-2079-4bab-8974-611bc0b8bb58`, tenant `9530cd32-9e33-47f0-9247-ed964730b580`, and South Africa North region.
+- API CI passed all 7 suites and 77 tests, including transaction, durable idempotency, user isolation, and SQLite migration coverage.
+- A production-mode runtime smoke proved add, list, restart, reload, stable duplicate detection, and database-backed `/ready` behavior.
+- Web production build, extension typecheck/build, focused web auth/session tests, Terraform format/validate, and workflow lint all passed.
+- Protected OIDC infrastructure plan run `30135613432` resolved the current production API image and target port before planning.
+- The reviewed production plan is limited to `4 to add, 1 to change, 0 to destroy`: PostgreSQL Flexible Server `B_Standard_B1ms`, the `convolens` database, its Azure-services firewall rule, the generated password in Key Vault, and an in-place API database/readiness configuration update.
+- Estimated recurring PostgreSQL compute and 32 GiB storage cost is approximately USD 20.53/month before taxes, excess backup, and egress, within the existing USD 75 resource-group budget.
 
 ### Deployment Proof — 2026-07-24
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -91,7 +91,7 @@ jobs:
             PORT=3001 \
             DB_TYPE=sqlite \
             DATABASE_PATH="$DB_PATH" \
-            DB_MIGRATIONS_RUN=false \
+            DB_MIGRATIONS_RUN=true \
             node apps/api/dist/index.js > api-startup.log 2>&1 &
           API_PID=$!
           for attempt in {1..30}; do
@@ -154,6 +154,19 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=infra/terraform/env/prod init -backend-config=backend.hcl
 
+      - name: Verify PostgreSQL SKU Availability
+        run: |
+          set -euo pipefail
+          AVAILABLE_SKUS=$(az postgres flexible-server list-skus \
+            --location southafricanorth \
+            --query '[].name' \
+            -o tsv)
+          if ! grep -Eq '(^|_)Standard_B1ms$' <<< "$AVAILABLE_SKUS"; then
+            echo "PostgreSQL Flexible Server SKU Standard_B1ms is not available in southafricanorth." >&2
+            echo "$AVAILABLE_SKUS"
+            exit 1
+          fi
+
       - name: Resolve Base API Runtime
         id: base-api
         run: |
@@ -215,15 +228,18 @@ jobs:
               --output none
           fi
 
-      - name: Terraform Apply Base Infrastructure
+      - name: Terraform Plan Base Infrastructure
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
         run: |
-          terraform -chdir=infra/terraform/env/prod apply \
-            -auto-approve \
+          terraform -chdir=infra/terraform/env/prod plan \
+            -out=base.tfplan \
             -var "container_image_api=${{ steps.base-api.outputs.image }}" \
             -var "api_target_port=${{ steps.base-api.outputs.target-port }}"
+
+      - name: Terraform Apply Base Infrastructure
+        run: terraform -chdir=infra/terraform/env/prod apply base.tfplan
 
       - name: Ensure Web Secrets In Key Vault
         env:
@@ -273,15 +289,18 @@ jobs:
             .
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
-      - name: Terraform Apply API Image
+      - name: Terraform Plan API Image
         run: |
-          terraform -chdir=infra/terraform/env/prod apply \
-            -auto-approve \
+          terraform -chdir=infra/terraform/env/prod plan \
+            -out=api-image.tfplan \
             -var "container_image_api=${{ steps.api-image.outputs.image }}" \
             -var "api_target_port=3001"
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+
+      - name: Terraform Apply API Image
+        run: terraform -chdir=infra/terraform/env/prod apply api-image.tfplan
 
       - name: Rebuild Web With Production API URL
         timeout-minutes: 15
@@ -383,7 +402,7 @@ jobs:
             curl "${curl_args[@]}" "$url" >/dev/null
           }
 
-          smoke "" "${{ steps.tf.outputs.api-url }}/health"
+          smoke "" "${{ steps.tf.outputs.api-url }}/ready"
           smoke "-I" "${{ steps.tf.outputs.web-url }}"
           for attempt in {1..12}; do
             if curl -fsS --max-time 30 "${{ steps.tf.outputs.web-url }}/api/runtime/auth-status" | jq -e '.mystiraConfigured == true' >/dev/null; then

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -120,6 +120,9 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        env:
+          TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
+          TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
         run: |
           set -euo pipefail
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} plan -no-color -out=tfplan | tee plan-output.txt

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -118,6 +118,31 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} init -backend-config=backend.hcl
 
+      - name: Resolve Current Production API Runtime
+        id: prod-api
+        if: matrix.environment == 'prod'
+        run: |
+          set -euo pipefail
+          DEFAULT_IMAGE="mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+          CURRENT_IMAGE=$(az containerapp show \
+            --resource-group nl-prod-convolens-rg \
+            --name nl-prod-convolens-api \
+            --query 'properties.template.containers[0].image' \
+            -o tsv 2>/dev/null || true)
+          CURRENT_PORT=$(az containerapp show \
+            --resource-group nl-prod-convolens-rg \
+            --name nl-prod-convolens-api \
+            --query 'properties.configuration.ingress.targetPort' \
+            -o tsv 2>/dev/null || true)
+          if [ -z "$CURRENT_IMAGE" ]; then
+            CURRENT_IMAGE="$DEFAULT_IMAGE"
+          fi
+          if [ "$CURRENT_IMAGE" = "$DEFAULT_IMAGE" ] || [ -z "$CURRENT_PORT" ]; then
+            CURRENT_PORT="80"
+          fi
+          echo "image=$CURRENT_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "target-port=$CURRENT_PORT" >> "$GITHUB_OUTPUT"
+
       - name: Terraform Plan
         id: plan
         env:
@@ -125,7 +150,17 @@ jobs:
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
         run: |
           set -euo pipefail
-          terraform -chdir=infra/terraform/env/${{ matrix.environment }} plan -no-color -out=tfplan | tee plan-output.txt
+          PLAN_ARGS=()
+          if [ "${{ matrix.environment }}" = "prod" ]; then
+            PLAN_ARGS+=(
+              -var "container_image_api=${{ steps.prod-api.outputs.image }}"
+              -var "api_target_port=${{ steps.prod-api.outputs.target-port }}"
+            )
+          fi
+          terraform -chdir=infra/terraform/env/${{ matrix.environment }} plan \
+            -no-color \
+            -out=tfplan \
+            "${PLAN_ARGS[@]}" | tee plan-output.txt
           {
             echo "plan<<EOF"
             cat plan-output.txt

--- a/apps/api/docs/openapi.yaml
+++ b/apps/api/docs/openapi.yaml
@@ -164,6 +164,67 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/chat-export:
+    get:
+      summary: List stored conversation intakes
+      description: List up to 100 durable conversation records for the signed-in user
+      tags:
+        - Chat Export
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: User-scoped conversation list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      conversations:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ConversationSummary'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/chat-export/{id}:
+    get:
+      summary: Get a stored conversation intake
+      description: Load one durable conversation and its messages for the signed-in user
+      tags:
+        - Chat Export
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: User-scoped conversation detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      conversation:
+                        $ref: '#/components/schemas/ConversationDetail'
+        '404':
+          description: Conversation not found for this user
+
   /api/chat-export/upload:
     post:
       summary: Upload chat export file
@@ -425,9 +486,16 @@ components:
       properties:
         message:
           type: string
+        duplicate:
+          type: boolean
         data:
           type: object
           properties:
+            intakeId:
+              type: string
+              format: uuid
+            displayName:
+              type: string
             messageCount:
               type: integer
             participants:
@@ -443,6 +511,8 @@ components:
                 end:
                   type: string
                   format: date-time
+            dashboardUrl:
+              type: string
 
     ExtensionChatData:
       type: object
@@ -516,6 +586,9 @@ components:
           properties:
             chatId:
               type: string
+            intakeId:
+              type: string
+              format: uuid
             chatName:
               type: string
             messageCount:
@@ -523,8 +596,75 @@ components:
             receivedAt:
               type: string
               format: date-time
+            dashboardUrl:
+              type: string
         duplicate:
           type: boolean
+
+    ConversationSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sourcePlatform:
+          type: string
+        sourceKind:
+          type: string
+          enum: [extension, upload]
+        displayName:
+          type: string
+        isGroup:
+          type: boolean
+        participants:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [received]
+        messageCount:
+          type: integer
+        sourceExtractedAt:
+          type: string
+          format: date-time
+        receivedAt:
+          type: string
+          format: date-time
+
+    ConversationDetail:
+      allOf:
+        - $ref: '#/components/schemas/ConversationSummary'
+        - type: object
+          properties:
+            provenance:
+              type: object
+            messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/ConversationMessage'
+
+    ConversationMessage:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        position:
+          type: integer
+        senderName:
+          type: string
+        content:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+        isOutgoing:
+          type: boolean
+        isMedia:
+          type: boolean
+        mediaType:
+          type: string
 
     SelectorResponse:
       type: object

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { correlationMiddleware } from './middleware/correlation.js';
 import { metricsMiddleware, metrics } from './services/metrics.service.js';
 import { idempotencyMiddleware, deduplicationService } from './services/deduplication.service.js';
 import { getAllCircuitBreakerStats } from './services/circuit-breaker.service.js';
+import { AppDataSource } from './config/database.js';
 
 const { json, urlencoded } = bodyParser;
 
@@ -26,11 +27,13 @@ export const createApp = (): Application => {
 
   // Security middleware
   app.use(helmet());
-  app.use(cors({
-    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-    credentials: true,
-    exposedHeaders: ['x-correlation-id', 'x-request-id'],
-  }));
+  app.use(
+    cors({
+      origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+      credentials: true,
+      exposedHeaders: ['x-correlation-id', 'x-request-id'],
+    })
+  );
   app.use(json());
   app.use(urlencoded({ extended: true }));
 
@@ -46,6 +49,27 @@ export const createApp = (): Application => {
       timestamp: new Date().toISOString(),
       environment: process.env.NODE_ENV || 'development',
     });
+  });
+
+  app.get('/ready', async (_req: Request, res: Response) => {
+    try {
+      if (!AppDataSource.isInitialized) {
+        throw new Error('Database is not initialized');
+      }
+      await AppDataSource.query('SELECT 1');
+      return res.status(200).json({
+        status: 'ready',
+        database: 'ok',
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('Readiness check failed:', error);
+      return res.status(503).json({
+        status: 'not-ready',
+        database: 'unavailable',
+        timestamp: new Date().toISOString(),
+      });
+    }
   });
 
   // Metrics endpoint (for monitoring)
@@ -85,7 +109,7 @@ export const createApp = (): Application => {
     logger.error('Error:', err);
     res.status(500).json({
       message: 'Internal Server Error',
-      error: process.env.NODE_ENV === 'development' ? err.message : {}
+      error: process.env.NODE_ENV === 'development' ? err.message : {},
     });
   });
 

--- a/apps/api/src/config/database.ts
+++ b/apps/api/src/config/database.ts
@@ -1,21 +1,24 @@
-import { DataSource } from 'typeorm';
-import type { DataSourceOptions } from 'typeorm';
+import { DataSource, type DataSourceOptions } from 'typeorm';
 import { Message } from '../db/entities/Message';
 import { Group } from '../db/entities/Group';
 import { User } from '../db/entities/User';
+import { ConversationIntake } from '../db/entities/ConversationIntake';
+import { ConversationMessage } from '../db/entities/ConversationMessage';
+import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
 import { logger } from '../utils/logger';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const dbType = process.env.DB_TYPE || 'sqlite';
-const migrationsRun = process.env.DB_MIGRATIONS_RUN === undefined
-  ? isProduction
-  : process.env.DB_MIGRATIONS_RUN === 'true';
+const migrationsRun =
+  process.env.DB_MIGRATIONS_RUN === undefined
+    ? isProduction
+    : process.env.DB_MIGRATIONS_RUN === 'true';
 
 const commonOptions = {
   synchronize: !isProduction && process.env.DB_SYNCHRONIZE !== 'false',
   logging: process.env.DB_LOGGING === 'true' || process.env.NODE_ENV === 'development',
-  entities: [Message, Group, User],
-  migrations: ['dist/db/migrations/*.js'],
+  entities: [Message, Group, User, ConversationIntake, ConversationMessage],
+  migrations: [CreateConversationIntake1753400000000],
   migrationsRun,
   subscribers: [],
   cache: {
@@ -43,6 +46,12 @@ const postgresOptions: DataSourceOptions = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME || 'convolens',
   ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+  extra: {
+    max: Number.parseInt(process.env.DB_POOL_MAX || '10', 10),
+    connectionTimeoutMillis: Number.parseInt(process.env.DB_CONNECTION_TIMEOUT_MS || '5000', 10),
+    idleTimeoutMillis: Number.parseInt(process.env.DB_IDLE_TIMEOUT_MS || '30000', 10),
+    options: '-c statement_timeout=30000',
+  },
 };
 
 const getDataSourceOptions = (): DataSourceOptions => {
@@ -64,9 +73,8 @@ export const initializeDatabase = async (): Promise<void> => {
   try {
     await AppDataSource.initialize();
     logger.info('Database connection established');
-    
-    // Run migrations in production
-    if (process.env.NODE_ENV === 'production') {
+
+    if (migrationsRun) {
       await AppDataSource.runMigrations();
       logger.info('Database migrations completed');
     }

--- a/apps/api/src/config/datasource.ts
+++ b/apps/api/src/config/datasource.ts
@@ -1,8 +1,10 @@
-import { DataSource } from 'typeorm';
-import type { DataSourceOptions } from 'typeorm';
+import { DataSource, type DataSourceOptions } from 'typeorm';
 import { User } from '../db/entities/User';
 import { Group } from '../db/entities/Group';
 import { Message } from '../db/entities/Message';
+import { ConversationIntake } from '../db/entities/ConversationIntake';
+import { ConversationMessage } from '../db/entities/ConversationMessage';
+import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
 import { logger } from '../utils/logger';
 
 // Load environment variables
@@ -11,18 +13,20 @@ dotenv.config();
 
 const isProduction = process.env.NODE_ENV === 'production';
 const dbType = process.env.DB_TYPE || 'sqlite';
-const migrationsRun = process.env.DB_MIGRATIONS_RUN === undefined
-  ? isProduction
-  : process.env.DB_MIGRATIONS_RUN === 'true';
+const migrationsRun =
+  process.env.DB_MIGRATIONS_RUN === undefined
+    ? isProduction
+    : process.env.DB_MIGRATIONS_RUN === 'true';
 
 const commonOptions = {
   synchronize: !isProduction && process.env.DB_SYNCHRONIZE !== 'false',
-  logging: process.env.DB_LOGGING === 'true' || process.env.NODE_ENV === 'development'
-    ? 'all'
-    : ['error', 'warn'],
+  logging:
+    process.env.DB_LOGGING === 'true' || process.env.NODE_ENV === 'development'
+      ? 'all'
+      : ['error', 'warn'],
   logger: isProduction ? 'file' : 'debug',
-  entities: [User, Group, Message],
-  migrations: ['dist/db/migrations/*.js'],
+  entities: [User, Group, Message, ConversationIntake, ConversationMessage],
+  migrations: [CreateConversationIntake1753400000000],
   migrationsRun,
   migrationsTableName: 'migrations',
   cache: {
@@ -50,6 +54,12 @@ const postgresOptions: DataSourceOptions = {
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME || 'convolens',
   ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+  extra: {
+    max: Number.parseInt(process.env.DB_POOL_MAX || '10', 10),
+    connectionTimeoutMillis: Number.parseInt(process.env.DB_CONNECTION_TIMEOUT_MS || '5000', 10),
+    idleTimeoutMillis: Number.parseInt(process.env.DB_IDLE_TIMEOUT_MS || '30000', 10),
+    options: '-c statement_timeout=30000',
+  },
 };
 
 const getDataSourceOptions = (): DataSourceOptions => {

--- a/apps/api/src/db/column-types.ts
+++ b/apps/api/src/db/column-types.ts
@@ -1,0 +1,4 @@
+import type { ColumnType } from 'typeorm';
+
+export const dateColumnType: ColumnType =
+  process.env.DB_TYPE === 'postgres' ? 'timestamptz' : 'datetime';

--- a/apps/api/src/db/entities/ConversationIntake.ts
+++ b/apps/api/src/db/entities/ConversationIntake.ts
@@ -1,0 +1,80 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  type Relation,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ConversationMessage } from './ConversationMessage';
+import { dateColumnType } from '../column-types';
+
+export type ConversationSourceKind = 'extension' | 'upload';
+export type ConversationStatus = 'received';
+
+export interface ConversationProvenance {
+  connectorVersion?: string;
+  originalFileName?: string;
+  captureInitiatedBy: 'user';
+  consentBasis: 'user-selected-conversation';
+}
+
+@Entity({ name: 'conversation_intakes' })
+@Index('IDX_conversation_intakes_user_received', ['userId', 'receivedAt'])
+@Index('UQ_conversation_intakes_user_content_hash', ['userId', 'contentHash'], {
+  unique: true,
+})
+@Index('IDX_conversation_intakes_status', ['status'])
+export class ConversationIntake {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  sourcePlatform!: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  sourceKind!: ConversationSourceKind;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  sourceConversationId?: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  displayName!: string;
+
+  @Column({ type: 'boolean', default: false })
+  isGroup!: boolean;
+
+  @Column({ type: 'simple-json', nullable: true })
+  participants?: string[];
+
+  @Column({ type: 'varchar', length: 64 })
+  contentHash!: string;
+
+  @Column({ type: 'varchar', length: 50, default: 'received' })
+  status!: ConversationStatus;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  errorCode?: string;
+
+  @Column({ type: dateColumnType, nullable: true })
+  sourceExtractedAt?: Date;
+
+  @Column({ type: 'simple-json', nullable: true })
+  provenance?: ConversationProvenance;
+
+  @OneToMany(() => ConversationMessage, (message) => message.intake, {
+    cascade: ['insert'],
+  })
+  messages!: Relation<ConversationMessage[]>;
+
+  @CreateDateColumn()
+  receivedAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/apps/api/src/db/entities/ConversationMessage.ts
+++ b/apps/api/src/db/entities/ConversationMessage.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  type Relation,
+} from 'typeorm';
+import { ConversationIntake } from './ConversationIntake';
+import { dateColumnType } from '../column-types';
+
+@Entity({ name: 'conversation_messages' })
+@Index('UQ_conversation_messages_intake_position', ['intakeId', 'position'], {
+  unique: true,
+})
+@Index('IDX_conversation_messages_intake_sent', ['intakeId', 'sentAt'])
+export class ConversationMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  intakeId!: string;
+
+  @ManyToOne(() => ConversationIntake, (intake) => intake.messages, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'intakeId' })
+  intake!: Relation<ConversationIntake>;
+
+  @Column({ type: 'integer' })
+  position!: number;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  sourceMessageId?: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  senderName!: string;
+
+  @Column({ type: 'text' })
+  content!: string;
+
+  @Column({ type: dateColumnType })
+  sentAt!: Date;
+
+  @Column({ type: 'boolean', default: false })
+  isOutgoing!: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isMedia!: boolean;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  mediaType?: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  replyToSourceMessageId?: string;
+}

--- a/apps/api/src/db/entities/Group.ts
+++ b/apps/api/src/db/entities/Group.ts
@@ -9,11 +9,12 @@ import {
   JoinTable,
   JoinColumn,
   ManyToMany,
-  Index
+  Index,
 } from 'typeorm';
 import type { Relation } from 'typeorm';
 import { Message } from './Message';
 import { User } from './User';
+import { dateColumnType } from '../column-types';
 
 export interface GroupMetadata {
   whatsappGroupId?: string;
@@ -52,22 +53,22 @@ export class Group {
   @Column({ type: 'boolean', default: false })
   isArchived: boolean;
 
-  @ManyToOne(() => User, user => user.ownedGroups, { onDelete: 'SET NULL', nullable: true })
+  @ManyToOne(() => User, (user) => user.ownedGroups, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'ownerId' })
   owner: Relation<User>;
 
   @Column({ type: 'uuid', nullable: true })
   ownerId?: string;
 
-  @ManyToMany(() => User, user => user.groups)
+  @ManyToMany(() => User, (user) => user.groups)
   @JoinTable({
     name: 'group_members',
     joinColumn: { name: 'groupId', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'userId' }
+    inverseJoinColumn: { name: 'userId' },
   })
   members: Relation<User[]>;
 
-  @OneToMany(() => Message, message => message.group, { cascade: true })
+  @OneToMany(() => Message, (message) => message.group, { cascade: true })
   messages: Relation<Message[]>;
 
   @Column({ type: 'simple-json', nullable: true })
@@ -79,6 +80,6 @@ export class Group {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ type: 'datetime', nullable: true })
+  @Column({ type: dateColumnType, nullable: true })
   archivedAt?: Date;
 }

--- a/apps/api/src/db/entities/Message.ts
+++ b/apps/api/src/db/entities/Message.ts
@@ -1,16 +1,17 @@
-import { 
-  Entity, 
-  PrimaryGeneratedColumn, 
-  Column, 
-  ManyToOne, 
-  CreateDateColumn, 
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
   UpdateDateColumn,
   JoinColumn,
-  Index
+  Index,
 } from 'typeorm';
 import type { Relation } from 'typeorm';
 import { Group } from './Group';
 import { User } from './User';
+import { dateColumnType } from '../column-types';
 
 export interface MessageMetadata {
   whatsappMessageId?: string;
@@ -51,9 +52,9 @@ export class Message {
   @Column({ type: 'simple-json', nullable: true })
   metadata?: MessageMetadata;
 
-  @ManyToOne(() => Group, group => group.messages, { 
+  @ManyToOne(() => Group, (group) => group.messages, {
     onDelete: 'CASCADE',
-    nullable: false
+    nullable: false,
   })
   @JoinColumn({ name: 'groupId' })
   group: Relation<Group>;
@@ -67,6 +68,6 @@ export class Message {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ type: 'datetime', nullable: true })
+  @Column({ type: dateColumnType, nullable: true })
   deletedAt?: Date;
 }

--- a/apps/api/src/db/entities/User.ts
+++ b/apps/api/src/db/entities/User.ts
@@ -1,25 +1,26 @@
-import { 
-  Entity, 
-  PrimaryGeneratedColumn, 
-  Column, 
-  CreateDateColumn, 
-  UpdateDateColumn, 
-  BeforeInsert, 
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  BeforeInsert,
   BeforeUpdate,
-  OneToMany 
+  OneToMany,
 } from 'typeorm';
 import type { Relation } from 'typeorm';
 import bcrypt from 'bcryptjs';
 import { Group } from './Group';
 import { Message } from './Message';
 import { Exclude } from 'class-transformer';
+import { dateColumnType } from '../column-types';
 
 export enum UserRole {
   ADMIN = 'admin',
   USER = 'user',
 }
 
-@Entity()
+@Entity({ name: 'users' })
 export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -44,16 +45,16 @@ export class User {
   @Column({ type: 'boolean', default: true })
   isActive: boolean;
 
-  @Column({ type: 'datetime', nullable: true })
+  @Column({ type: dateColumnType, nullable: true })
   lastLogin?: Date;
 
-  @OneToMany(() => Group, group => group.owner)
+  @OneToMany(() => Group, (group) => group.owner)
   ownedGroups: Relation<Group[]>;
 
-  @OneToMany(() => Group, group => group.members)
+  @OneToMany(() => Group, (group) => group.members)
   groups: Relation<Group[]>;
 
-  @OneToMany(() => Message, message => message.sender)
+  @OneToMany(() => Message, (message) => message.sender)
   messages: Relation<Message[]>;
 
   @CreateDateColumn()

--- a/apps/api/src/db/migrations/1753400000000-CreateConversationIntake.ts
+++ b/apps/api/src/db/migrations/1753400000000-CreateConversationIntake.ts
@@ -1,0 +1,146 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class CreateConversationIntake1753400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const dateType =
+      queryRunner.connection.options.type === 'postgres' ? 'timestamptz' : 'datetime';
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'conversation_intakes',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          { name: 'userId', type: 'varchar', length: '255' },
+          { name: 'sourcePlatform', type: 'varchar', length: '50' },
+          { name: 'sourceKind', type: 'varchar', length: '50' },
+          {
+            name: 'sourceConversationId',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          { name: 'displayName', type: 'varchar', length: '255' },
+          { name: 'isGroup', type: 'boolean', default: false },
+          { name: 'participants', type: 'text', isNullable: true },
+          { name: 'contentHash', type: 'varchar', length: '64' },
+          {
+            name: 'status',
+            type: 'varchar',
+            length: '50',
+            default: "'received'",
+          },
+          {
+            name: 'errorCode',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          { name: 'sourceExtractedAt', type: dateType, isNullable: true },
+          { name: 'provenance', type: 'text', isNullable: true },
+          {
+            name: 'receivedAt',
+            type: dateType,
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: dateType,
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createIndices('conversation_intakes', [
+      new TableIndex({
+        name: 'IDX_conversation_intakes_user_received',
+        columnNames: ['userId', 'receivedAt'],
+      }),
+      new TableIndex({
+        name: 'UQ_conversation_intakes_user_content_hash',
+        columnNames: ['userId', 'contentHash'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'IDX_conversation_intakes_status',
+        columnNames: ['status'],
+      }),
+    ]);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'conversation_messages',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          { name: 'intakeId', type: 'uuid' },
+          { name: 'position', type: 'integer' },
+          {
+            name: 'sourceMessageId',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          { name: 'senderName', type: 'varchar', length: '255' },
+          { name: 'content', type: 'text' },
+          { name: 'sentAt', type: dateType },
+          { name: 'isOutgoing', type: 'boolean', default: false },
+          { name: 'isMedia', type: 'boolean', default: false },
+          {
+            name: 'mediaType',
+            type: 'varchar',
+            length: '50',
+            isNullable: true,
+          },
+          {
+            name: 'replyToSourceMessageId',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createIndices('conversation_messages', [
+      new TableIndex({
+        name: 'UQ_conversation_messages_intake_position',
+        columnNames: ['intakeId', 'position'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'IDX_conversation_messages_intake_sent',
+        columnNames: ['intakeId', 'sentAt'],
+      }),
+    ]);
+
+    await queryRunner.createForeignKey(
+      'conversation_messages',
+      new TableForeignKey({
+        name: 'FK_conversation_messages_intake',
+        columnNames: ['intakeId'],
+        referencedTableName: 'conversation_intakes',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('conversation_messages', true);
+    await queryRunner.dropTable('conversation_intakes', true);
+  }
+}

--- a/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
+++ b/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { CreateConversationIntake1753400000000 } from '../1753400000000-CreateConversationIntake';
+
+describe('CreateConversationIntake migration', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      synchronize: false,
+      migrationsRun: false,
+      entities: [],
+      migrations: [CreateConversationIntake1753400000000],
+    });
+    await dataSource.initialize();
+    await dataSource.runMigrations();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('creates durable intake and message tables with the idempotency index', async () => {
+    const queryRunner = dataSource.createQueryRunner();
+    const intakeTable = await queryRunner.getTable('conversation_intakes');
+    const messageTable = await queryRunner.getTable('conversation_messages');
+    await queryRunner.release();
+
+    expect(intakeTable).toBeDefined();
+    expect(messageTable).toBeDefined();
+    expect(
+      intakeTable?.indices.some(
+        (index) => index.name === 'UQ_conversation_intakes_user_content_hash' && index.isUnique
+      )
+    ).toBe(true);
+    expect(
+      messageTable?.foreignKeys.some(
+        (foreignKey) =>
+          foreignKey.name === 'FK_conversation_messages_intake' && foreignKey.onDelete === 'CASCADE'
+      )
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/middleware/auth.middleware.ts
+++ b/apps/api/src/middleware/auth.middleware.ts
@@ -4,15 +4,24 @@ import { JWT_SECRET } from '../config/constants';
 import { logger } from '../utils/logger';
 
 declare global {
+  // Express request augmentation follows the framework's namespace contract.
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
-      user?: any; // Replace 'any' with your User type
+      user?: {
+        id: string;
+        userId?: string;
+        email: string;
+        name?: string;
+        role?: string;
+        authProvider?: string;
+      };
     }
   }
 }
 
 export const authenticateToken = (req: Request, res: Response, next: NextFunction) => {
-  const authHeader = req.headers['authorization'];
+  const authHeader = req.headers.authorization;
   const token = authHeader && authHeader.split(' ')[1];
 
   if (!token) {
@@ -21,9 +30,23 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
   }
 
   try {
-    const user = jwt.verify(token, JWT_SECRET);
-    req.user = user;
-    next();
+    const decoded = jwt.verify(token, JWT_SECRET);
+    if (
+      typeof decoded === 'string' ||
+      typeof decoded.id !== 'string' ||
+      typeof decoded.email !== 'string'
+    ) {
+      throw new Error('Token is missing the required user claims');
+    }
+    req.user = {
+      id: decoded.id,
+      userId: typeof decoded.userId === 'string' ? decoded.userId : undefined,
+      email: decoded.email,
+      name: typeof decoded.name === 'string' ? decoded.name : undefined,
+      role: typeof decoded.role === 'string' ? decoded.role : undefined,
+      authProvider: typeof decoded.authProvider === 'string' ? decoded.authProvider : undefined,
+    };
+    return next();
   } catch (error) {
     logger.error('Invalid or expired token', { error });
     return res.sendStatus(403);

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -1,23 +1,10 @@
-import { Router, Request, Response, NextFunction } from 'express';
-import multer, { FileFilterCallback } from 'multer';
+import { Router, Request } from 'express';
+import multer from 'multer';
 import { authenticateToken } from '../middleware/auth.middleware.js';
 import { parseWhatsAppExport, isValidWhatsAppExport } from '../services/chat-export.service.js';
 import { logger } from '../utils/logger.js';
-import { deduplicationService } from '../services/deduplication.service.js';
 import { metrics } from '../services/metrics.service.js';
-
-declare global {
-  namespace Express {
-    interface Request {
-      file?: Express.Multer.File;
-      user?: {
-        id: string;
-        email: string;
-        name?: string;
-      };
-    }
-  }
-}
+import { conversationIntakeService } from '../services/conversation-intake.service.js';
 
 const router = Router();
 const upload = multer({
@@ -104,6 +91,7 @@ function isValidMessage(msg: unknown): msg is ExtractedMessage {
   if (typeof obj.text !== 'string') return false;
   if (typeof obj.sender !== 'string') return false;
   if (typeof obj.timestamp !== 'string') return false;
+  if (Number.isNaN(Date.parse(obj.timestamp))) return false;
 
   // Required boolean fields
   if (typeof obj.isOutgoing !== 'boolean') return false;
@@ -121,15 +109,15 @@ function isValidMessage(msg: unknown): msg is ExtractedMessage {
 }
 
 /**
- * Sanitize string to prevent XSS
+ * Bound connector-provided labels and remove control characters.
  */
 function sanitizeString(str: string, maxLength: number = 10000): string {
   return str
     .slice(0, maxLength)
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;');
+    .split('')
+    .map((character) => (character >= ' ' && character !== '\u007F' ? character : ' '))
+    .join('')
+    .trim();
 }
 
 // =============================================================================
@@ -141,141 +129,239 @@ function sanitizeString(str: string, maxLength: number = 10000): string {
  * @description Upload and process a WhatsApp chat export file
  * @access Private
  */
-router.post(
-  '/upload',
-  authenticateToken,
-  upload.single('file'),
-  async (req, res) => {
-    try {
-      if (!req.file) {
-        return res.status(400).json({ error: 'No file uploaded' });
-      }
-
-      const userId = req.user?.id;
-      if (!userId) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
-
-      const fileContent = req.file.buffer.toString('utf-8');
-
-      // Validate it's a valid WhatsApp export
-      if (!isValidWhatsAppExport(fileContent)) {
-        return res.status(400).json({
-          error: 'Invalid file format. Please upload a valid WhatsApp chat export.'
-        });
-      }
-
-      const chatData = await parseWhatsAppExport(fileContent);
-
-      // TODO: Store chatData in the database
-      // await saveChatData(chatData, userId);
-
-      res.status(200).json({
-        message: 'File processed successfully',
-        data: {
-          messageCount: chatData.messages.length,
-          participants: chatData.participants,
-          dateRange: {
-            start: chatData.messages[0]?.timestamp,
-            end: chatData.messages[chatData.messages.length - 1]?.timestamp,
-          },
-        },
-      });
-    } catch (error) {
-      logger.error('Error processing chat export:', error);
-      const errorMessage =
-        error instanceof Error ? error.message : 'Failed to process file';
-      res.status(500).json({ error: errorMessage });
+router.post('/upload', authenticateToken, upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
     }
+
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const fileContent = req.file.buffer.toString('utf-8');
+
+    // Validate it's a valid WhatsApp export
+    if (!isValidWhatsAppExport(fileContent)) {
+      return res.status(400).json({
+        error: 'Invalid file format. Please upload a valid WhatsApp chat export.',
+      });
+    }
+
+    const chatData = await parseWhatsAppExport(fileContent);
+
+    const saved = await conversationIntakeService.save({
+      userId,
+      sourcePlatform: 'whatsapp',
+      sourceKind: 'upload',
+      displayName: req.file.originalname.replace(/\.txt$/i, '') || 'WhatsApp export',
+      isGroup: chatData.participants.length > 2,
+      participants: chatData.participants,
+      provenance: {
+        originalFileName: req.file.originalname,
+        connectorVersion: chatData.metadata.version,
+        captureInitiatedBy: 'user',
+        consentBasis: 'user-selected-conversation',
+      },
+      messages: chatData.messages.map((message) => ({
+        senderName: message.sender,
+        content: message.content,
+        sentAt: message.timestamp,
+        isMedia: message.isMedia,
+      })),
+    });
+
+    return res.status(200).json({
+      message: saved.duplicate
+        ? 'Conversation was already received'
+        : 'File processed successfully',
+      duplicate: saved.duplicate,
+      data: {
+        intakeId: saved.conversation.id,
+        displayName: saved.conversation.displayName,
+        messageCount: chatData.messages.length,
+        participants: chatData.participants,
+        receivedAt: saved.conversation.receivedAt,
+        dashboardUrl: `/dashboard/conversations/${saved.conversation.id}`,
+        dateRange: {
+          start: chatData.messages[0]?.timestamp,
+          end: chatData.messages[chatData.messages.length - 1]?.timestamp,
+        },
+      },
+    });
+  } catch (error) {
+    logger.error('Error processing chat export:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Failed to process file';
+    return res.status(500).json({ error: errorMessage });
   }
-);
+});
 
 /**
  * @route POST /api/chat-export/extension
  * @description Receive chat data from Chrome extension
  * @access Private
  */
-router.post(
-  '/extension',
-  authenticateToken,
-  async (req, res) => {
-    const startTime = Date.now();
-    let success = false;
-
-    try {
-      const userId = req.user?.id;
-      if (!userId) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
-
-      const chatData = req.body;
-
-      // Validate the chat data structure
-      if (!isValidExtensionChatData(chatData)) {
-        logger.warn(`Invalid extension chat data from user ${userId}`);
-        metrics.trackExtraction(false, 'chrome-extension');
-        return res.status(400).json({
-          error: 'Invalid chat data format. Please ensure the extension is up to date.'
-        });
-      }
-
-      // Additional validation: check message count matches array length
-      if (chatData.messageCount !== chatData.messages.length) {
-        logger.warn(`Message count mismatch from user ${userId}: claimed ${chatData.messageCount}, got ${chatData.messages.length}`);
-        metrics.trackExtraction(false, 'chrome-extension');
-        return res.status(400).json({
-          error: 'Message count mismatch'
-        });
-      }
-
-      // Check for duplicate extraction (same chat within 5 minute window)
-      const extractionHash = deduplicationService.generateExtractionHash(chatData.chatId, userId, 5);
-      if (deduplicationService.isDuplicate(extractionHash)) {
-        const cachedResult = deduplicationService.getCachedResult<{ chatId: string }>(extractionHash);
-        logger.info(`Duplicate extraction detected for chat ${chatData.chatId} from user ${userId}`);
-        return res.status(200).json({
-          message: 'Chat data already received (duplicate)',
-          data: cachedResult || { chatId: chatData.chatId },
-          duplicate: true,
-        });
-      }
-
-      // Sanitize chat name to prevent XSS
-      const sanitizedChatName = sanitizeString(chatData.chatName, 200);
-
-      logger.info(`Received extension chat data: ${sanitizedChatName} with ${chatData.messages.length} messages from user ${userId}`);
-
-      // TODO: Store chatData in the database
-      // await saveChatData(chatData, userId);
-
-      // TODO: Queue for AI summarization
-      // await queueForSummarization(chatData, userId);
-
-      const result = {
-        chatId: chatData.chatId,
-        chatName: sanitizedChatName,
-        messageCount: chatData.messages.length,
-        receivedAt: new Date().toISOString(),
-      };
-
-      // Mark as processed for deduplication
-      deduplicationService.markProcessed(extractionHash, result);
-
-      success = true;
-      metrics.trackExtraction(true, 'chrome-extension', chatData.messages.length);
-
-      res.status(200).json({
-        message: 'Chat data received successfully',
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Error processing extension chat data:', error);
-      metrics.trackExtraction(false, 'chrome-extension');
-      const errorMessage =
-        error instanceof Error ? error.message : 'Failed to process chat data';
-      res.status(500).json({ error: errorMessage });
+router.post('/extension', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
     }
+
+    const chatData = req.body;
+
+    // Validate the chat data structure
+    if (!isValidExtensionChatData(chatData)) {
+      logger.warn(`Invalid extension chat data from user ${userId}`);
+      metrics.trackExtraction(false, 'chrome-extension');
+      return res.status(400).json({
+        error: 'Invalid chat data format. Please ensure the extension is up to date.',
+      });
+    }
+
+    // Additional validation: check message count matches array length
+    if (chatData.messageCount !== chatData.messages.length) {
+      logger.warn(
+        `Message count mismatch from user ${userId}: claimed ${chatData.messageCount}, got ${chatData.messages.length}`
+      );
+      metrics.trackExtraction(false, 'chrome-extension');
+      return res.status(400).json({
+        error: 'Message count mismatch',
+      });
+    }
+
+    // Limit the connector-provided label before logging and persistence.
+    const sanitizedChatName = sanitizeString(chatData.chatName, 200);
+
+    logger.info(
+      `Received extension chat data: ${sanitizedChatName} with ${chatData.messages.length} messages from user ${userId}`
+    );
+
+    const saved = await conversationIntakeService.save({
+      userId,
+      sourcePlatform: 'whatsapp',
+      sourceKind: 'extension',
+      sourceConversationId: chatData.chatId,
+      displayName: sanitizedChatName,
+      isGroup: chatData.isGroup,
+      participants: [...new Set(chatData.messages.map((message) => message.sender))],
+      sourceExtractedAt: new Date(chatData.extractedAt),
+      provenance: {
+        connectorVersion: chatData.version,
+        captureInitiatedBy: 'user',
+        consentBasis: 'user-selected-conversation',
+      },
+      messages: chatData.messages.map((message) => ({
+        sourceMessageId: message.id,
+        senderName: message.sender,
+        content: message.text,
+        sentAt: new Date(message.timestamp),
+        isOutgoing: message.isOutgoing,
+        isMedia: message.isMedia,
+        mediaType: message.mediaType,
+        replyToSourceMessageId: message.replyTo,
+      })),
+    });
+
+    const result = {
+      chatId: chatData.chatId,
+      intakeId: saved.conversation.id,
+      chatName: saved.conversation.displayName,
+      messageCount: chatData.messages.length,
+      receivedAt: saved.conversation.receivedAt,
+      dashboardUrl: `/dashboard/conversations/${saved.conversation.id}`,
+    };
+
+    metrics.trackExtraction(true, 'chrome-extension', chatData.messages.length);
+
+    return res.status(200).json({
+      message: saved.duplicate
+        ? 'Conversation was already received'
+        : 'Chat data received successfully',
+      data: result,
+      duplicate: saved.duplicate,
+    });
+  } catch (error) {
+    logger.error('Error processing extension chat data:', error);
+    metrics.trackExtraction(false, 'chrome-extension');
+    const errorMessage = error instanceof Error ? error.message : 'Failed to process chat data';
+    return res.status(500).json({ error: errorMessage });
   }
-);
+});
+
+/**
+ * @route GET /api/chat-export
+ * @description List durable conversation intakes for the current user
+ * @access Private
+ */
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const conversations = await conversationIntakeService.listForUser(userId);
+    return res.json({ data: { conversations } });
+  } catch (error) {
+    logger.error('Error listing conversation intakes:', error);
+    return res.status(500).json({ error: 'Failed to load conversations' });
+  }
+});
+
+/**
+ * @route GET /api/chat-export/:id
+ * @description Get one durable conversation intake for the current user
+ * @access Private
+ */
+router.get('/:id', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const conversation = await conversationIntakeService.getForUser(userId, req.params.id);
+    if (!conversation) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    return res.json({
+      data: {
+        conversation: {
+          id: conversation.id,
+          sourcePlatform: conversation.sourcePlatform,
+          sourceKind: conversation.sourceKind,
+          sourceConversationId: conversation.sourceConversationId,
+          displayName: conversation.displayName,
+          isGroup: conversation.isGroup,
+          participants: conversation.participants || [],
+          status: conversation.status,
+          errorCode: conversation.errorCode,
+          sourceExtractedAt: conversation.sourceExtractedAt,
+          provenance: conversation.provenance,
+          receivedAt: conversation.receivedAt,
+          updatedAt: conversation.updatedAt,
+          messages: conversation.messages.map((message) => ({
+            id: message.id,
+            position: message.position,
+            sourceMessageId: message.sourceMessageId,
+            senderName: message.senderName,
+            content: message.content,
+            sentAt: message.sentAt,
+            isOutgoing: message.isOutgoing,
+            isMedia: message.isMedia,
+            mediaType: message.mediaType,
+            replyToSourceMessageId: message.replyToSourceMessageId,
+          })),
+        },
+      },
+    });
+  } catch (error) {
+    logger.error('Error loading conversation intake:', error);
+    return res.status(500).json({ error: 'Failed to load conversation' });
+  }
+});
 
 export { router as default };

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { ConversationIntake } from '../../db/entities/ConversationIntake';
+import { ConversationMessage } from '../../db/entities/ConversationMessage';
+import {
+  ConversationIntakeService,
+  createConversationContentHash,
+  type ConversationIntakeInput,
+} from '../conversation-intake.service';
+
+const baseInput: ConversationIntakeInput = {
+  userId: 'mystira-user-1',
+  sourcePlatform: 'whatsapp',
+  sourceKind: 'extension',
+  sourceConversationId: 'unstable-chat-id',
+  displayName: 'Alpha Group',
+  isGroup: true,
+  participants: ['Hans', 'Irma'],
+  sourceExtractedAt: new Date('2026-07-25T08:05:00.000Z'),
+  messages: [
+    {
+      sourceMessageId: 'unstable-message-id',
+      senderName: 'Hans',
+      content: 'Morning!',
+      sentAt: new Date('2026-07-25T08:00:00.000Z'),
+      isOutgoing: false,
+      isMedia: false,
+    },
+    {
+      senderName: 'Irma',
+      content: 'Ready for alpha.',
+      sentAt: new Date('2026-07-25T08:01:00.000Z'),
+      isOutgoing: true,
+      isMedia: false,
+    },
+  ],
+};
+
+describe('ConversationIntakeService', () => {
+  let dataSource: DataSource;
+  let service: ConversationIntakeService;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      synchronize: true,
+      entities: [ConversationIntake, ConversationMessage],
+    });
+    await dataSource.initialize();
+    service = new ConversationIntakeService(dataSource);
+  });
+
+  beforeEach(async () => {
+    await dataSource.getRepository(ConversationMessage).clear();
+    await dataSource.getRepository(ConversationIntake).clear();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('stores messages and returns a user-scoped list and detail', async () => {
+    const saved = await service.save(baseInput);
+
+    expect(saved.duplicate).toBe(false);
+    expect(saved.conversation.messages).toHaveLength(2);
+
+    const list = await service.listForUser(baseInput.userId);
+    expect(list).toEqual([
+      expect.objectContaining({
+        id: saved.conversation.id,
+        displayName: 'Alpha Group',
+        messageCount: 2,
+        participants: ['Hans', 'Irma'],
+      }),
+    ]);
+
+    const detail = await service.getForUser(baseInput.userId, saved.conversation.id);
+    expect(detail?.messages.map((message) => message.content)).toEqual([
+      'Morning!',
+      'Ready for alpha.',
+    ]);
+    expect(await service.getForUser('other-user', saved.conversation.id)).toBeNull();
+  });
+
+  it('deduplicates stable content even when connector IDs change', async () => {
+    const first = await service.save(baseInput);
+    const second = await service.save({
+      ...baseInput,
+      sourceConversationId: 'another-generated-chat-id',
+      sourceExtractedAt: new Date('2026-07-25T09:00:00.000Z'),
+      messages: baseInput.messages.map((message, index) => ({
+        ...message,
+        sourceMessageId: `another-generated-message-${index}`,
+      })),
+    });
+
+    expect(second.duplicate).toBe(true);
+    expect(second.conversation.id).toBe(first.conversation.id);
+    expect(await dataSource.getRepository(ConversationIntake).count()).toBe(1);
+    expect(await dataSource.getRepository(ConversationMessage).count()).toBe(2);
+  });
+
+  it('allows the same conversation for a different user', async () => {
+    await service.save(baseInput);
+    await service.save({ ...baseInput, userId: 'mystira-user-2' });
+
+    expect(await dataSource.getRepository(ConversationIntake).count()).toBe(2);
+  });
+
+  it('excludes generated source IDs from the durable content hash', () => {
+    const firstHash = createConversationContentHash(baseInput);
+    const secondHash = createConversationContentHash({
+      ...baseInput,
+      messages: baseInput.messages.map((message) => ({
+        ...message,
+        sourceMessageId: `changed-${message.sourceMessageId || 'none'}`,
+      })),
+    });
+
+    expect(secondHash).toBe(firstHash);
+  });
+});

--- a/apps/api/src/services/chat-export.service.ts
+++ b/apps/api/src/services/chat-export.service.ts
@@ -1,5 +1,5 @@
+import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger';
-import { v4 as uuidv4 } from 'uuid';
 
 export interface ChatMessage {
   id: string;
@@ -22,10 +22,12 @@ export interface ChatExportData {
 
 // Regular expression to match WhatsApp message format:
 // [DD/MM/YYYY, HH:MM:SS] Sender: Message
-const MESSAGE_REGEX = /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+?):\s(.+)$/i;
+const MESSAGE_REGEX =
+  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+?):\s(.+)$/i;
 
 // Alternative format for system messages
-const SYSTEM_MESSAGE_REGEX = /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+)$/i;
+const SYSTEM_MESSAGE_REGEX =
+  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+)$/i;
 
 // Media indicator in WhatsApp exports
 const MEDIA_INDICATOR = '<Media omitted>';
@@ -35,11 +37,9 @@ const MEDIA_INDICATOR = '<Media omitted>';
  * @param fileContent The raw text content of the WhatsApp export file
  * @returns Parsed chat data
  */
-export async function parseWhatsAppExport(
-  fileContent: string
-): Promise<ChatExportData> {
+export async function parseWhatsAppExport(fileContent: string): Promise<ChatExportData> {
   try {
-    const lines = fileContent.split('\n').filter(line => line.trim() !== '');
+    const lines = fileContent.split('\n').filter((line) => line.trim() !== '');
     const participants = new Set<string>();
     const messages: ChatMessage[] = [];
 
@@ -77,7 +77,14 @@ export async function parseWhatsAppExport(
         if (isPM && hours24 < 12) hours24 += 12;
         if (!isPM && hours24 === 12) hours24 = 0;
 
-        const timestamp = new Date(yearFull, month - 1, day, hours24, parseInt(minutes, 10), parseInt(seconds, 10));
+        const timestamp = new Date(
+          yearFull,
+          month - 1,
+          day,
+          hours24,
+          parseInt(minutes, 10),
+          parseInt(seconds, 10)
+        );
 
         if (isNaN(timestamp.getTime())) {
           logger.warn(`Invalid timestamp in line: ${line}`);
@@ -100,12 +107,12 @@ export async function parseWhatsAppExport(
 
         // Add the message
         messages.push({
-          id: uuidv4(),
+          id: randomUUID(),
           timestamp,
           sender: isSystemMessage ? 'System' : trimmedSender,
           content: isMedia ? MEDIA_INDICATOR : trimmedContent,
           isMedia,
-          mediaUrl: isMedia ? undefined : undefined
+          mediaUrl: isMedia ? undefined : undefined,
         });
       } catch (error) {
         logger.warn(`Error processing line: ${line}`, error);
@@ -122,8 +129,8 @@ export async function parseWhatsAppExport(
       metadata: {
         exportDate: new Date(),
         platform: 'whatsapp',
-        version: '1.0.0'
-      }
+        version: '1.0.0',
+      },
     };
   } catch (error) {
     logger.error('Error parsing WhatsApp export:', error);
@@ -145,5 +152,5 @@ export function isValidWhatsAppExport(content: string): boolean {
   ];
 
   // Check if any of the patterns match
-  return patterns.some(pattern => pattern.test(content));
+  return patterns.some((pattern) => pattern.test(content));
 }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -1,0 +1,179 @@
+import { createHash } from 'node:crypto';
+import type { DataSource } from 'typeorm';
+import { AppDataSource } from '../config/database';
+import {
+  ConversationIntake,
+  type ConversationProvenance,
+  type ConversationSourceKind,
+} from '../db/entities/ConversationIntake';
+import { ConversationMessage } from '../db/entities/ConversationMessage';
+
+export interface ConversationMessageInput {
+  sourceMessageId?: string;
+  senderName: string;
+  content: string;
+  sentAt: Date;
+  isOutgoing?: boolean;
+  isMedia?: boolean;
+  mediaType?: string;
+  replyToSourceMessageId?: string;
+}
+
+export interface ConversationIntakeInput {
+  userId: string;
+  sourcePlatform: string;
+  sourceKind: ConversationSourceKind;
+  sourceConversationId?: string;
+  displayName: string;
+  isGroup: boolean;
+  participants: string[];
+  sourceExtractedAt?: Date;
+  provenance?: ConversationProvenance;
+  messages: ConversationMessageInput[];
+}
+
+export interface ConversationIntakeSummary {
+  id: string;
+  sourcePlatform: string;
+  sourceKind: ConversationSourceKind;
+  displayName: string;
+  isGroup: boolean;
+  participants: string[];
+  status: string;
+  messageCount: number;
+  sourceExtractedAt?: Date;
+  receivedAt: Date;
+}
+
+export interface SaveConversationResult {
+  conversation: ConversationIntake;
+  duplicate: boolean;
+}
+
+function normalizeHashValue(value: string): string {
+  return value.normalize('NFKC').replace(/\r\n/g, '\n').trim();
+}
+
+export function createConversationContentHash(
+  input: Pick<ConversationIntakeInput, 'sourcePlatform' | 'messages'>
+): string {
+  const canonical = {
+    sourcePlatform: input.sourcePlatform.toLowerCase(),
+    messages: input.messages.map((message) => ({
+      senderName: normalizeHashValue(message.senderName),
+      content: normalizeHashValue(message.content),
+      sentAt: message.sentAt.toISOString(),
+      isMedia: Boolean(message.isMedia),
+      mediaType: message.mediaType || null,
+    })),
+  };
+
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+}
+
+export class ConversationIntakeService {
+  constructor(private readonly dataSource: DataSource = AppDataSource) {}
+
+  async save(input: ConversationIntakeInput): Promise<SaveConversationResult> {
+    const contentHash = createConversationContentHash(input);
+    const intakeRepository = this.dataSource.getRepository(ConversationIntake);
+    const existing = await intakeRepository.findOne({
+      where: { userId: input.userId, contentHash },
+      relations: { messages: true },
+      order: { messages: { position: 'ASC' } },
+    });
+
+    if (existing) {
+      return { conversation: existing, duplicate: true };
+    }
+
+    try {
+      const conversation = await this.dataSource.transaction(async (manager) => {
+        const intake = manager.create(ConversationIntake, {
+          userId: input.userId,
+          sourcePlatform: input.sourcePlatform,
+          sourceKind: input.sourceKind,
+          sourceConversationId: input.sourceConversationId,
+          displayName: input.displayName.trim().slice(0, 255),
+          isGroup: input.isGroup,
+          participants: [
+            ...new Set(input.participants.map((value) => value.trim()).filter(Boolean)),
+          ].sort((a, b) => a.localeCompare(b)),
+          contentHash,
+          status: 'received',
+          sourceExtractedAt: input.sourceExtractedAt,
+          provenance: input.provenance,
+        });
+        const savedIntake = await manager.save(intake);
+        const messages = input.messages.map((message, position) =>
+          manager.create(ConversationMessage, {
+            intakeId: savedIntake.id,
+            position,
+            sourceMessageId: message.sourceMessageId,
+            senderName: message.senderName.trim().slice(0, 255) || 'Unknown',
+            content: message.content,
+            sentAt: message.sentAt,
+            isOutgoing: Boolean(message.isOutgoing),
+            isMedia: Boolean(message.isMedia),
+            mediaType: message.mediaType,
+            replyToSourceMessageId: message.replyToSourceMessageId,
+          })
+        );
+
+        if (messages.length > 0) {
+          await manager.save(messages, { chunk: 500 });
+        }
+
+        savedIntake.messages = messages;
+        return savedIntake;
+      });
+
+      return { conversation, duplicate: false };
+    } catch (error) {
+      // A concurrent identical intake can win the unique constraint race.
+      const duplicate = await intakeRepository.findOne({
+        where: { userId: input.userId, contentHash },
+        relations: { messages: true },
+        order: { messages: { position: 'ASC' } },
+      });
+      if (duplicate) {
+        return { conversation: duplicate, duplicate: true };
+      }
+      throw error;
+    }
+  }
+
+  async listForUser(userId: string): Promise<ConversationIntakeSummary[]> {
+    const conversations = (await this.dataSource
+      .getRepository(ConversationIntake)
+      .createQueryBuilder('intake')
+      .loadRelationCountAndMap('intake.messageCount', 'intake.messages')
+      .where('intake.userId = :userId', { userId })
+      .orderBy('intake.receivedAt', 'DESC')
+      .take(100)
+      .getMany()) as Array<ConversationIntake & { messageCount: number }>;
+
+    return conversations.map((conversation) => ({
+      id: conversation.id,
+      sourcePlatform: conversation.sourcePlatform,
+      sourceKind: conversation.sourceKind,
+      displayName: conversation.displayName,
+      isGroup: conversation.isGroup,
+      participants: conversation.participants || [],
+      status: conversation.status,
+      messageCount: conversation.messageCount,
+      sourceExtractedAt: conversation.sourceExtractedAt,
+      receivedAt: conversation.receivedAt,
+    }));
+  }
+
+  async getForUser(userId: string, id: string): Promise<ConversationIntake | null> {
+    return this.dataSource.getRepository(ConversationIntake).findOne({
+      where: { id, userId },
+      relations: { messages: true },
+      order: { messages: { position: 'ASC' } },
+    });
+  }
+}
+
+export const conversationIntakeService = new ConversationIntakeService();

--- a/apps/api/src/services/deduplication.service.ts
+++ b/apps/api/src/services/deduplication.service.ts
@@ -59,6 +59,7 @@ class DeduplicationService {
 
     // Start periodic cleanup
     this.cleanupInterval = setInterval(() => this.cleanup(), 60000);
+    this.cleanupInterval.unref?.();
   }
 
   /**

--- a/apps/api/tests/fixtures/alpha-chat.txt
+++ b/apps/api/tests/fixtures/alpha-chat.txt
@@ -1,0 +1,2 @@
+[25/07/2026, 09:00:00] Hans: Morning, are we ready for the alpha?
+[25/07/2026, 09:01:00] Irma: Yes, durable intake is the first gate.

--- a/apps/api/tests/test-utils/database.ts
+++ b/apps/api/tests/test-utils/database.ts
@@ -6,16 +6,14 @@ export async function setupTestDatabase(): Promise<DataSource> {
   const testDataSource = new DataSource({
     ...AppDataSource.options,
     database: ':memory:', // Use in-memory SQLite for tests
-    synchronize: true,    // Auto-create schema
-    dropSchema: true,     // Drop schema each time connection is set up
-    logging: false,       // Disable logging for tests
+    synchronize: true, // Auto-create schema
+    dropSchema: true, // Drop schema each time connection is set up
+    migrationsRun: false,
+    logging: false, // Disable logging for tests
   });
 
   await testDataSource.initialize();
-  
-  // Run migrations if needed
-  await testDataSource.runMigrations();
-  
+
   return testDataSource;
 }
 
@@ -39,27 +37,27 @@ export async function resetTestDatabase(): Promise<void> {
     await setupTestDatabase();
     return;
   }
-  
+
   // Get all entities
   const entities = AppDataSource.entityMetadatas;
-  
+
   // Create a query runner
   const queryRunner = AppDataSource.createQueryRunner();
-  
+
   try {
     await queryRunner.startTransaction();
-    
+
     // Disable foreign key checks
     await queryRunner.query('PRAGMA foreign_keys = OFF');
-    
+
     // Truncate all tables
     for (const entity of entities) {
       await queryRunner.query(`DELETE FROM ${entity.tableName}`);
     }
-    
+
     // Re-enable foreign key checks
     await queryRunner.query('PRAGMA foreign_keys = ON');
-    
+
     await queryRunner.commitTransaction();
   } catch (err) {
     await queryRunner.rollbackTransaction();

--- a/apps/web/src/app/api/chat-export/[id]/route.ts
+++ b/apps/web/src/app/api/chat-export/[id]/route.ts
@@ -1,0 +1,26 @@
+import {
+  apiAuthErrorResponse,
+  getConvolensApiBaseUrl,
+  getConvolensApiToken,
+} from "@/lib/convolens-api";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const token = await getConvolensApiToken();
+    const { id } = await params;
+    const response = await fetch(
+      `${getConvolensApiBaseUrl()}/api/chat-export/${encodeURIComponent(id)}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      },
+    );
+    const payload = await response.json();
+    return Response.json(payload, { status: response.status });
+  } catch (error) {
+    return apiAuthErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/api/chat-export/route.ts
+++ b/apps/web/src/app/api/chat-export/route.ts
@@ -1,0 +1,22 @@
+import {
+  apiAuthErrorResponse,
+  getConvolensApiBaseUrl,
+  getConvolensApiToken,
+} from "@/lib/convolens-api";
+
+export async function GET() {
+  try {
+    const token = await getConvolensApiToken();
+    const response = await fetch(
+      `${getConvolensApiBaseUrl()}/api/chat-export`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      },
+    );
+    const payload = await response.json();
+    return Response.json(payload, { status: response.status });
+  } catch (error) {
+    return apiAuthErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/api/chat-export/upload/route.ts
+++ b/apps/web/src/app/api/chat-export/upload/route.ts
@@ -1,36 +1,33 @@
-import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { NextResponse } from "next/server";
+import {
+  apiAuthErrorResponse,
+  getConvolensApiBaseUrl,
+  getConvolensApiToken,
+} from "@/lib/convolens-api";
 
 export const maxDuration = 60; // 1 minute timeout
 
 export async function POST(request: Request) {
   try {
-    const session = await getServerSession(authOptions);
-    if (!session?.user) {
-      return new NextResponse('Unauthorized', { status: 401 });
-    }
+    const apiToken = await getConvolensApiToken();
 
     const formData = await request.formData();
-    const file = formData.get('file') as File | null;
+    const file = formData.get("file") as File | null;
 
     if (!file) {
-      return NextResponse.json(
-        { error: 'No file provided' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
 
     // Forward the file to the backend service
-    const backendUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'}/api/chat-export/upload`;
-    
+    const backendUrl = `${getConvolensApiBaseUrl()}/api/chat-export/upload`;
+
     const formDataToSend = new FormData();
-    formDataToSend.append('file', file);
+    formDataToSend.append("file", file);
 
     const response = await fetch(backendUrl, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Authorization': `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${apiToken}`,
       },
       body: formDataToSend,
     });
@@ -39,17 +36,13 @@ export async function POST(request: Request) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data.error || 'Failed to process file' },
-        { status: response.status }
+        { error: data.error || "Failed to process file" },
+        { status: response.status },
       );
     }
 
     return NextResponse.json(data);
   } catch (error) {
-    console.error('Upload error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return apiAuthErrorResponse(error);
   }
 }

--- a/apps/web/src/app/dashboard/conversations/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/conversations/[id]/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, MessageSquare, Users } from "lucide-react";
+import { useAuth } from "@convolens/contexts";
+import PageWrapper from "../../../page-wrapper";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import { StyledCard } from "@/components/ui/styled-card";
+
+interface ConversationMessage {
+  id: string;
+  position: number;
+  senderName: string;
+  content: string;
+  sentAt: string;
+  isOutgoing: boolean;
+  isMedia: boolean;
+  mediaType?: string;
+}
+
+interface Conversation {
+  id: string;
+  displayName: string;
+  sourcePlatform: string;
+  sourceKind: "extension" | "upload";
+  participants?: string[];
+  status: string;
+  receivedAt: string;
+  messages: ConversationMessage[];
+}
+
+export default function ConversationPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+  const [conversation, setConversation] = useState<Conversation>();
+  const [error, setError] = useState<string>();
+  const [loadingConversation, setLoadingConversation] = useState(true);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(
+        `/login?redirectTo=${encodeURIComponent(`/dashboard/conversations/${id}`)}`,
+      );
+    }
+  }, [id, isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !id) return;
+
+    let cancelled = false;
+    fetch(`/api/chat-export/${encodeURIComponent(id)}`, { cache: "no-store" })
+      .then(async (response) => {
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error || "Failed to load conversation");
+        }
+        return payload as { data?: { conversation?: Conversation } };
+      })
+      .then((payload) => {
+        if (!cancelled) setConversation(payload.data?.conversation);
+      })
+      .catch((reason) => {
+        if (!cancelled) {
+          setError(
+            reason instanceof Error
+              ? reason.message
+              : "Failed to load conversation",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingConversation(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, isAuthenticated]);
+
+  if (isLoading || loadingConversation) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-primary" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) return null;
+
+  return (
+    <PageWrapper>
+      <PageHeader
+        title={conversation?.displayName || "Conversation"}
+        description={
+          conversation
+            ? `${conversation.messages.length} stored messages · received ${new Date(conversation.receivedAt).toLocaleString()}`
+            : "Durable conversation intake"
+        }
+        actions={
+          <Button asChild variant="outline">
+            <Link href="/dashboard">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to dashboard
+            </Link>
+          </Button>
+        }
+      />
+
+      {error ? (
+        <div className="mt-8 rounded-xl border border-red-200 bg-red-50 p-5 text-red-900 dark:border-red-900 dark:bg-red-950/30 dark:text-red-100">
+          {error}
+        </div>
+      ) : conversation ? (
+        <>
+          <section className="mt-8 grid gap-6 md:grid-cols-2">
+            <StyledCard
+              title="Intake status"
+              icon={<MessageSquare className="h-6 w-6" />}
+            >
+              <p className="capitalize text-muted-foreground">
+                {conversation.status} via{" "}
+                {conversation.sourceKind === "extension"
+                  ? "browser extension"
+                  : "chat export"}
+              </p>
+            </StyledCard>
+            <StyledCard
+              title="Participants"
+              icon={<Users className="h-6 w-6" />}
+            >
+              <p className="text-muted-foreground">
+                {conversation.participants?.join(", ") ||
+                  "No participant names were provided"}
+              </p>
+            </StyledCard>
+          </section>
+
+          <section className="mt-8 space-y-3">
+            <h2 className="text-xl font-bold">Stored messages</h2>
+            {conversation.messages.map((message) => (
+              <article
+                key={message.id}
+                className="rounded-xl border bg-card p-4 text-card-foreground"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="font-semibold">{message.senderName}</p>
+                  <time className="text-xs text-muted-foreground">
+                    {new Date(message.sentAt).toLocaleString()}
+                  </time>
+                </div>
+                <p className="mt-2 whitespace-pre-wrap text-sm leading-6">
+                  {message.content}
+                </p>
+              </article>
+            ))}
+          </section>
+        </>
+      ) : null}
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -22,14 +22,15 @@ export default function ImportChatPage() {
   const [activeTab, setActiveTab] = useState("file");
 
   const { uploadFile } = useFileUpload("/api/chat-export/upload", {
-    onSuccess: () => {
+    onSuccess: (result) => {
       toast({
         title: "Conversation received",
-        description: "Your WhatsApp export passed the alpha intake checks.",
+        description: result?.duplicate
+          ? "This conversation was already in your workspace."
+          : "Your WhatsApp export is now stored in your alpha workspace.",
         variant: "default",
       });
-      // Redirect to chat view or dashboard
-      router.push("/dashboard");
+      router.push(result?.data?.dashboardUrl || "/dashboard");
     },
     onError: (error) => {
       console.error("Upload error:", error);

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@convolens/contexts";
 import {
@@ -9,6 +10,7 @@ import {
   FileText,
   MessageSquare,
   Sparkles,
+  Users,
 } from "lucide-react";
 import PageWrapper from "../page-wrapper";
 import { PageHeader } from "@/components/ui/page-header";
@@ -36,15 +38,66 @@ const onboardingSteps = [
   },
 ];
 
+interface ConversationSummary {
+  id: string;
+  sourcePlatform: string;
+  sourceKind: "extension" | "upload";
+  displayName: string;
+  isGroup: boolean;
+  participants: string[];
+  status: string;
+  messageCount: number;
+  receivedAt: string;
+}
+
 export default function DashboardPage() {
   const { user, isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [isLoadingConversations, setIsLoadingConversations] = useState(true);
+  const [conversationError, setConversationError] = useState<string>();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       router.replace("/login?redirectTo=/dashboard");
     }
   }, [isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    let cancelled = false;
+
+    fetch("/api/chat-export", { cache: "no-store" })
+      .then(async (response) => {
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error || "Failed to load conversations");
+        }
+        return payload as { data?: { conversations?: ConversationSummary[] } };
+      })
+      .then((payload) => {
+        if (!cancelled) {
+          setConversations(payload.data?.conversations || []);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setConversationError(
+            error instanceof Error
+              ? error.message
+              : "Failed to load conversations",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingConversations(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
 
   if (isLoading) {
     return (
@@ -84,10 +137,14 @@ export default function DashboardPage() {
             </div>
             <div>
               <p className="text-sm font-semibold uppercase tracking-wider text-green-800 dark:text-green-300">
-                First-time setup
+                {conversations.length > 0
+                  ? "Alpha workspace"
+                  : "First-time setup"}
               </p>
               <h2 className="mt-1 text-xl font-bold text-foreground">
-                Send your first conversation in three steps
+                {conversations.length > 0
+                  ? `${conversations.length} conversation${conversations.length === 1 ? "" : "s"} received`
+                  : "Send your first conversation in three steps"}
               </h2>
               <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
                 This is an alpha workspace. We will show confirmed intake
@@ -111,32 +168,83 @@ export default function DashboardPage() {
         </div>
       </section>
 
+      {conversationError ? (
+        <section className="mt-8 rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/30 dark:text-red-100">
+          <p className="font-semibold">Conversations could not be loaded</p>
+          <p className="mt-1">{conversationError}</p>
+        </section>
+      ) : null}
+
       <section className="mt-8 grid gap-6 md:grid-cols-2">
-        <StyledCard
-          title="No conversations yet"
-          icon={<FileText className="h-6 w-6" />}
-        >
-          <p className="text-muted-foreground">
-            Your real conversation activity will appear here after a successful
-            intake. ConvoLens does not seed this dashboard with demo records.
-          </p>
-        </StyledCard>
-        <StyledCard
-          title="Ready when you are"
-          icon={<MessageSquare className="h-6 w-6" />}
-        >
-          <p className="mb-4 text-muted-foreground">
-            Choose the browser extension or a WhatsApp export file on the next
-            screen.
-          </p>
-          <Button
-            className="w-full"
-            variant="primary"
-            onClick={() => router.push("/dashboard/import")}
+        {isLoadingConversations ? (
+          <StyledCard
+            title="Loading your conversations"
+            icon={<MessageSquare className="h-6 w-6" />}
           >
-            Choose an intake method
-          </Button>
-        </StyledCard>
+            <p className="text-muted-foreground">
+              Checking your durable alpha workspace…
+            </p>
+          </StyledCard>
+        ) : conversations.length > 0 ? (
+          conversations.map((conversation) => (
+            <StyledCard
+              key={conversation.id}
+              title={conversation.displayName}
+              icon={
+                conversation.isGroup ? (
+                  <Users className="h-6 w-6" />
+                ) : (
+                  <MessageSquare className="h-6 w-6" />
+                )
+              }
+            >
+              <p className="text-sm text-muted-foreground">
+                {conversation.messageCount} messages ·{" "}
+                {conversation.participants.length} participants ·{" "}
+                {conversation.sourceKind === "extension"
+                  ? "Browser extension"
+                  : "Chat export"}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Received {new Date(conversation.receivedAt).toLocaleString()}
+              </p>
+              <Button asChild className="mt-4 w-full" variant="outline">
+                <Link href={`/dashboard/conversations/${conversation.id}`}>
+                  View conversation
+                </Link>
+              </Button>
+            </StyledCard>
+          ))
+        ) : (
+          <>
+            <StyledCard
+              title="No conversations yet"
+              icon={<FileText className="h-6 w-6" />}
+            >
+              <p className="text-muted-foreground">
+                Your real conversation activity will appear here after a
+                successful intake. ConvoLens does not seed this dashboard with
+                demo records.
+              </p>
+            </StyledCard>
+            <StyledCard
+              title="Ready when you are"
+              icon={<MessageSquare className="h-6 w-6" />}
+            >
+              <p className="mb-4 text-muted-foreground">
+                Choose the browser extension or a WhatsApp export file on the
+                next screen.
+              </p>
+              <Button
+                className="w-full"
+                variant="primary"
+                onClick={() => router.push("/dashboard/import")}
+              >
+                Choose an intake method
+              </Button>
+            </StyledCard>
+          </>
+        )}
       </section>
     </PageWrapper>
   );

--- a/apps/web/src/lib/convolens-api.ts
+++ b/apps/web/src/lib/convolens-api.ts
@@ -1,0 +1,67 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export class ConvolensApiAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "ConvolensApiAuthError";
+  }
+}
+
+export function getConvolensApiBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001"
+  ).replace(/\/$/, "");
+}
+
+export async function getConvolensApiToken(): Promise<string> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    throw new ConvolensApiAuthError("Unauthorized", 401);
+  }
+  if (!session.idToken) {
+    throw new ConvolensApiAuthError(
+      "Your Mystira Identity session needs to be refreshed",
+      401,
+    );
+  }
+
+  const response = await fetch(
+    `${getConvolensApiBaseUrl()}/api/auth/mystira/exchange`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ idToken: session.idToken }),
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    throw new ConvolensApiAuthError(
+      "Unable to authorize the ConvoLens API session",
+      response.status === 401 ? 401 : 502,
+    );
+  }
+
+  const payload = (await response.json()) as { token?: string };
+  if (!payload.token) {
+    throw new ConvolensApiAuthError(
+      "ConvoLens API token exchange returned an invalid response",
+      502,
+    );
+  }
+
+  return payload.token;
+}
+
+export function apiAuthErrorResponse(error: unknown): Response {
+  if (error instanceof ConvolensApiAuthError) {
+    return Response.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error("ConvoLens API proxy error:", error);
+  return Response.json({ error: "Internal server error" }, { status: 500 });
+}

--- a/docs/ALPHA-GO-LIVE-ROADMAP.md
+++ b/docs/ALPHA-GO-LIVE-ROADMAP.md
@@ -129,9 +129,9 @@ accumulated, governed memory and outcome history.
 | WhatsApp extension identity | Branded icon set and clearer alpha purpose are implemented locally. | Package and installation proof required. |
 | WhatsApp selected-chat capture | Extraction and authenticated POST work. | Keep the consent boundary explicit. |
 | Timeout/offline behavior | Blocking alerts and raw abort text are replaced locally with inline status and a single persistent retry queue. | Must be tested against a real cold API revision. |
-| Durable conversation storage | The API routes still contain `TODO` storage calls. A 200 response does not currently prove durable persistence. | **Stop-ship for a functional alpha.** |
+| Durable conversation storage | Implemented in PR #120 with transactional records/messages, stable content-hash idempotency, user-scoped list/detail, and a PostgreSQL production plan. Production deployment and live restart/reload proof remain pending. | Code-complete; keep the functional alpha gate closed until production proof passes. |
 | Summary generation from intake | The extension intake route does not queue or generate a summary. | **Stop-ship if the product promises summaries.** |
-| Conversation history | Dashboard currently presents an honest empty state, not user data. | Add real list/reload proof before cohort opening. |
+| Conversation history | PR #120 renders stored conversations and message detail from user-scoped APIs. | Verify the production web token exchange and reload journey before cohort opening. |
 | Extension distribution | Direct to invited testers; no self-serve public install path. | Acceptable for a small invite-only cohort only. |
 | Privacy, retention, deletion | No complete public policy and in-product deletion flow found. | **Stop-ship for external cohort data.** |
 | Monitoring | API health exists; end-to-end intake/auth alerting is not yet proven. | Add business-flow telemetry and alerts before cohort opening. |

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -390,7 +390,7 @@ resource "azurerm_container_app" "api" {
       readiness_probe {
         transport               = "HTTP"
         port                    = var.api_target_port
-        path                    = "/health"
+        path                    = "/ready"
         interval_seconds        = 10
         timeout                 = 5
         failure_count_threshold = 6

--- a/infra/terraform/env/prod/terraform.tfvars
+++ b/infra/terraform/env/prod/terraform.tfvars
@@ -10,7 +10,7 @@ custom_hostname = "convolens.neuralliquid.ai"
 
 enable_budget_alerts      = true
 enable_container_registry = true
-enable_postgres           = false
+enable_postgres           = true
 enable_redis              = false
 
 admin_email           = ""

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -70,7 +70,7 @@ variable "postgres_backup_retention_days" {
 
 variable "enable_postgres" {
   type        = bool
-  description = "Provision PostgreSQL Flexible Server. Keep false for the internal eval apply to minimize recurring cost."
+  description = "Provision PostgreSQL Flexible Server as the durable conversation source of truth."
   default     = false
 }
 


### PR DESCRIPTION
## Outcome
- persist WhatsApp extension and file-export intakes transactionally before returning 200
- add stable content-hash idempotency plus user-scoped list/detail endpoints
- exchange the Mystira ID token for a ConvoLens API token in the web proxy
- render real conversation history and a stored-message detail view
- enable PostgreSQL Flexible Server for production and gate applies with SKU checks and saved Terraform plans

## Production cost change
- PostgreSQL Flexible Server B1ms + 32 GiB storage: approximately USD 20.53/month before taxes and excess backup/egress
- existing resource-group budget: USD 75/month

## Verification
- API CI suite: 7 suites, 77 tests passed
- persistence migration/service tests: 5 passed
- production-mode SQLite smoke: add, list, restart, reload, duplicate all passed
- web production build passed
- extension typecheck/build passed
- focused web auth/session tests: 7 passed
- Terraform fmt/validate passed
- actionlint passed

## Rollout
The production deployment remains manual. The deploy workflow now validates South Africa North SKU availability, runs a saved Terraform plan before each apply, and verifies database-backed readiness at /ready.