### PR TITLE
Fix PostgreSQL SKU availability check

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -159,7 +159,7 @@ jobs:
           set -euo pipefail
           AVAILABLE_SKUS=$(az postgres flexible-server list-skus \
             --location southafricanorth \
-            --query '[].name' \
+            --query '[].supportedServerEditions[].supportedServerSkus[].name' \
             -o tsv)
           if ! grep -Eq '(^|_)Standard_B1ms$' <<< "$AVAILABLE_SKUS"; then
             echo "PostgreSQL Flexible Server SKU Standard_B1ms is not available in southafricanorth." >&2


### PR DESCRIPTION
Fix the production deployment guard to query nested PostgreSQL Flexible Server SKU capabilities. Evidence: failed run 30137083074; live Azure query returns Standard_B1ms; actionlint and git diff --check pass.