### PR TITLE
Use native PostgreSQL UUID generation

### DIFF
--- a/apps/api/src/config/__tests__/postgres-uuid.test.ts
+++ b/apps/api/src/config/__tests__/postgres-uuid.test.ts
@@ -1,0 +1,20 @@
+import { DataSource } from 'typeorm';
+import { postgresNativeUuidOptions } from '../postgres-uuid';
+
+describe('PostgreSQL UUID configuration', () => {
+  it('uses the native UUID generator without installing extensions', () => {
+    const dataSource = new DataSource({
+      type: 'postgres',
+      entities: [],
+      ...postgresNativeUuidOptions,
+    });
+
+    expect(dataSource.options).toMatchObject({
+      uuidExtension: 'pgcrypto',
+      installExtensions: false,
+    });
+    expect((dataSource.driver as unknown as { uuidGenerator: string }).uuidGenerator).toBe(
+      'gen_random_uuid()'
+    );
+  });
+});

--- a/apps/api/src/config/database.ts
+++ b/apps/api/src/config/database.ts
@@ -5,6 +5,7 @@ import { User } from '../db/entities/User';
 import { ConversationIntake } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
 import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
+import { postgresNativeUuidOptions } from './postgres-uuid';
 import { logger } from '../utils/logger';
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -39,6 +40,7 @@ const sqliteOptions: DataSourceOptions = {
 
 const postgresOptions: DataSourceOptions = {
   ...commonOptions,
+  ...postgresNativeUuidOptions,
   type: 'postgres',
   host: process.env.DB_HOST,
   port: Number.parseInt(process.env.DB_PORT || '5432', 10),

--- a/apps/api/src/config/datasource.ts
+++ b/apps/api/src/config/datasource.ts
@@ -5,6 +5,7 @@ import { Message } from '../db/entities/Message';
 import { ConversationIntake } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
 import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
+import { postgresNativeUuidOptions } from './postgres-uuid';
 import { logger } from '../utils/logger';
 
 // Load environment variables
@@ -47,6 +48,7 @@ const sqliteOptions: DataSourceOptions = {
 
 const postgresOptions: DataSourceOptions = {
   ...commonOptions,
+  ...postgresNativeUuidOptions,
   type: 'postgres',
   host: process.env.DB_HOST,
   port: Number.parseInt(process.env.DB_PORT || '5432', 10),

--- a/apps/api/src/config/postgres-uuid.ts
+++ b/apps/api/src/config/postgres-uuid.ts
@@ -1,0 +1,6 @@
+export const postgresNativeUuidOptions = {
+  // PostgreSQL 13+ provides gen_random_uuid() natively. Avoid requiring
+  // extension allow-listing on managed PostgreSQL services.
+  uuidExtension: 'pgcrypto',
+  installExtensions: false,
+} as const;


### PR DESCRIPTION
Fix the production startup failure from run 30137359012. TypeORM now uses PostgreSQL's native gen_random_uuid() and skips managed-service extension installation. Validation: 8 API suites / 78 tests pass; API production build passes; compiled output contains uuidExtension=pgcrypto and installExtensions=false.