### PR TITLE
Fix conversation uploads and clarify the support-to-resolution loop

### DIFF
--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import {
-  Bot,
   Chrome,
   FileText,
-  Layers3,
+  ListChecks,
   LogIn,
   MessageSquareText,
+  Network,
+  Send,
 } from "lucide-react";
 import PageWrapper from "../page-wrapper";
 import { Button } from "@/components/ui/button";
@@ -45,17 +46,24 @@ const features = [
     href: "/dashboard",
   },
   {
-    title: "Generated summaries and insight",
+    title: "AI-assisted ticket drafting",
     description:
-      "Turn received conversation context into useful summaries and follow-up views.",
-    icon: Bot,
+      "Extract requests, evidence, ownership, and commitments into reviewable work without publishing automatically.",
+    icon: ListChecks,
     status: "In development",
   },
   {
-    title: "Additional platforms",
+    title: "Codeflow and Cognitive Mesh resolution",
     description:
-      "Bring more conversation sources into the same intake workspace after the WhatsApp alpha.",
-    icon: Layers3,
+      "Carry approved work into the execution stack while retaining links to the source conversation and human decisions.",
+    icon: Network,
+    status: "Planned",
+  },
+  {
+    title: "OmniPost response loop",
+    description:
+      "Turn resolved work into governed customer and stakeholder responses through the OmniPost stack.",
+    icon: Send,
     status: "Planned",
   },
 ];
@@ -70,11 +78,12 @@ export default function FeaturesPage() {
               Alpha scope
             </p>
             <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-              What ConvoLens does today—and what comes next.
+              From support signal to accountable resolution.
             </h1>
             <p className="mt-5 text-lg leading-8 text-muted-foreground">
-              WhatsApp conversation intake is live now. Summary experiences and
-              additional platforms are being built as the alpha develops.
+              WhatsApp intake and durable context are live now. AI-assisted
+              ticket creation, Codeflow/Cognitive Mesh resolution, and OmniPost
+              response delivery define the next layers of the operating loop.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Button asChild variant="primary">

--- a/apps/web/src/app/landing-page.tsx
+++ b/apps/web/src/app/landing-page.tsx
@@ -3,9 +3,10 @@
 import Link from "next/link";
 import {
   ArrowRight,
-  FileText,
-  Layers3,
+  ListChecks,
   MessageSquare,
+  Network,
+  Send,
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
@@ -13,29 +14,39 @@ import styles from "./landing-page.module.css";
 import "./enhanced-styles.css";
 
 const availableNow = [
-  "WhatsApp Web capture",
-  "WhatsApp .txt import",
-  "Mystira Identity sign-in",
+  "Sign in with Mystira Identity",
+  "Choose one WhatsApp conversation",
+  "Store its messages and provenance",
 ];
 
-const capabilities = [
+const operatingLoop = [
   {
     icon: MessageSquare,
-    title: "Capture a conversation",
+    eyebrow: "Live now",
+    title: "Capture the support signal",
     description:
-      "Choose the WhatsApp chat you want to send. ConvoLens does not scan your entire account.",
+      "Bring in the customer conversation you choose without opening the rest of the account.",
   },
   {
-    icon: FileText,
-    title: "Keep useful context",
+    icon: ListChecks,
+    eyebrow: "Next layer",
+    title: "Draft accountable work",
     description:
-      "Bring message text, senders, and timestamps into one structured intake flow.",
+      "AI-assisted extraction turns requests, evidence, and commitments into tickets for human review.",
   },
   {
-    icon: Layers3,
-    title: "Grow beyond one platform",
+    icon: Network,
+    eyebrow: "Planned stack",
+    title: "Coordinate resolution",
     description:
-      "WhatsApp is the first live connector. Additional conversation sources are planned as the alpha develops.",
+      "Approved work can move through Codeflow and Cognitive Mesh while keeping the source conversation attached.",
+  },
+  {
+    icon: Send,
+    eyebrow: "Planned stack",
+    title: "Close the response loop",
+    description:
+      "Resolution context can flow into OmniPost for governed customer and stakeholder responses.",
   },
 ];
 
@@ -67,28 +78,28 @@ export default function LandingPage() {
           <div>
             <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-green-200 bg-white/80 px-4 py-2 text-sm font-semibold text-green-800 shadow-sm backdrop-blur dark:border-green-800 dark:bg-gray-900/75 dark:text-green-300">
               <Sparkles className="h-4 w-4" />
-              ConvoLens Alpha is open
+              Consent-first support intake
             </div>
             <h1 className="max-w-4xl text-4xl font-bold leading-tight text-gray-900 dark:text-white sm:text-5xl md:text-6xl">
-              Bring important conversations into focus.
+              Turn support conversations into work that gets resolved.
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-8 text-gray-600 dark:text-gray-300">
-              ConvoLens is an early conversation-intake workspace. WhatsApp is
-              the first live connector, with a multi-platform future being
-              shaped through the alpha.
+              ConvoLens preserves the customer signal at intake, then builds
+              toward AI-assisted ticket creation, coordinated resolution, and an
+              accountable response loop across the NeuralLiquid stack.
             </p>
             <div className="mt-9 flex flex-col gap-4 sm:flex-row">
               <Link
                 href="/login?redirectTo=/dashboard"
                 className="btn-glow rounded-lg bg-green-700 px-8 py-3 text-center font-semibold text-white shadow-md transition hover:bg-green-800 hover:shadow-lg"
               >
-                Join the alpha
+                Start an intake
               </Link>
               <Link
                 href="/features"
                 className="glassmorphism flex items-center justify-center rounded-lg px-8 py-3 text-center font-semibold text-gray-900 shadow-md transition hover:shadow-lg dark:text-white"
               >
-                See what works today
+                Explore the operating loop
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </div>
@@ -101,7 +112,7 @@ export default function LandingPage() {
                   Available now
                 </p>
                 <h2 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white">
-                  Start with one WhatsApp chat
+                  From conversation to accountable work
                 </h2>
               </div>
               <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300">
@@ -122,8 +133,9 @@ export default function LandingPage() {
               ))}
             </ol>
             <p className="mt-6 text-sm leading-6 text-gray-500 dark:text-gray-400">
-              Alpha access means the workflow and product will keep evolving. We
-              will be explicit about what is live and what is still planned.
+              Conversation capture and durable storage are live. Ticket
+              drafting, resolution orchestration, and response delivery are the
+              product direction—not claims of current automation.
             </p>
           </div>
         </div>
@@ -133,34 +145,39 @@ export default function LandingPage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-3xl text-center">
             <p className="text-sm font-bold uppercase tracking-[0.2em] text-green-700 dark:text-green-300">
-              Alpha workflow
+              The operating loop
             </p>
             <h2 className="mt-3 text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
-              A clearer way to bring conversations in
+              Intake is the start, not the destination
             </h2>
             <p className="mt-4 text-lg leading-8 text-gray-600 dark:text-gray-400">
-              Start with the channels available today while we build toward a
-              shared intake layer for more of the places conversations happen.
+              Preserve the original support context, convert it into reviewed
+              work, carry it through resolution, and return a governed response.
             </p>
           </div>
 
-          <div className="mt-14 grid gap-8 md:grid-cols-3">
-            {capabilities.map(({ icon: Icon, title, description }) => (
-              <article
-                key={title}
-                className="rounded-2xl border border-gray-200 bg-white p-7 shadow-sm dark:border-gray-700 dark:bg-gray-800"
-              >
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/40">
-                  <Icon className="h-6 w-6 text-green-700 dark:text-green-300" />
-                </div>
-                <h3 className="mt-5 text-xl font-semibold text-gray-900 dark:text-white">
-                  {title}
-                </h3>
-                <p className="mt-3 leading-7 text-gray-600 dark:text-gray-400">
-                  {description}
-                </p>
-              </article>
-            ))}
+          <div className="mt-14 grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+            {operatingLoop.map(
+              ({ icon: Icon, eyebrow, title, description }) => (
+                <article
+                  key={title}
+                  className="rounded-2xl border border-gray-200 bg-white p-7 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/40">
+                    <Icon className="h-6 w-6 text-green-700 dark:text-green-300" />
+                  </div>
+                  <p className="mt-5 text-xs font-bold uppercase tracking-[0.16em] text-green-700 dark:text-green-300">
+                    {eyebrow}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-gray-900 dark:text-white">
+                    {title}
+                  </h3>
+                  <p className="mt-3 leading-7 text-gray-600 dark:text-gray-400">
+                    {description}
+                  </p>
+                </article>
+              ),
+            )}
           </div>
         </div>
       </section>
@@ -170,23 +187,24 @@ export default function LandingPage() {
           <div className="rounded-2xl border border-green-100 bg-green-50 p-8 dark:border-green-900 dark:bg-green-950/30">
             <ShieldCheck className="h-8 w-8 text-green-700 dark:text-green-300" />
             <h2 className="mt-5 text-2xl font-bold text-gray-900 dark:text-white">
-              You choose what enters ConvoLens
+              Consent and provenance stay attached
             </h2>
             <p className="mt-3 leading-7 text-gray-700 dark:text-gray-300">
-              The extension reads the selected WhatsApp Web chat when you
-              activate it, then sends that conversation to the ConvoLens service
-              for processing. It does not silently ingest every chat.
+              You choose the conversation. ConvoLens preserves senders,
+              timestamps, and source context so later tickets and decisions can
+              be traced back to the customer signal.
             </p>
           </div>
           <div className="rounded-2xl border border-amber-100 bg-amber-50 p-8 dark:border-amber-900 dark:bg-amber-950/25">
             <Sparkles className="h-8 w-8 text-amber-700 dark:text-amber-300" />
             <h2 className="mt-5 text-2xl font-bold text-gray-900 dark:text-white">
-              Alpha, without invented social proof
+              The moat compounds through outcomes
             </h2>
             <p className="mt-3 leading-7 text-gray-700 dark:text-gray-300">
-              We are launching now, so there are no customer reviews or usage
-              claims to show yet. Early users will help shape the workflow as it
-              becomes multi-platform.
+              The defensible asset is not a message count or a generic summary.
+              It is the growing link between support evidence, reviewed work,
+              resolution decisions, corrections, and the response that closed
+              the loop.
             </p>
           </div>
         </div>
@@ -197,17 +215,17 @@ export default function LandingPage() {
       >
         <div className="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-white sm:text-4xl">
-            Start with the conversation in front of you.
+            Start with the support conversation in front of you.
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-xl text-green-100">
-            Sign in, choose an intake method, and send your first WhatsApp
-            conversation into the ConvoLens alpha.
+            Preserve the source now. Build the reviewed ticket, resolution, and
+            response trail from there.
           </p>
           <Link
             href="/login?redirectTo=/dashboard"
             className="mt-9 inline-block rounded-lg bg-white px-8 py-3 font-semibold text-green-800 shadow-md transition hover:bg-gray-100"
           >
-            Sign in to the alpha
+            Start an intake
           </Link>
         </div>
       </section>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,22 +5,22 @@ import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 
 export const metadata = {
-  title: "ConvoLens Alpha - Conversation Intake",
+  title: "ConvoLens Alpha - From Support Signal to Resolution",
   description:
-    "Bring selected WhatsApp conversations into the ConvoLens alpha workspace.",
+    "Turn selected support conversations into durable context and, over time, reviewed tickets, coordinated resolution, and governed responses.",
   icons: {
     icon: "/favicon.svg",
   },
   openGraph: {
-    title: "ConvoLens Alpha - Conversation Intake",
+    title: "ConvoLens Alpha - From Support Signal to Resolution",
     description:
-      "WhatsApp is the first live connector in a growing multi-platform conversation intake workspace.",
+      "Consent-first support intake building toward AI-assisted work, coordinated resolution, and governed responses.",
     siteName: "ConvoLens",
   },
   twitter: {
-    title: "ConvoLens Alpha - Conversation Intake",
+    title: "ConvoLens Alpha - From Support Signal to Resolution",
     description:
-      "WhatsApp is the first live connector in a growing multi-platform conversation intake workspace.",
+      "Consent-first support intake building toward AI-assisted work, coordinated resolution, and governed responses.",
     card: "summary_large_image",
   },
 };

--- a/apps/web/src/components/file-upload/FileUpload.tsx
+++ b/apps/web/src/components/file-upload/FileUpload.tsx
@@ -1,17 +1,22 @@
-import React, { useCallback, useState } from 'react';
-import { useDropzone } from 'react-dropzone';
-import { FiUpload, FiX, FiCheck } from 'react-icons/fi';
-import styles from './file-upload.module.css';
+import React, { useCallback, useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { FiUpload, FiX, FiCheck } from "react-icons/fi";
+import styles from "./file-upload.module.css";
+
+interface FileUploadResult {
+  success: boolean;
+  error?: string;
+}
 
 interface FileUploadProps {
-  onFileUpload: (file: File) => Promise<void>;
+  onFileUpload: (file: File) => Promise<FileUploadResult>;
   acceptedFormats?: string[];
   maxSizeMB?: number;
 }
 
 const FileUpload: React.FC<FileUploadProps> = ({
   onFileUpload,
-  acceptedFormats = ['.txt'],
+  acceptedFormats = [".txt"],
   maxSizeMB = 10,
 }) => {
   const [isUploading, setIsUploading] = useState(false);
@@ -23,7 +28,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
       if (acceptedFiles.length === 0) return;
 
       const file = acceptedFiles[0];
-      
+
       // Validate file size
       if (file.size > maxSizeMB * 1024 * 1024) {
         setUploadError(`File size exceeds ${maxSizeMB}MB`);
@@ -33,36 +38,42 @@ const FileUpload: React.FC<FileUploadProps> = ({
       try {
         setIsUploading(true);
         setUploadError(null);
-        await onFileUpload(file);
+        const result = await onFileUpload(file);
+        if (!result.success) {
+          setUploadError(
+            result.error || "Failed to upload file. Please try again.",
+          );
+          return;
+        }
         setUploadSuccess(true);
         // Reset success state after 3 seconds
         setTimeout(() => setUploadSuccess(false), 3000);
       } catch (error) {
-        console.error('Upload error:', error);
-        setUploadError('Failed to upload file. Please try again.');
+        console.error("Upload error:", error);
+        setUploadError("Failed to upload file. Please try again.");
       } finally {
         setIsUploading(false);
       }
     },
-    [maxSizeMB, onFileUpload]
+    [maxSizeMB, onFileUpload],
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: {
-      'text/plain': acceptedFormats,
+      "text/plain": acceptedFormats,
     },
     maxFiles: 1,
     disabled: isUploading,
   });
 
   const formatBytes = (bytes: number, decimals = 2) => {
-    if (bytes === 0) return '0 Bytes';
+    if (bytes === 0) return "0 Bytes";
     const k = 1024;
     const dm = decimals < 0 ? 0 : decimals;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const sizes = ["Bytes", "KB", "MB", "GB"];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
   };
 
   return (
@@ -70,9 +81,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
       <div
         {...getRootProps()}
         className={`${styles.dropzone} ${
-          isDragActive ? styles.active : ''
-        } ${uploadSuccess ? styles.success : ''} ${
-          uploadError ? styles.error : ''
+          isDragActive ? styles.active : ""
+        } ${uploadSuccess ? styles.success : ""} ${
+          uploadError ? styles.error : ""
         }`}
       >
         <input {...getInputProps()} />
@@ -91,11 +102,12 @@ const FileUpload: React.FC<FileUploadProps> = ({
             <FiUpload className={styles.icon} />
             <p className={styles.dropzoneText}>
               {isDragActive
-                ? 'Drop the file here...'
-                : 'Drag & drop a WhatsApp chat export file here, or click to select'}
+                ? "Drop the file here..."
+                : "Drag & drop a WhatsApp chat export file here, or click to select"}
             </p>
             <p className={styles.smallText}>
-              Supported formats: {acceptedFormats.join(', ')} (max {maxSizeMB}MB)
+              Supported formats: {acceptedFormats.join(", ")} (max {maxSizeMB}
+              MB)
             </p>
           </div>
         )}

--- a/apps/web/src/components/layouts/footer/index.tsx
+++ b/apps/web/src/components/layouts/footer/index.tsx
@@ -12,18 +12,23 @@ export function Footer() {
       </div>
 
       <div className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8 relative z-10">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-5">
           {/* Logo and description */}
-          <div className="col-span-1 md:col-span-2">
+          <div className="col-span-1 md:col-span-3">
             <h2 className="text-2xl font-bold text-green-600 dark:text-green-400 text-gradient">
               ConvoLens
             </h2>
             <p className="mt-4 text-gray-600 dark:text-gray-400 max-w-md">
-              An early conversation-intake workspace. WhatsApp is the first live
-              connector; more platforms are planned.
+              A consent-first path from support conversations to reviewed work,
+              coordinated resolution, and governed responses.
+            </p>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-gray-500 dark:text-gray-500">
+              Intake is live. AI-assisted ticket creation, Codeflow/Cognitive
+              Mesh resolution, and OmniPost delivery describe the planned
+              NeuralLiquid operating loop.
             </p>
             <p className="mt-5 inline-flex rounded-full border border-green-200 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-green-700 dark:border-green-800 dark:text-green-300">
-              Alpha
+              Technical alpha
             </p>
           </div>
 
@@ -83,7 +88,7 @@ export function Footer() {
             &copy; {new Date().getFullYear()} ConvoLens. All rights reserved.
           </p>
           <p className="mt-4 text-sm text-gray-500 dark:text-gray-400 md:mt-0">
-            WhatsApp connector available now · More sources planned
+            Support signal → reviewed work → resolution → response
           </p>
         </div>
       </div>

--- a/apps/web/src/hooks/__tests__/useFileUpload.test.ts
+++ b/apps/web/src/hooks/__tests__/useFileUpload.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { useFileUpload } from "../useFileUpload";
+import { toast } from "../../components/ui/toaster";
+
+jest.mock("../../components/ui/toaster", () => ({
+  toast: jest.fn(),
+}));
+
+const mockedToast = jest.mocked(toast);
+const fetchMock = jest.fn<
+  Promise<Partial<Response>>,
+  [RequestInfo | URL, RequestInit?]
+>();
+
+describe("useFileUpload", () => {
+  const update = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(global, "fetch", {
+      configurable: true,
+      writable: true,
+      value: fetchMock,
+    });
+    mockedToast.mockReturnValue({
+      id: "toast-1",
+      dismiss: jest.fn(),
+      update,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("posts an accepted text export and reports success", async () => {
+    const onSuccess = jest.fn();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { intakeId: "intake-1" } }),
+    });
+    const { result } = renderHook(() =>
+      useFileUpload("/api/chat-export/upload", { onSuccess }),
+    );
+
+    let uploadResult;
+    await act(async () => {
+      uploadResult = await result.current.uploadFile(
+        new File(["[26/07/2026, 10:00] Agent: Test"], "chat.txt", {
+          type: "text/plain",
+        }),
+      );
+    });
+
+    expect(uploadResult).toEqual({
+      success: true,
+      data: { data: { intakeId: "intake-1" } },
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/chat-export/upload",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+    expect(onSuccess).toHaveBeenCalledWith({ data: { intakeId: "intake-1" } });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Success", variant: "success" }),
+    );
+  });
+
+  it("returns the API error so the dropzone can display it", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "Invalid WhatsApp export" }),
+    });
+    const { result } = renderHook(() =>
+      useFileUpload("/api/chat-export/upload"),
+    );
+
+    let uploadResult;
+    await act(async () => {
+      uploadResult = await result.current.uploadFile(
+        new File(["not an export"], "chat.txt", { type: "text/plain" }),
+      );
+    });
+
+    expect(uploadResult).toEqual({
+      success: false,
+      error: "Invalid WhatsApp export",
+    });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Upload Failed",
+        description: "Invalid WhatsApp export",
+        variant: "destructive",
+      }),
+    );
+  });
+});

--- a/apps/web/src/hooks/useFileUpload.ts
+++ b/apps/web/src/hooks/useFileUpload.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback } from 'react';
-import { useToast } from '../components/ui/toaster';
+import { useState, useCallback } from "react";
+import { toast } from "../components/ui/toaster";
 
-interface UploadResult {
+export interface UploadResult {
   success: boolean;
   data?: any;
   error?: string;
@@ -16,41 +16,45 @@ interface UseFileUploadOptions {
   errorMessage?: string;
 }
 
-export function useFileUpload(endpoint: string, options: UseFileUploadOptions = {}) {
+export function useFileUpload(
+  endpoint: string,
+  options: UseFileUploadOptions = {},
+) {
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState(0);
-  const { addToast } = useToast();
-  
   const {
     onSuccess,
     onError,
     maxSizeMB = 10,
-    acceptedTypes = ['text/plain'],
-    successMessage = 'File uploaded successfully',
-    errorMessage: defaultErrorMessage = 'Failed to upload file',
+    acceptedTypes = ["text/plain"],
+    successMessage = "File uploaded successfully",
+    errorMessage: defaultErrorMessage = "Failed to upload file",
   } = options;
 
   const uploadFile = useCallback(
     async (file: File): Promise<UploadResult> => {
       if (!file) {
-        const error = 'No file provided';
+        const error = "No file provided";
         onError?.(error);
-        addToast({
-          title: 'Upload Failed',
+        toast({
+          title: "Upload Failed",
           description: error,
-          type: 'error',
+          variant: "destructive",
         });
         return { success: false, error };
       }
 
       // Validate file type
-      if (!acceptedTypes.includes(file.type) && !acceptedTypes.includes('*/*')) {
-        const error = `Unsupported file type. Allowed types: ${acceptedTypes.join(', ')}`;
+      if (
+        !acceptedTypes.includes(file.type) &&
+        !acceptedTypes.includes("*/*")
+      ) {
+        const error = `Unsupported file type. Allowed types: ${acceptedTypes.join(", ")}`;
         onError?.(error);
-        addToast({
-          title: 'Upload Failed',
+        toast({
+          title: "Upload Failed",
           description: error,
-          type: 'error',
+          variant: "destructive",
         });
         return { success: false, error };
       }
@@ -59,22 +63,22 @@ export function useFileUpload(endpoint: string, options: UseFileUploadOptions = 
       if (file.size > maxSizeMB * 1024 * 1024) {
         const error = `File is too large. Maximum size is ${maxSizeMB}MB.`;
         onError?.(error);
-        addToast({
-          title: 'Upload Failed',
+        toast({
+          title: "Upload Failed",
           description: error,
-          type: 'error',
+          variant: "destructive",
         });
         return { success: false, error };
       }
 
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append("file", file);
 
       // Add loading toast
-      const toastId = addToast({
-        title: 'Uploading...',
-        description: 'Your file is being uploaded',
-        type: 'default',
+      const uploadToast = toast({
+        title: "Uploading...",
+        description: "Your file is being uploaded",
+        variant: "default",
         duration: 0, // Don't auto-dismiss
       });
 
@@ -83,51 +87,58 @@ export function useFileUpload(endpoint: string, options: UseFileUploadOptions = 
         setProgress(0);
 
         const response = await fetch(endpoint, {
-          method: 'POST',
+          method: "POST",
           body: formData,
-          credentials: 'include',
+          credentials: "include",
         });
 
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           throw new Error(
-            errorData.error || `Upload failed with status ${response.status}`
+            errorData.error || `Upload failed with status ${response.status}`,
           );
         }
 
         const data = await response.json();
         onSuccess?.(data);
-        
+
         // Update toast to success
-        addToast({
-          id: toastId,
-          title: 'Success',
+        uploadToast.update({
+          title: "Success",
           description: successMessage,
-          type: 'success',
+          variant: "success",
           duration: 5000,
         });
-        
+
         return { success: true, data };
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : defaultErrorMessage;
+        const errorMessage =
+          error instanceof Error ? error.message : defaultErrorMessage;
         onError?.(errorMessage);
-        
+
         // Update toast to error
-        addToast({
-          id: toastId,
-          title: 'Upload Failed',
+        uploadToast.update({
+          title: "Upload Failed",
           description: errorMessage,
-          type: 'error',
+          variant: "destructive",
           duration: 5000,
         });
-        
+
         return { success: false, error: errorMessage };
       } finally {
         setIsUploading(false);
         setProgress(0);
       }
     },
-    [endpoint, onSuccess, onError, maxSizeMB, acceptedTypes, successMessage, defaultErrorMessage, addToast]
+    [
+      endpoint,
+      onSuccess,
+      onError,
+      maxSizeMB,
+      acceptedTypes,
+      successMessage,
+      defaultErrorMessage,
+    ],
   );
 
   return {


### PR DESCRIPTION
## What changed

- Fix authenticated conversation uploads by using the actual toast API instead of the nonexistent `addToast` function.
- Return upload failures to the dropzone so users see the backend validation message instead of a false success or generic error.
- Add focused hook regression coverage for successful uploads and API validation failures.
- Reframe the landing page, feature page, metadata, and footer around the product loop: support intake → AI-assisted ticket drafting → Codeflow/Cognitive Mesh resolution → OmniPost response.
- Replace defensive social-proof copy with the intended compounding moat: provenance, reviewed work, resolution decisions, corrections, and closed-loop outcomes.
- Keep current capabilities and planned stack layers explicitly distinguished.

## Root cause and impact

The production browser threw `TypeError: ... is not a function` before `fetch` because `useFileUpload` destructured and called `addToast`, which the toaster hook does not expose. No upload POST reached the API. This change uses the supported `toast()` return contract and allows the file component to render the real result.

## Validation

- Focused upload regression tests: 2 passed.
- `pnpm --filter @convolens/web build`: passed.
- Targeted ESLint: passed.
- `git diff --check`: passed.
- Local browser verification passed for landing, features, metadata, and footer.
- Authenticated production reproduction confirmed the original client-side failure; no private conversation content was retained.

## Known baseline

The broad web Jest command remains red on unrelated existing configuration problems: mixed Vitest/Playwright suites under Jest, stale module paths/test utilities, and `TransformStream` setup. The new focused suite passes independently.