### PR TITLE
Improve import positioning and reject empty parses

### DIFF
--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -150,6 +150,11 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
     }
 
     const chatData = await parseWhatsAppExport(fileContent);
+    if (chatData.messages.length === 0) {
+      return res.status(400).json({
+        error: 'No WhatsApp messages could be read from this export.',
+      });
+    }
 
     const saved = await conversationIntakeService.save({
       userId,

--- a/apps/api/src/services/__tests__/chat-export.service.test.ts
+++ b/apps/api/src/services/__tests__/chat-export.service.test.ts
@@ -17,16 +17,16 @@ describe('ChatExportService', () => {
       expect(result.participants).toContain('John Doe');
       expect(result.participants).toContain('Jane Smith');
       expect(result.messages).toHaveLength(3);
-      
+
       const firstMessage = result.messages[0];
       expect(firstMessage.sender).toBe('John Doe');
       expect(firstMessage.content).toBe('Hello, how are you?');
       expect(firstMessage.timestamp).toBeInstanceOf(Date);
-      
+
       const secondMessage = result.messages[1];
       expect(secondMessage.sender).toBe('Jane Smith');
-      expect(secondMessage.content).toBe('I\'m good, thanks! How about you?');
-      
+      expect(secondMessage.content).toBe("I'm good, thanks! How about you?");
+
       // Verify metadata
       expect(result.metadata).toBeDefined();
       expect(result.metadata.exportDate).toBeInstanceOf(Date);
@@ -35,7 +35,7 @@ describe('ChatExportService', () => {
 
     it('should handle empty content', async () => {
       const result = await parseWhatsAppExport('');
-      
+
       expect(result).toBeDefined();
       expect(result.participants).toHaveLength(0);
       expect(result.messages).toHaveLength(0);
@@ -49,21 +49,50 @@ This is not a valid line
       `;
 
       const result = await parseWhatsAppExport(chatContent);
-      
+
       expect(result).toBeDefined();
       expect(result.messages).toHaveLength(0);
     });
-    
+
     it('should handle media messages', async () => {
       const chatContent = `
 [08/01/2023, 10:30:00] John Doe: <Media omitted>
 [08/01/2023, 10:31:00] Jane Smith: Here's a photo!
       `;
-      
+
       const result = await parseWhatsAppExport(chatContent);
-      
+
       expect(result.messages[0].isMedia).toBe(true);
       expect(result.messages[1].isMedia).toBe(false);
+    });
+
+    it('should parse Windows CRLF exports', async () => {
+      const chatContent =
+        '[25/07/2026, 09:00:00] Hans: First message\r\n' +
+        '[25/07/2026, 09:01:00] Irma: Second message\r\n';
+
+      const result = await parseWhatsAppExport(chatContent);
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.participants).toEqual(['Hans', 'Irma']);
+    });
+
+    it('should preserve system messages and parse 12-hour timestamps', async () => {
+      const chatContent = `
+[25/07/2026, 12:30:00] Hans: Twenty-four-hour noon
+[25/07/2026, 01:15:00 PM] Irma: Afternoon message
+[25/07/2026, 01:16:00 PM] Messages are end-to-end encrypted
+      `;
+
+      const result = await parseWhatsAppExport(chatContent);
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].timestamp.getHours()).toBe(12);
+      expect(result.messages[1].timestamp.getHours()).toBe(13);
+      expect(result.messages[2]).toMatchObject({
+        sender: 'System',
+        content: 'Messages are end-to-end encrypted',
+      });
     });
   });
 });

--- a/apps/api/src/services/chat-export.service.ts
+++ b/apps/api/src/services/chat-export.service.ts
@@ -23,11 +23,11 @@ export interface ChatExportData {
 // Regular expression to match WhatsApp message format:
 // [DD/MM/YYYY, HH:MM:SS] Sender: Message
 const MESSAGE_REGEX =
-  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+?):\s(.+)$/i;
+  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(AM|PM)?\]\s(.+?):\s(.+)$/i;
 
 // Alternative format for system messages
 const SYSTEM_MESSAGE_REGEX =
-  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(?:AM|PM)?\]\s(.+)$/i;
+  /^\[(\d{1,2}\/\d{1,2}\/\d{2,4}),\s(\d{1,2}:\d{2}(?::\d{2})?)\s?(AM|PM)?\]\s(.+)$/i;
 
 // Media indicator in WhatsApp exports
 const MEDIA_INDICATOR = '<Media omitted>';
@@ -39,30 +39,27 @@ const MEDIA_INDICATOR = '<Media omitted>';
  */
 export async function parseWhatsAppExport(fileContent: string): Promise<ChatExportData> {
   try {
-    const lines = fileContent.split('\n').filter((line) => line.trim() !== '');
+    const lines = fileContent.split(/\r?\n/).filter((line) => line.trim() !== '');
     const participants = new Set<string>();
     const messages: ChatMessage[] = [];
 
     for (const line of lines) {
       if (!line.trim()) continue;
 
-      let match = MESSAGE_REGEX.exec(line);
-      let isSystemMessage = false;
-
-      if (!match) {
-        // Try matching system message format
-        const systemMatch = SYSTEM_MESSAGE_REGEX.exec(line);
-        if (systemMatch) {
-          isSystemMessage = true;
-          match = systemMatch;
-        } else {
-          logger.warn(`Skipping malformed line: ${line}`);
-          continue;
-        }
+      const messageMatch = MESSAGE_REGEX.exec(line);
+      const systemMatch = messageMatch ? null : SYSTEM_MESSAGE_REGEX.exec(line);
+      if (!messageMatch && !systemMatch) {
+        logger.warn(`Skipping malformed line: ${line}`);
+        continue;
       }
 
       try {
-        const [_, dateStr, timeStr, sender, content] = match;
+        const dateStr = (messageMatch || systemMatch)![1];
+        const timeStr = (messageMatch || systemMatch)![2];
+        const meridiem = (messageMatch || systemMatch)![3]?.toLowerCase();
+        const sender = messageMatch?.[4] || 'System';
+        const content = messageMatch?.[5] || systemMatch![4];
+        const isSystemMessage = Boolean(systemMatch);
 
         // Parse date and time
         const [day, month, year] = dateStr.split('/').map(Number);
@@ -73,9 +70,8 @@ export async function parseWhatsAppExport(fileContent: string): Promise<ChatExpo
 
         // Adjust for AM/PM if present (case-insensitive)
         let hours24 = parseInt(hours, 10);
-        const isPM = timeStr.toLowerCase().includes('pm');
-        if (isPM && hours24 < 12) hours24 += 12;
-        if (!isPM && hours24 === 12) hours24 = 0;
+        if (meridiem === 'pm' && hours24 < 12) hours24 += 12;
+        if (meridiem === 'am' && hours24 === 12) hours24 = 0;
 
         const timestamp = new Date(
           yearFull,

--- a/apps/api/tests/fixtures/acceptance-chat.txt
+++ b/apps/api/tests/fixtures/acceptance-chat.txt
@@ -1,0 +1,2 @@
+[25/07/2026, 09:00:00] Hans: Morning, is the conversation import ready?
+[25/07/2026, 09:01:00] Irma: Yes, this is a synthetic acceptance fixture.

--- a/apps/api/tests/fixtures/alpha-chat.txt
+++ b/apps/api/tests/fixtures/alpha-chat.txt
@@ -1,2 +1,0 @@
-[25/07/2026, 09:00:00] Hans: Morning, are we ready for the alpha?
-[25/07/2026, 09:01:00] Irma: Yes, durable intake is the first gate.

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "ConvoLens Alpha - WhatsApp Intake",
+  "name": "ConvoLens - WhatsApp Intake",
   "version": "1.0.0",
-  "description": "Send the WhatsApp Web conversation you choose into the ConvoLens alpha workspace.",
+  "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {
     "16": "icons/icon-16.png",
@@ -24,7 +24,7 @@
 
   "action": {
     "default_popup": "popup/popup.html",
-    "default_title": "ConvoLens Alpha",
+    "default_title": "ConvoLens",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -53,7 +53,7 @@
         font-weight: 700;
       }
 
-      .alpha-badge {
+      .preview-badge {
         border: 1px solid rgba(255, 255, 255, 0.55);
         border-radius: 999px;
         padding: 2px 7px;
@@ -266,7 +266,7 @@
       <div class="brand-copy">
         <div class="brand-title">
           <h1>ConvoLens</h1>
-          <span class="alpha-badge">Alpha</span>
+          <span class="preview-badge">Preview</span>
         </div>
         <p>WhatsApp conversation intake</p>
       </div>
@@ -331,7 +331,7 @@
 
     <div class="footer">
       <a href="https://convolens.neuralliquid.ai" target="_blank">ConvoLens</a>
-      Alpha · WhatsApp is the first connector
+      Preview · WhatsApp is the first connector
     </div>
 
     <script src="popup.js"></script>

--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -27,7 +27,7 @@ export default function ImportChatPage() {
         title: "Conversation received",
         description: result?.duplicate
           ? "This conversation was already in your workspace."
-          : "Your WhatsApp export is now stored in your alpha workspace.",
+          : "Your WhatsApp export is now stored in your workspace.",
         variant: "default",
       });
       router.push(result?.data?.dashboardUrl || "/dashboard");
@@ -44,8 +44,8 @@ export default function ImportChatPage() {
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-2">Import Chat</h1>
         <p className="text-muted-foreground mb-8">
-          Choose how to bring your first WhatsApp conversation into the
-          ConvoLens alpha.
+          Choose a WhatsApp text export or the browser extension. Additional
+          import options are planned as the preview expands.
         </p>
 
         <Tabs
@@ -107,8 +107,7 @@ export default function ImportChatPage() {
               <CardHeader>
                 <CardTitle>Connect WhatsApp Web</CardTitle>
                 <CardDescription>
-                  Use the ConvoLens Alpha extension to send only the chat you
-                  select.
+                  Use the ConvoLens extension to send only the chat you select.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
@@ -116,7 +115,7 @@ export default function ImportChatPage() {
                   <div className="rounded-lg border p-4 md:col-span-2">
                     <div className="mb-3 flex items-center gap-2 font-medium">
                       <Chrome className="h-5 w-5 text-primary" />
-                      Use the alpha extension
+                      Use the browser extension
                     </div>
                     <ol className="list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
                       <li>Open WhatsApp Web and select a conversation.</li>
@@ -132,8 +131,8 @@ export default function ImportChatPage() {
                     <div className="mt-4 flex gap-3 rounded-md bg-muted p-3 text-sm text-muted-foreground">
                       <FileText className="mt-0.5 h-4 w-4 shrink-0" />
                       <p>
-                        Extension distribution is currently handled directly for
-                        invited alpha users.
+                        The browser extension is available to private-preview
+                        participants.
                       </p>
                     </div>
                   </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -22,13 +22,13 @@ const onboardingSteps = [
     icon: MessageSquare,
     title: "Choose one conversation",
     description:
-      "Start with a WhatsApp chat that you have permission to bring into the alpha.",
+      "Start with a WhatsApp chat that you are authorized to upload.",
   },
   {
     icon: Chrome,
     title: "Pick an intake method",
     description:
-      "Use the browser extension on WhatsApp Web or upload a WhatsApp .txt export.",
+      "Upload a WhatsApp .txt export or use the browser extension. Additional import paths are planned.",
   },
   {
     icon: Sparkles,
@@ -114,10 +114,8 @@ export default function DashboardPage() {
   return (
     <PageWrapper>
       <PageHeader
-        title={
-          firstName ? `Welcome, ${firstName}` : "Welcome to ConvoLens Alpha"
-        }
-        description="Your first step is to bring in one conversation. WhatsApp is the live connector during this alpha."
+        title={firstName ? `Welcome, ${firstName}` : "Welcome to ConvoLens"}
+        description="Import a WhatsApp conversation to review it in your workspace."
         actions={
           <Button
             variant="primary"
@@ -138,18 +136,17 @@ export default function DashboardPage() {
             <div>
               <p className="text-sm font-semibold uppercase tracking-wider text-green-800 dark:text-green-300">
                 {conversations.length > 0
-                  ? "Alpha workspace"
-                  : "First-time setup"}
+                  ? "Conversation workspace"
+                  : "Getting started"}
               </p>
               <h2 className="mt-1 text-xl font-bold text-foreground">
                 {conversations.length > 0
                   ? `${conversations.length} conversation${conversations.length === 1 ? "" : "s"} received`
-                  : "Send your first conversation in three steps"}
+                  : "Import your first conversation"}
               </h2>
               <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
-                This is an alpha workspace. We will show confirmed intake
-                results and avoid presenting sample activity as if it were
-                yours.
+                Imported conversations appear here after ConvoLens confirms
+                receipt.
               </p>
             </div>
           </div>
@@ -182,7 +179,7 @@ export default function DashboardPage() {
             icon={<MessageSquare className="h-6 w-6" />}
           >
             <p className="text-muted-foreground">
-              Checking your durable alpha workspace…
+              Loading your conversation workspace…
             </p>
           </StyledCard>
         ) : conversations.length > 0 ? (
@@ -222,9 +219,8 @@ export default function DashboardPage() {
               icon={<FileText className="h-6 w-6" />}
             >
               <p className="text-muted-foreground">
-                Your real conversation activity will appear here after a
-                successful intake. ConvoLens does not seed this dashboard with
-                demo records.
+                Imported conversations will appear here after ConvoLens confirms
+                receipt.
               </p>
             </StyledCard>
             <StyledCard

--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -6,9 +6,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const features = [
   {
-    title: "WhatsApp text import",
+    title: "Two import paths",
     description:
-      "Upload a WhatsApp .txt export without media through the authenticated workspace.",
+      "Upload a WhatsApp .txt export or send a selected chat with the private-preview browser extension.",
     icon: FileText,
   },
   {
@@ -44,8 +44,8 @@ export default function FeaturesPage() {
               Preserve a WhatsApp support conversation and its context.
             </h1>
             <p className="mt-5 text-lg leading-8 text-muted-foreground">
-              ConvoLens currently provides a focused, authenticated path for
-              importing WhatsApp text exports and reviewing the saved record.
+              ConvoLens provides two authenticated WhatsApp import paths today,
+              with additional sources planned as validated workflows are added.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Button asChild variant="primary">

--- a/apps/web/src/app/landing-page.tsx
+++ b/apps/web/src/app/landing-page.tsx
@@ -7,7 +7,7 @@ import "./enhanced-styles.css";
 
 const availableNow = [
   "Sign in with Mystira Identity",
-  "Upload one WhatsApp text export",
+  "Choose a text export or browser extension",
   "Review the saved messages and context",
 ];
 
@@ -20,9 +20,9 @@ const importSteps = [
   },
   {
     icon: FileText,
-    title: "Upload the text file",
+    title: "Choose an import path",
     description:
-      "Import the conversation without media. ConvoLens preserves its participants, messages, and timestamps.",
+      "Upload a WhatsApp text export or send the selected chat with the browser extension.",
   },
   {
     icon: ShieldCheck,
@@ -66,8 +66,9 @@ export default function LandingPage() {
               Keep important support conversations in one place.
             </h1>
             <p className="mt-6 max-w-2xl text-xl leading-8 text-gray-600 dark:text-gray-300">
-              Import a WhatsApp chat you choose and preserve its messages,
-              participants, and timestamps in a focused workspace.
+              Import a WhatsApp chat by text export or browser extension and
+              preserve its messages, participants, and timestamps in a focused
+              workspace.
             </p>
             <div className="mt-9 flex flex-col gap-4 sm:flex-row">
               <Link
@@ -114,8 +115,9 @@ export default function LandingPage() {
               ))}
             </ol>
             <p className="mt-6 text-sm leading-6 text-gray-500 dark:text-gray-400">
-              The preview currently supports WhatsApp text exports without
-              media. Use only conversations you are authorized to upload.
+              Start with a WhatsApp text export or the private-preview browser
+              extension. Additional import paths are planned as the preview
+              expands.
             </p>
           </div>
         </div>

--- a/apps/web/src/components/layouts/footer/index.tsx
+++ b/apps/web/src/components/layouts/footer/index.tsx
@@ -20,8 +20,8 @@ export function Footer() {
               Preserve the WhatsApp support conversation you need to review.
             </p>
             <p className="mt-4 max-w-2xl text-sm leading-6 text-gray-500 dark:text-gray-500">
-              The private preview currently supports authenticated WhatsApp text
-              imports without media.
+              Import by WhatsApp text export or browser extension. Additional
+              import paths are planned as the private preview expands.
             </p>
             <p className="mt-5 inline-flex rounded-full border border-green-200 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-green-700 dark:border-green-800 dark:text-green-300">
               Private preview

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -2,29 +2,43 @@ import fs from "node:fs";
 import path from "node:path";
 
 const appRoot = path.resolve(__dirname, "../..");
+const repoRoot = path.resolve(appRoot, "../../..");
 
 const read = (relativePath: string) =>
   fs.readFileSync(path.join(appRoot, relativePath), "utf8");
+const readRepo = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
 
 describe("external surface containment", () => {
   it("keeps internal strategy and unshipped platform names out of public copy", () => {
-    const publicCopy = [
+    const externalCopy = [
       "app/landing-page.tsx",
       "app/features/page.tsx",
       "components/layouts/footer/index.tsx",
       "app/layout.tsx",
       "app/login/page.tsx",
+      "app/dashboard/page.tsx",
+      "app/dashboard/import/page.tsx",
     ]
       .map(read)
+      .concat([
+        readRepo("apps/chrome-extension/manifest.json"),
+        readRepo("apps/chrome-extension/popup/popup.html"),
+      ])
       .join("\n");
 
-    expect(publicCopy).not.toMatch(
-      /\b(?:moat|operating loop|NeuralLiquid stack|Codeflow|Cognitive Mesh|OmniPost|governed responses?)\b/i,
+    expect(externalCopy).not.toMatch(
+      /\b(?:alpha|moat|operating loop|NeuralLiquid stack|Codeflow|Cognitive Mesh|OmniPost|governed responses?)\b/i,
     );
-    expect(publicCopy).not.toMatch(/defensible asset/i);
+    expect(externalCopy).not.toMatch(
+      /(?:defensible asset|sample activity|demo records?)/i,
+    );
     expect(read("app/login/page.tsx")).not.toMatch(
       /(?:browser extension|ConvoLens Alpha|alpha team|new to the alpha)/i,
     );
+    expect(read("app/dashboard/import/page.tsx")).toMatch(/text export/i);
+    expect(read("app/dashboard/import/page.tsx")).toMatch(/browser extension/i);
+    expect(read("app/dashboard/import/page.tsx")).toMatch(/planned/i);
   });
 
   it("does not ship the developer theme-test route", () => {


### PR DESCRIPTION
## Outcome

- removes remaining Alpha/defensive wording from authenticated dashboard, import flow, and Chrome extension
- presents the two current import paths (text export and browser extension) and planned expansion across marketing surfaces
- expands external-copy regression coverage to authenticated pages and extension UI
- fixes Windows CRLF, system-message, and AM/PM parsing
- rejects uploads when zero WhatsApp messages can be parsed
- renames the synthetic acceptance fixture so its filename does not leak stale positioning into production records

## Production finding

Authenticated acceptance on revision `nl-prod-convolens-api--0000030` uploaded the prior CRLF fixture as intake `ff9f3b04-ff74-4ec0-9d8d-baaedde589e9`, but the record contained 0 messages and no participants. The server response confirmed `messageCount: 0`. Local reproduction traced this to `split('\n')` leaving carriage returns that the parser regex skipped.

## Validation

- external-surface Jest contract: 4/4
- direct parser assertions: CRLF fixture 2 messages / 2 participants; system message preserved; noon and PM hours correct
- web production build: passed, 23 routes
- API production build: passed
- Chrome extension typecheck/build: passed
- targeted web ESLint: passed
- source scan: no Alpha/internal-strategy/defensive-demo wording across web app and extension
- `git diff --check`: passed

Known repo tooling baseline: API ESLint references an unavailable `import/order` rule and excludes API test files from its configured TS project. The normal GitHub CI remains the authoritative full harness.
