### PR TITLE
Reject WhatsApp exports with empty senders

### DIFF
--- a/apps/api/src/services/__tests__/chat-export.service.test.ts
+++ b/apps/api/src/services/__tests__/chat-export.service.test.ts
@@ -46,6 +46,7 @@ describe('ChatExportService', () => {
 This is not a valid line
 [Invalid Date Format] John Doe: This line will be skipped
 [08/01/2023, 10:30:00] : Message with missing sender
+[08/01/2023, 10:31:00]    : Message with a whitespace-only sender
       `;
 
       const result = await parseWhatsAppExport(chatContent);

--- a/apps/api/src/services/chat-export.service.ts
+++ b/apps/api/src/services/chat-export.service.ts
@@ -53,6 +53,14 @@ export async function parseWhatsAppExport(fileContent: string): Promise<ChatExpo
         continue;
       }
 
+      // A timestamp followed by an empty sender ("... ] : message") also
+      // matches the broader system-message format. Keep it malformed instead
+      // of persisting it as a message from System.
+      if (systemMatch?.[4].trimStart().startsWith(':')) {
+        logger.warn(`Skipping malformed line with empty sender: ${line}`);
+        continue;
+      }
+
       try {
         const dateStr = (messageMatch || systemMatch)![1];
         const timeStr = (messageMatch || systemMatch)![2];


### PR DESCRIPTION
## Summary
- reject timestamped export lines whose sender is blank instead of treating them as system events
- extend the malformed-line regression fixture for empty and whitespace-only senders
- follow up the actionable automated review on #127

## Validation
- pnpm --dir apps/api exec jest src/services/__tests__/chat-export.service.test.ts --runInBand (6/6 passed)
- pnpm --dir apps/api run build
- git diff --check