### PR TITLE
Fix extension WhatsApp connection status

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "ConvoLens Chrome Extension for WhatsApp Web",
   "scripts": {

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -73,7 +73,12 @@ async function checkWhatsAppStatus() {
         action: "CHECK_STATUS",
       });
 
-      if (response.isWhatsAppWeb && response.isLoggedIn) {
+      // The TypeScript content script wraps status payloads in the shared
+      // ExtensionResponse shape. Keep the legacy fallback for older builds
+      // that returned these fields at the top level.
+      const connectionStatus = response.data || response;
+
+      if (connectionStatus.isWhatsAppWeb && connectionStatus.isLoggedIn) {
         statusDot.classList.add("connected");
         statusText.textContent = "Connected to WhatsApp Web";
       } else {

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -62,6 +62,15 @@ describe("external surface containment", () => {
     );
   });
 
+  it("reads the wrapped WhatsApp connection status returned by the extension", () => {
+    const popupRuntime = readRepo("apps/chrome-extension/popup/popup.js");
+
+    expect(popupRuntime).toMatch(/const connectionStatus = response\.data \|\| response/);
+    expect(popupRuntime).toMatch(
+      /connectionStatus\.isWhatsAppWeb && connectionStatus\.isLoggedIn/,
+    );
+  });
+
   it("keeps preview navigation limited to implemented workflows", () => {
     const navigation = [
       "components/layouts/navigation/hooks/useNavigation.ts",


### PR DESCRIPTION
## Summary
- read CHECK_STATUS from the shared wrapped response shape
- retain compatibility with legacy top-level status responses
- bump the unpacked extension to 1.0.1
- add regression coverage for the popup/content-script contract

## Validation
- extension typecheck and production build passed
- extension package created successfully
- external-surface contract tests: 6/6 passed
- targeted ESLint: clean
- git diff --check