### PR TITLE
Repair production typography and compact navigation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,6 +7,7 @@
 
 @layer base {
   :root {
+    --font-sans: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
@@ -59,6 +60,37 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 262 83% 58%;
+  }
+
+  html {
+    font-family: var(--font-sans);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    min-width: 320px;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    letter-spacing: -0.025em;
+    line-height: 1.15;
   }
 }
 

--- a/apps/web/src/components/layouts/navigation/navigation.module.css
+++ b/apps/web/src/components/layouts/navigation/navigation.module.css
@@ -59,6 +59,7 @@
   color: inherit;
   text-decoration: none;
   transition: opacity 0.2s;
+  white-space: nowrap;
 }
 
 .logoLink:hover {
@@ -92,6 +93,7 @@
   text-decoration: none;
   transition: all 0.2s;
   margin-right: 0.25rem;
+  white-space: nowrap;
 }
 
 .navLink:hover {
@@ -490,7 +492,7 @@
 /* Responsive */
 @media (min-width: 768px) {
   .mobileMenuButton {
-    display: none;
+    display: none !important;
   }
 
   .desktopNav {
@@ -504,6 +506,29 @@
 
   .searchModal {
     padding-top: 8rem;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .container {
+    padding: 0 0.75rem;
+  }
+
+  .logo {
+    margin-right: 0.75rem;
+  }
+
+  .navLink {
+    padding: 0.5rem 0.625rem;
+    font-size: 0.875rem;
+  }
+
+  .navIcon {
+    display: none;
+  }
+
+  .userName {
+    max-width: 6rem;
   }
 }
 

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -71,6 +71,21 @@ describe("external surface containment", () => {
     );
   });
 
+  it("uses explicit production typography and non-wrapping desktop navigation", () => {
+    const globalStyles = read("app/globals.css");
+    const navigationStyles = read(
+      "components/layouts/navigation/navigation.module.css",
+    );
+
+    expect(globalStyles).toMatch(/--font-sans:\s*"Segoe UI", Roboto/);
+    expect(globalStyles).toMatch(/body\s*{[^}]*font-family:\s*var\(--font-sans\)/s);
+    expect(globalStyles).toMatch(/button,[\s\S]*textarea\s*{\s*font:\s*inherit/);
+    expect(navigationStyles).toMatch(/\.navLink\s*{[^}]*white-space:\s*nowrap/s);
+    expect(navigationStyles).toMatch(
+      /\.mobileMenuButton\s*{\s*display:\s*none\s*!important/,
+    );
+  });
+
   it("keeps preview navigation limited to implemented workflows", () => {
     const navigation = [
       "components/layouts/navigation/hooks/useNavigation.ts",


### PR DESCRIPTION
## Summary
- define an explicit Segoe UI production font stack instead of relying on browser defaults
- inherit typography into controls and normalize body/heading metrics
- prevent desktop labels from wrapping
- remove the duplicate desktop hamburger caused by utility/CSS ordering
- compact navigation at narrow desktop widths
- add regression coverage for the typography and navigation contract

## Validation
- external-surface tests: 7/7 passed
- web production build: 24 routes
- targeted ESLint: clean
- 945x1000 browser check: Segoe UI computed, 16/24 body metrics, hamburger hidden
- git diff --check