### PR TITLE
Use predictable web-safe typography

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,7 +7,7 @@
 
 @layer base {
   :root {
-    --font-sans: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --font-sans: Arial, Helvetica, sans-serif;
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -77,7 +77,7 @@ describe("external surface containment", () => {
       "components/layouts/navigation/navigation.module.css",
     );
 
-    expect(globalStyles).toMatch(/--font-sans:\s*"Segoe UI", Roboto/);
+    expect(globalStyles).toMatch(/--font-sans:\s*Arial, Helvetica/);
     expect(globalStyles).toMatch(/body\s*{[^}]*font-family:\s*var\(--font-sans\)/s);
     expect(globalStyles).toMatch(/button,[\s\S]*textarea\s*{\s*font:\s*inherit/);
     expect(navigationStyles).toMatch(/\.navLink\s*{[^}]*white-space:\s*nowrap/s);


### PR DESCRIPTION
## Summary
- make Arial/Helvetica the explicit production font stack
- avoid the stylized Segoe rendering observed in the live Windows browser
- retain the global metrics and responsive navigation repair from #131

## Validation
- external-surface tests: 7/7 passed
- web production build: 24 routes
- live browser A/B at 945x1000 confirmed the web-safe stack is clearer
- git diff --check