### PR TITLE
Align external and import page layouts

### DIFF
--- a/apps/web/src/app/dashboard/import/page.tsx
+++ b/apps/web/src/app/dashboard/import/page.tsx
@@ -40,7 +40,7 @@ export default function ImportChatPage() {
   });
 
   return (
-    <div className="container py-8">
+    <div className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-2">Import Chat</h1>
         <p className="text-muted-foreground mb-8">

--- a/apps/web/src/app/extension-welcome/page.tsx
+++ b/apps/web/src/app/extension-welcome/page.tsx
@@ -30,7 +30,7 @@ const steps = [
 export default function ExtensionWelcomePage() {
   return (
     <PageWrapper>
-      <main className="container py-12 sm:py-16">
+      <main className="py-4 sm:py-8">
         <div className="mx-auto max-w-5xl">
           <section className="max-w-3xl">
             <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 text-primary">

--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -34,7 +34,7 @@ const features = [
 export default function FeaturesPage() {
   return (
     <PageWrapper>
-      <section className="container py-12">
+      <section className="py-4 sm:py-8">
         <div className="mx-auto max-w-5xl">
           <div className="max-w-3xl">
             <p className="text-sm font-semibold uppercase tracking-[0.18em] text-primary">

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 export default function NotFound() {
   return (
     <PageWrapper>
-      <main className="container flex min-h-[70vh] items-center py-16">
+      <main className="flex min-h-[70vh] items-center py-8 sm:py-16">
         <section className="mx-auto max-w-2xl text-center">
           <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
             <Compass className="h-8 w-8" />

--- a/apps/web/src/app/page-wrapper.tsx
+++ b/apps/web/src/app/page-wrapper.tsx
@@ -15,7 +15,7 @@ export default function PageWrapper({ children }: PageWrapperProps) {
         <div className="vector-shape vector-triangle"></div>
         <div className="vector-shape vector-hexagon"></div>
       </div>
-      <div className="section-container">
+      <div className="relative z-[1] mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </div>
     </div>

--- a/apps/web/src/components/layouts/navigation/navigation.module.css
+++ b/apps/web/src/components/layouts/navigation/navigation.module.css
@@ -38,10 +38,10 @@
   align-items: center;
   justify-content: space-between;
   height: 100%;
-  max-width: 100%;
+  max-width: 80rem;
   width: 100%;
   margin: 0 auto;
-  padding: 0 1.5rem;
+  padding: 0 1rem;
 }
 
 /* Logo */
@@ -490,6 +490,12 @@
 }
 
 /* Responsive */
+@media (min-width: 640px) {
+  .container {
+    padding: 0 1.5rem;
+  }
+}
+
 @media (min-width: 768px) {
   .mobileMenuButton {
     display: none !important;
@@ -510,10 +516,6 @@
 }
 
 @media (min-width: 768px) and (max-width: 1023px) {
-  .container {
-    padding: 0 0.75rem;
-  }
-
   .logo {
     margin-right: 0.75rem;
   }
@@ -529,6 +531,12 @@
 
   .userName {
     max-width: 6rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    padding: 0 2rem;
   }
 }
 

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -10,6 +10,25 @@ const readRepo = (relativePath: string) =>
   fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
 
 describe("external surface containment", () => {
+  it("keeps public, authenticated import, and navigation content on one responsive grid", () => {
+    expect(read("app/page-wrapper.tsx")).toContain(
+      "mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8",
+    );
+    expect(read("app/dashboard/import/page.tsx")).toContain(
+      "mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8",
+    );
+
+    const navigationStyles = read(
+      "components/layouts/navigation/navigation.module.css",
+    );
+    expect(navigationStyles).toContain("max-width: 80rem");
+    expect(navigationStyles).toContain("padding: 0 1rem");
+    expect(navigationStyles).toMatch(
+      /@media \(min-width: 640px\) \{\s+\.container \{\s+padding: 0 1\.5rem/,
+    );
+    expect(navigationStyles).toContain("padding: 0 2rem");
+  });
+
   it("keeps internal strategy and unshipped platform names out of public copy", () => {
     const externalCopy = [
       "app/landing-page.tsx",


### PR DESCRIPTION
## Summary
- replace the legacy nested page wrapper with the same centered 1280px responsive shell used by the footer
- align navigation gutters to the shared 16/24/32px grid
- center the authenticated import flow and remove duplicate public-page containers
- add a regression check for the shared layout contract

## Validation
- pnpm --filter @convolens/web exec jest --config=jest.config.js --runInBand src/lib/__tests__/external-surface.test.ts`n- pnpm --filter @convolens/web exec eslint on changed TS/TSX files
- pnpm --filter @convolens/web build`n- git diff --check`n- local Chrome renders at 945x900 and 375x812

Repo-wide lint remains blocked by 22 pre-existing errors in unrelated legacy files.