### PR TITLE
Fix WhatsApp message-list detection

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
+  "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",
   "scripts": {
     "build": "npm run typecheck && node scripts/build-extension.mjs",
@@ -10,6 +11,7 @@
     "copy-assets": "node -e \"const fs=require('fs');const p=require('path');try{fs.mkdirSync('dist',{recursive:true});fs.readdirSync('src').filter(f=>f.endsWith('.css')).forEach(f=>fs.copyFileSync(p.join('src',f),p.join('dist',f)))}catch(e){}\"",
     "package": "npm run build:prod && node scripts/package-extension.mjs",
     "clean": "rm -rf dist",
+    "test": "tsx --test tests/dom-selectors.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
@@ -18,6 +20,7 @@
     "@types/chrome": "^0.0.260",
     "archiver": "^8.0.0",
     "esbuild": "^0.27.7",
+    "tsx": "^4.7.0",
     "typescript": "^5.3.0"
   }
 }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -24,6 +24,11 @@ import {
   type SetAuthTokenMessage,
   type CheckStatusData,
 } from "./config";
+import {
+  findConversationRoot,
+  findMessageContainers,
+  findMessageText,
+} from "./dom-selectors";
 
 // =============================================================================
 // Types
@@ -371,7 +376,8 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
   const isGroup = detectGroupChat();
 
   // Get message container
-  const messageList = querySelector(
+  const messageList = findConversationRoot(
+    document,
     SELECTORS.primary.messageList,
     SELECTORS.fallback.messageList,
   );
@@ -383,8 +389,10 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
   // await scrollToLoadMessages(messageList);
 
   // Extract messages
-  const messageContainers = messageList.querySelectorAll(
-    `${SELECTORS.primary.messageContainer}, ${SELECTORS.fallback.messageContainer}`,
+  const messageContainers = findMessageContainers(
+    messageList,
+    SELECTORS.primary.messageContainer,
+    SELECTORS.fallback.messageContainer,
   );
 
   const messages: ExtractedMessage[] = [];
@@ -436,9 +444,11 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
  */
 function extractMessageData(container: HTMLElement): ExtractedMessage | null {
   // Get message text
-  const textEl =
-    container.querySelector(SELECTORS.primary.messageText) ||
-    container.querySelector(SELECTORS.fallback.messageText);
+  const textEl = findMessageText(
+    container,
+    SELECTORS.primary.messageText,
+    SELECTORS.fallback.messageText,
+  );
 
   const text = textEl?.textContent?.trim() || "";
 

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -1,0 +1,78 @@
+export const MESSAGE_CONTAINER_SELECTOR =
+  '[data-testid="msg-container"], .message-in, .message-out';
+
+export const MESSAGE_TEXT_SELECTOR =
+  '[data-testid="msg-text"], .selectable-text.copyable-text[dir], .selectable-text[dir]';
+
+/**
+ * Return the active conversation body without depending on WhatsApp's
+ * frequently renamed scrolling wrapper.
+ */
+export function findConversationRoot(
+  documentRoot: ParentNode,
+  primarySelector: string,
+  fallbackSelector: string,
+): Element | null {
+  const configuredRoot =
+    documentRoot.querySelector(primarySelector) ||
+    documentRoot.querySelector(fallbackSelector);
+
+  if (configuredRoot) return configuredRoot;
+
+  const activeConversation = documentRoot.querySelector("#main");
+  if (
+    activeConversation?.querySelector(MESSAGE_CONTAINER_SELECTOR) ||
+    activeConversation?.querySelector(MESSAGE_TEXT_SELECTOR)
+  ) {
+    return activeConversation;
+  }
+
+  return null;
+}
+
+/**
+ * Prefer message bubbles, but recover from class churn by walking from stable
+ * selectable message text to its nearest message record.
+ */
+export function findMessageContainers(
+  root: Element,
+  primarySelector: string,
+  fallbackSelector: string,
+): HTMLElement[] {
+  const directMatches = Array.from(
+    root.querySelectorAll(`${primarySelector}, ${fallbackSelector}`),
+  ) as HTMLElement[];
+
+  if (directMatches.length > 0) return directMatches;
+
+  const containers = new Set<HTMLElement>();
+  const textNodes = root.querySelectorAll(MESSAGE_TEXT_SELECTOR);
+
+  for (const textNode of textNodes) {
+    const container = textNode.closest(
+      '[data-id], [role="row"], .message-in, .message-out',
+    ) as HTMLElement | null;
+
+    if (container && (!root.contains || root.contains(container))) {
+      containers.add(container);
+    }
+  }
+
+  return Array.from(containers);
+}
+
+export function findMessageText(
+  container: Element,
+  primarySelector: string,
+  fallbackSelector: string,
+): Element | null {
+  const selectors = `${primarySelector}, ${fallbackSelector}, ${MESSAGE_TEXT_SELECTOR}`;
+
+  if (container.matches?.(selectors)) return container;
+
+  return (
+    container.querySelector(primarySelector) ||
+    container.querySelector(fallbackSelector) ||
+    container.querySelector(MESSAGE_TEXT_SELECTOR)
+  );
+}

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findConversationRoot,
+  findMessageContainers,
+  findMessageText,
+  MESSAGE_TEXT_SELECTOR,
+} from "../src/dom-selectors.ts";
+
+test("falls back to the active #main conversation when WhatsApp removes its message-list wrapper", () => {
+  const message = {};
+  const main = {
+    querySelector: (selector: string) =>
+      selector.includes("selectable-text") ? message : null,
+  };
+  const documentRoot = {
+    querySelector: (selector: string) => (selector === "#main" ? main : null),
+  };
+
+  assert.equal(
+    findConversationRoot(
+      documentRoot as unknown as ParentNode,
+      '[data-testid="conversation-panel-messages"]',
+      ".message-list",
+    ),
+    main,
+  );
+});
+
+test("derives unique message records from selectable text when bubble selectors change", () => {
+  const firstContainer = {};
+  const secondContainer = {};
+  const textNodes = [
+    { closest: () => firstContainer },
+    { closest: () => firstContainer },
+    { closest: () => secondContainer },
+  ];
+  const root = {
+    querySelectorAll: (selector: string) =>
+      selector.includes("selectable-text") ? textNodes : [],
+    contains: () => true,
+  };
+
+  assert.deepEqual(
+    findMessageContainers(
+      root as unknown as Element,
+      '[data-testid="msg-container"]',
+      ".message-in, .message-out",
+    ),
+    [firstContainer, secondContainer],
+  );
+});
+
+test("reads text through the generic selector used for container discovery", () => {
+  const genericText = { textContent: "Current WhatsApp message" };
+  const container = {
+    matches: () => false,
+    querySelector: (selector: string) =>
+      selector === MESSAGE_TEXT_SELECTOR ? genericText : null,
+  };
+
+  assert.equal(
+    findMessageText(
+      container as unknown as Element,
+      '[data-testid="msg-text"]',
+      ".selectable-text.copyable-text[dir]",
+    ),
+    genericText,
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       esbuild:
         specifier: ^0.27.7
         version: 0.27.7
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.3
       typescript:
         specifier: ^5.3.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- stop requiring WhatsApp's removed conversation message-list wrapper
- safely fall back to the active main conversation and selectable message text
- add deterministic coverage for wrapper removal and bubble-class churn
- bump the unpacked extension to 1.0.2

## Validation
- extension DOM tests
- extension typecheck
- production extension package
- ZIP manifest/resources and compiled fallback verified
- diff check