### PR TITLE
Fix extension receiver after reload

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -88,7 +88,7 @@ async function checkWhatsAppStatus() {
       statusText.textContent = "Open WhatsApp Web to start";
     }
   } catch (error) {
-    statusText.textContent = "Open WhatsApp Web to start";
+    statusText.textContent = "Extension is reconnecting — refresh WhatsApp Web";
   }
 }
 
@@ -179,9 +179,14 @@ extractBtn.addEventListener("click", async () => {
       );
     }
   } catch (error) {
+    const receiverUnavailable = error?.message?.includes(
+      "Receiving end does not exist",
+    );
     setActionStatus(
-      error?.message ||
-        "The extension could not read this chat. Please try again.",
+      receiverUnavailable
+        ? "Refresh WhatsApp Web once, then reopen the chat."
+        : error?.message ||
+            "The extension could not read this chat. Please try again.",
       "error",
     );
   } finally {

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -47,7 +47,8 @@ export const SELECTORS = {
   },
   // Fallback selectors (class-based - less stable)
   fallback: {
-    chatList: '.copyable-area [role="listitem"]',
+    chatList:
+      '#pane-side, [aria-label="Chat list"], .copyable-area [role="listitem"]',
     messageList: ".message-list",
     messageContainer: ".message-in, .message-out",
     messageText: ".selectable-text.copyable-text[dir]",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -99,6 +99,13 @@ async function init(): Promise<void> {
     return;
   }
 
+  // Register the receiver before waiting on WhatsApp's frequently changing
+  // DOM. The popup must be able to query status immediately after an extension
+  // reload, even while the page UI is still settling.
+  chrome.runtime.onMessage.addListener(handleMessage);
+  isInitialized = true;
+  window.addEventListener("beforeunload", cleanup);
+
   // Wait for WhatsApp to fully load
   await waitForWhatsAppReady();
 
@@ -113,17 +120,8 @@ async function init(): Promise<void> {
   // Inject UI elements
   injectUI();
 
-  // Set up message listener (only once)
-  chrome.runtime.onMessage.addListener(handleMessage);
-
   // Observe chat navigation
   observeChatChanges();
-
-  // Mark as initialized
-  isInitialized = true;
-
-  // Set up cleanup on page unload
-  window.addEventListener("beforeunload", cleanup);
 
   console.log("[ConvoLens] Content script initialized successfully");
 }
@@ -136,6 +134,7 @@ function cleanup(): void {
     chatObserver.disconnect();
     chatObserver = null;
   }
+  chrome.runtime.onMessage.removeListener(handleMessage);
   isInitialized = false;
   console.log("[ConvoLens] Cleanup completed");
 }

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   findConversationRoot,
@@ -6,6 +7,21 @@ import {
   findMessageText,
   MESSAGE_TEXT_SELECTOR,
 } from "../src/dom-selectors.ts";
+
+test("registers the popup receiver before waiting for WhatsApp DOM readiness", () => {
+  const contentSource = readFileSync(
+    new URL("../src/content.ts", import.meta.url),
+    "utf8",
+  );
+  const receiverRegistration = contentSource.indexOf(
+    "chrome.runtime.onMessage.addListener(handleMessage)",
+  );
+  const readinessWait = contentSource.indexOf("await waitForWhatsAppReady()");
+
+  assert.notEqual(receiverRegistration, -1);
+  assert.notEqual(readinessWait, -1);
+  assert.ok(receiverRegistration < readinessWait);
+});
 
 test("falls back to the active #main conversation when WhatsApp removes its message-list wrapper", () => {
   const message = {};


### PR DESCRIPTION
## Summary
- register the content-script message receiver before waiting for WhatsApp DOM readiness
- recognize the current WhatsApp side pane as a loaded workspace
- replace the misleading disconnected status with actionable refresh guidance
- bump the unpacked extension to 1.0.3

## Validation
- extension DOM/startup tests: 4 passing
- extension typecheck
- production extension package
- diff check