### PR TITLE
Recover missing WhatsApp extension receiver

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {
@@ -11,7 +11,13 @@
     "128": "icons/icon-128.png"
   },
 
-  "permissions": ["storage", "activeTab", "alarms", "notifications"],
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting",
+    "alarms",
+    "notifications"
+  ],
 
   "host_permissions": [
     "https://web.whatsapp.com/*",

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",
@@ -11,7 +11,7 @@
     "copy-assets": "node -e \"const fs=require('fs');const p=require('path');try{fs.mkdirSync('dist',{recursive:true});fs.readdirSync('src').filter(f=>f.endsWith('.css')).forEach(f=>fs.copyFileSync(p.join('src',f),p.join('dist',f)))}catch(e){}\"",
     "package": "npm run build:prod && node scripts/package-extension.mjs",
     "clean": "rm -rf dist",
-    "test": "tsx --test tests/dom-selectors.test.ts",
+    "test": "tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -27,6 +27,46 @@ function setActionStatus(message = "", type = "info") {
     : "action-status";
 }
 
+function isWhatsAppTab(tab) {
+  return tab?.url?.startsWith("https://web.whatsapp.com/");
+}
+
+async function getWhatsAppTab() {
+  const [activeTab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+
+  if (isWhatsAppTab(activeTab)) return activeTab;
+
+  const whatsappTabs = await chrome.tabs.query({
+    url: "https://web.whatsapp.com/*",
+  });
+  return whatsappTabs.find((tab) => !tab.discarded) || whatsappTabs[0];
+}
+
+async function sendToWhatsApp(tabId, message) {
+  try {
+    return await chrome.tabs.sendMessage(tabId, message);
+  } catch (error) {
+    if (!error?.message?.includes("Receiving end does not exist")) throw error;
+
+    // Declarative content scripts are not reattached to an already-open tab
+    // when an unpacked extension is reloaded. Inject the verified bundle once
+    // and retry so the operator does not need to chase Chrome lifecycle state.
+    await chrome.scripting.insertCSS({
+      target: { tabId },
+      files: ["dist/content.css"],
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["dist/content.js"],
+    });
+
+    return chrome.tabs.sendMessage(tabId, message);
+  }
+}
+
 // Initialize popup
 async function init() {
   // Check auth status
@@ -66,10 +106,10 @@ function showLoggedOut() {
 // Check WhatsApp Web status
 async function checkWhatsAppStatus() {
   try {
-    const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
+    const tab = await getWhatsAppTab();
 
-    if (tabs.length > 0) {
-      const response = await chrome.tabs.sendMessage(tabs[0].id, {
+    if (tab?.id) {
+      const response = await sendToWhatsApp(tab.id, {
         action: "CHECK_STATUS",
       });
 
@@ -134,9 +174,9 @@ extractBtn.addEventListener("click", async () => {
   setActionStatus("");
 
   try {
-    const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
+    const tab = await getWhatsAppTab();
 
-    if (tabs.length === 0) {
+    if (!tab?.id) {
       setActionStatus("Open WhatsApp Web and select a chat first.", "error");
       return;
     }
@@ -144,7 +184,7 @@ extractBtn.addEventListener("click", async () => {
     extractBtn.textContent = "Reading chat…";
     extractBtn.disabled = true;
 
-    const response = await chrome.tabs.sendMessage(tabs[0].id, {
+    const response = await sendToWhatsApp(tab.id, {
       action: "GET_CURRENT_CHAT",
     });
 

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const popupSource = readFileSync(
+  new URL("../popup/popup.js", import.meta.url),
+  "utf8",
+);
+const manifest = JSON.parse(
+  readFileSync(new URL("../manifest.json", import.meta.url), "utf8"),
+);
+
+test("targets the active WhatsApp tab before searching background tabs", () => {
+  const activeQuery = popupSource.indexOf("active: true");
+  const urlQuery = popupSource.indexOf('url: "https://web.whatsapp.com/*"');
+
+  assert.notEqual(activeQuery, -1);
+  assert.notEqual(urlQuery, -1);
+  assert.ok(activeQuery < urlQuery);
+});
+
+test("self-heals a missing content-script receiver and retries the message", () => {
+  assert.ok(manifest.permissions.includes("scripting"));
+  assert.match(popupSource, /chrome\.scripting\.insertCSS/);
+  assert.match(popupSource, /chrome\.scripting\.executeScript/);
+
+  const receiverError = popupSource.indexOf("Receiving end does not exist");
+  const injection = popupSource.indexOf("chrome.scripting.executeScript");
+  const retry = popupSource.lastIndexOf("chrome.tabs.sendMessage");
+
+  assert.ok(receiverError < injection);
+  assert.ok(injection < retry);
+});


### PR DESCRIPTION
## Summary
- target the active WhatsApp tab before background tabs
- inject the verified content bundle when Chrome reports no receiver, then retry automatically
- add the scripting permission and startup regression coverage
- bump the unpacked extension to 1.0.4

## Validation
- extension tests: 6 passing
- extension typecheck
- production extension package
- packaged active-tab injection and manifest permission verified
- diff check