### PR TITLE
feat: show extension version in popup

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -248,10 +248,26 @@
 
       .footer {
         padding: 12px 20px;
-        text-align: center;
         font-size: 11px;
         color: #999;
         border-top: 1px solid #f0f0f0;
+      }
+
+      .footer-primary {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+      }
+
+      .extension-version {
+        color: #777;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .footer-connector {
+        margin-top: 2px;
+        text-align: center;
       }
 
       .footer a {
@@ -330,8 +346,20 @@
     </div>
 
     <div class="footer">
-      <a href="https://convolens.neuralliquid.ai" target="_blank">ConvoLens</a>
-      Preview · WhatsApp is the first connector
+      <div class="footer-primary">
+        <span>
+          <a href="https://convolens.neuralliquid.ai" target="_blank"
+            >ConvoLens</a
+          >
+          Preview
+        </span>
+        <span
+          class="extension-version"
+          id="extensionVersion"
+          aria-label="Extension version"
+        ></span>
+      </div>
+      <div class="footer-connector">WhatsApp is the first connector</div>
     </div>
 
     <script src="popup.js"></script>

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -19,6 +19,9 @@ const userName = document.getElementById("userName");
 const userEmail = document.getElementById("userEmail");
 const userAvatar = document.getElementById("userAvatar");
 const actionStatus = document.getElementById("actionStatus");
+const extensionVersion = document.getElementById("extensionVersion");
+
+extensionVersion.textContent = `v${chrome.runtime.getManifest().version}`;
 
 function setActionStatus(message = "", type = "info") {
   actionStatus.textContent = message;

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -6,9 +6,26 @@ const popupSource = readFileSync(
   new URL("../popup/popup.js", import.meta.url),
   "utf8",
 );
+const popupHtml = readFileSync(
+  new URL("../popup/popup.html", import.meta.url),
+  "utf8",
+);
 const manifest = JSON.parse(
   readFileSync(new URL("../manifest.json", import.meta.url), "utf8"),
 );
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+test("renders the runtime manifest version and keeps release versions aligned", () => {
+  assert.match(popupHtml, /id="extensionVersion"/);
+  assert.match(
+    popupSource,
+    /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
+  );
+  assert.equal(manifest.version, packageJson.version);
+  assert.equal(manifest.version, "1.0.5");
+});
 
 test("targets the active WhatsApp tab before searching background tabs", () => {
   const activeQuery = popupSource.indexOf("active: true");


### PR DESCRIPTION
## Summary

- show the running Chrome extension version in the popup footer
- derive the label from `chrome.runtime.getManifest().version`
- bump and enforce aligned package and manifest versions at `1.0.5`

## Why

Operators need screenshots and support reports to identify the exact unpacked build without opening `chrome://extensions`.

## Validation

- extension tests: 7/7 passed
- TypeScript typecheck passed
- Prettier check passed
- production extension build and ZIP packaging passed
- packaged manifest inspected at version `1.0.5`
