### PR TITLE
Add conversation deletion and version visibility

### DIFF
--- a/apps/api/docs/openapi.yaml
+++ b/apps/api/docs/openapi.yaml
@@ -224,6 +224,27 @@ paths:
                         $ref: '#/components/schemas/ConversationDetail'
         '404':
           description: Conversation not found for this user
+    delete:
+      summary: Delete a stored conversation intake
+      description: Permanently delete one conversation and its messages for the signed-in owner
+      tags:
+        - Chat Export
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Conversation deleted
+        '401':
+          description: Not authenticated
+        '404':
+          description: Conversation not found for this user
 
   /api/chat-export/upload:
     post:

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -369,4 +369,28 @@ router.get('/:id', authenticateToken, async (req, res) => {
   }
 });
 
+/**
+ * @route DELETE /api/chat-export/:id
+ * @description Delete one durable conversation intake owned by the current user
+ * @access Private
+ */
+router.delete('/:id', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const deleted = await conversationIntakeService.deleteForUser(userId, req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    return res.json({ message: 'Conversation deleted' });
+  } catch (error) {
+    logger.error('Error deleting conversation intake:', error);
+    return res.status(500).json({ error: 'Failed to delete conversation' });
+  }
+});
+
 export { router as default };

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -109,6 +109,19 @@ describe('ConversationIntakeService', () => {
     expect(await dataSource.getRepository(ConversationIntake).count()).toBe(2);
   });
 
+  it('deletes only the owning user conversation and cascades its messages', async () => {
+    const owned = await service.save(baseInput);
+    const otherUser = await service.save({ ...baseInput, userId: 'mystira-user-2' });
+
+    expect(await service.deleteForUser('mystira-user-2', owned.conversation.id)).toBe(false);
+    expect(await service.getForUser(baseInput.userId, owned.conversation.id)).not.toBeNull();
+
+    expect(await service.deleteForUser(baseInput.userId, owned.conversation.id)).toBe(true);
+    expect(await service.getForUser(baseInput.userId, owned.conversation.id)).toBeNull();
+    expect(await dataSource.getRepository(ConversationMessage).count()).toBe(2);
+    expect(await service.getForUser('mystira-user-2', otherUser.conversation.id)).not.toBeNull();
+  });
+
   it('excludes generated source IDs from the durable content hash', () => {
     const firstHash = createConversationContentHash(baseInput);
     const secondHash = createConversationContentHash({

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -174,6 +174,11 @@ export class ConversationIntakeService {
       order: { messages: { position: 'ASC' } },
     });
   }
+
+  async deleteForUser(userId: string, id: string): Promise<boolean> {
+    const result = await this.dataSource.getRepository(ConversationIntake).delete({ id, userId });
+    return result.affected === 1;
+  }
 }
 
 export const conversationIntakeService = new ConversationIntakeService();

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -348,7 +348,10 @@
     <div class="footer">
       <div class="footer-primary">
         <span>
-          <a href="https://convolens.neuralliquid.ai" target="_blank"
+          <a
+            href="https://convolens.neuralliquid.ai/dashboard"
+            id="dashboardLink"
+            target="_blank"
             >ConvoLens</a
           >
           Preview

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -20,8 +20,10 @@ const userEmail = document.getElementById("userEmail");
 const userAvatar = document.getElementById("userAvatar");
 const actionStatus = document.getElementById("actionStatus");
 const extensionVersion = document.getElementById("extensionVersion");
+const dashboardLink = document.getElementById("dashboardLink");
 
 extensionVersion.textContent = `v${chrome.runtime.getManifest().version}`;
+dashboardLink.href = `${DASHBOARD_URL}/dashboard`;
 
 function setActionStatus(message = "", type = "info") {
   actionStatus.textContent = message;
@@ -241,7 +243,7 @@ extractBtn.addEventListener("click", async () => {
 });
 
 openDashboard.addEventListener("click", () => {
-  chrome.tabs.create({ url: `${DASHBOARD_URL}/dashboard/import` });
+  chrome.tabs.create({ url: `${DASHBOARD_URL}/dashboard` });
 });
 
 // Initialize

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,19 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.5");
+  assert.equal(manifest.version, "1.0.6");
+});
+
+test("opens the conversation dashboard from both popup entry points", () => {
+  assert.match(popupHtml, /id="dashboardLink"/);
+  assert.match(
+    popupSource,
+    /dashboardLink\.href = `\$\{DASHBOARD_URL\}\/dashboard`/,
+  );
+  assert.match(
+    popupSource,
+    /openDashboard\.addEventListener\("click", \(\) => \{\s+chrome\.tabs\.create\(\{ url: `\$\{DASHBOARD_URL\}\/dashboard` \}\)/,
+  );
 });
 
 test("targets the active WhatsApp tab before searching background tabs", () => {

--- a/apps/web/src/app/api/chat-export/[id]/route.ts
+++ b/apps/web/src/app/api/chat-export/[id]/route.ts
@@ -24,3 +24,25 @@ export async function GET(
     return apiAuthErrorResponse(error);
   }
 }
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const token = await getConvolensApiToken();
+    const { id } = await params;
+    const response = await fetch(
+      `${getConvolensApiBaseUrl()}/api/chat-export/${encodeURIComponent(id)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      },
+    );
+    const payload = await response.json();
+    return Response.json(payload, { status: response.status });
+  } catch (error) {
+    return apiAuthErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/dashboard/conversations/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/conversations/[id]/page.tsx
@@ -9,6 +9,7 @@ import PageWrapper from "../../../page-wrapper";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { StyledCard } from "@/components/ui/styled-card";
+import { DeleteConversationButton } from "@/components/conversations/delete-conversation-button";
 
 interface ConversationMessage {
   id: string;
@@ -101,12 +102,20 @@ export default function ConversationPage() {
             : "Durable conversation intake"
         }
         actions={
-          <Button asChild variant="outline">
-            <Link href="/dashboard">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to dashboard
-            </Link>
-          </Button>
+          <>
+            <Button asChild variant="outline">
+              <Link href="/dashboard">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to dashboard
+              </Link>
+            </Button>
+            {conversation ? (
+              <DeleteConversationButton
+                conversationId={conversation.id}
+                onDeleted={() => router.push("/dashboard")}
+              />
+            ) : null}
+          </>
         }
       />
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ import PageWrapper from "../page-wrapper";
 import { PageHeader } from "@/components/ui/page-header";
 import { Button } from "@/components/ui/button";
 import { StyledCard } from "@/components/ui/styled-card";
+import { DeleteConversationButton } from "@/components/conversations/delete-conversation-button";
 
 const onboardingSteps = [
   {
@@ -194,6 +195,23 @@ export default function DashboardPage() {
                   <MessageSquare className="h-6 w-6" />
                 )
               }
+              footer={
+                <div className="grid w-full gap-2 sm:grid-cols-2">
+                  <Button asChild variant="outline">
+                    <Link href={`/dashboard/conversations/${conversation.id}`}>
+                      View conversation
+                    </Link>
+                  </Button>
+                  <DeleteConversationButton
+                    conversationId={conversation.id}
+                    onDeleted={() =>
+                      setConversations((current) =>
+                        current.filter((item) => item.id !== conversation.id),
+                      )
+                    }
+                  />
+                </div>
+              }
             >
               <p className="text-sm text-muted-foreground">
                 {conversation.messageCount} messages ·{" "}
@@ -205,11 +223,6 @@ export default function DashboardPage() {
               <p className="mt-2 text-xs text-muted-foreground">
                 Received {new Date(conversation.receivedAt).toLocaleString()}
               </p>
-              <Button asChild className="mt-4 w-full" variant="outline">
-                <Link href={`/dashboard/conversations/${conversation.id}`}>
-                  View conversation
-                </Link>
-              </Button>
             </StyledCard>
           ))
         ) : (

--- a/apps/web/src/components/conversations/__tests__/delete-conversation-button.test.tsx
+++ b/apps/web/src/components/conversations/__tests__/delete-conversation-button.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DeleteConversationButton } from "../delete-conversation-button";
+
+describe("DeleteConversationButton", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("requires confirmation before deleting", () => {
+    jest.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <DeleteConversationButton
+        conversationId="conversation-1"
+        onDeleted={jest.fn()}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete conversation" }),
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("deletes through the user-scoped route and reports success", async () => {
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: "Conversation deleted" }),
+    });
+    const onDeleted = jest.fn();
+
+    render(
+      <DeleteConversationButton
+        conversationId="conversation/1"
+        onDeleted={onDeleted}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete conversation" }),
+    );
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledTimes(1));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/chat-export/conversation%2F1",
+      { method: "DELETE" },
+    );
+  });
+
+  it("keeps the conversation visible and shows an API error", async () => {
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Conversation not found" }),
+    });
+    const onDeleted = jest.fn();
+
+    render(
+      <DeleteConversationButton
+        conversationId="missing"
+        onDeleted={onDeleted}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete conversation" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Conversation not found",
+    );
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/conversations/delete-conversation-button.tsx
+++ b/apps/web/src/components/conversations/delete-conversation-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface DeleteConversationButtonProps {
+  conversationId: string;
+  onDeleted: () => void;
+  className?: string;
+}
+
+export function DeleteConversationButton({
+  conversationId,
+  onDeleted,
+  className = "",
+}: DeleteConversationButtonProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string>();
+
+  async function deleteConversation() {
+    const confirmed = window.confirm(
+      "Delete this conversation and all of its stored messages? This cannot be undone.",
+    );
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    setError(undefined);
+
+    try {
+      const response = await fetch(
+        `/api/chat-export/${encodeURIComponent(conversationId)}`,
+        { method: "DELETE" },
+      );
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || "Failed to delete conversation");
+      }
+      onDeleted();
+    } catch (reason) {
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : "Failed to delete conversation",
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className={className}>
+      <Button
+        type="button"
+        className="w-full"
+        variant="destructive"
+        disabled={isDeleting}
+        onClick={deleteConversation}
+      >
+        <Trash2 className="mr-2 h-4 w-4" />
+        {isDeleting ? "Deleting…" : "Delete conversation"}
+      </Button>
+      {error ? (
+        <p className="mt-2 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/layouts/footer/index.tsx
+++ b/apps/web/src/components/layouts/footer/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import webPackage from "../../../../package.json";
 
 export function Footer() {
   return (
@@ -70,9 +71,12 @@ export function Footer() {
         </div>
 
         <div className="mt-12 flex flex-col items-center justify-between border-t border-gray-200 pt-8 dark:border-gray-700 md:flex-row">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            &copy; {new Date().getFullYear()} ConvoLens. All rights reserved.
-          </p>
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            <p>
+              &copy; {new Date().getFullYear()} ConvoLens. All rights reserved.
+            </p>
+            <p className="mt-1 text-xs">App v{webPackage.version}</p>
+          </div>
           <p className="mt-4 text-sm text-gray-500 dark:text-gray-400 md:mt-0">
             Use only conversations you are authorized to upload.
           </p>

--- a/apps/web/src/lib/__tests__/external-surface.test.ts
+++ b/apps/web/src/lib/__tests__/external-surface.test.ts
@@ -84,7 +84,9 @@ describe("external surface containment", () => {
   it("reads the wrapped WhatsApp connection status returned by the extension", () => {
     const popupRuntime = readRepo("apps/chrome-extension/popup/popup.js");
 
-    expect(popupRuntime).toMatch(/const connectionStatus = response\.data \|\| response/);
+    expect(popupRuntime).toMatch(
+      /const connectionStatus = response\.data \|\| response/,
+    );
     expect(popupRuntime).toMatch(
       /connectionStatus\.isWhatsAppWeb && connectionStatus\.isLoggedIn/,
     );
@@ -97,9 +99,15 @@ describe("external surface containment", () => {
     );
 
     expect(globalStyles).toMatch(/--font-sans:\s*Arial, Helvetica/);
-    expect(globalStyles).toMatch(/body\s*{[^}]*font-family:\s*var\(--font-sans\)/s);
-    expect(globalStyles).toMatch(/button,[\s\S]*textarea\s*{\s*font:\s*inherit/);
-    expect(navigationStyles).toMatch(/\.navLink\s*{[^}]*white-space:\s*nowrap/s);
+    expect(globalStyles).toMatch(
+      /body\s*{[^}]*font-family:\s*var\(--font-sans\)/s,
+    );
+    expect(globalStyles).toMatch(
+      /button,[\s\S]*textarea\s*{\s*font:\s*inherit/,
+    );
+    expect(navigationStyles).toMatch(
+      /\.navLink\s*{[^}]*white-space:\s*nowrap/s,
+    );
     expect(navigationStyles).toMatch(
       /\.mobileMenuButton\s*{\s*display:\s*none\s*!important/,
     );
@@ -116,6 +124,15 @@ describe("external surface containment", () => {
     expect(navigation).not.toMatch(
       /(?:\/groups|\/notifications|\/customize|\/settings|\/profile)/,
     );
+  });
+
+  it("shows the package-derived app version in the public footer", () => {
+    const footer = read("components/layouts/footer/index.tsx");
+
+    expect(footer).toMatch(
+      /import webPackage from ["']\.\.\/\.\.\/\.\.\/\.\.\/package\.json["']/,
+    );
+    expect(footer).toContain("App v{webPackage.version}");
   });
 
   it("prevents search indexing during the private preview", () => {


### PR DESCRIPTION
## What changed

- show the web package version in the application footer
- bump the Chrome extension to v1.0.6, keep its manifest-derived footer version, and route both dashboard entry points to `/dashboard`
- add an authenticated, owner-scoped conversation deletion endpoint and Next.js proxy
- add confirmation-based delete controls to the dashboard list and conversation detail views
- document the API operation and add regression coverage for ownership, cascade deletion, UI behavior, dashboard links, and version rendering

## Why

The app and extension did not expose enough build identity, the extension dashboard links did not land on the dashboard, and users had no supported way to remove an imported conversation.

## Validation

- Chrome extension tests: 8 passed
- API conversation intake tests: 5 passed
- Web focused tests: 12 passed
- Chrome extension typecheck passed
- changed-file Prettier check passed
- web production build passed with `next build --webpack`
- monorepo build passed for 7/8 workspaces; the isolated worktree's web Turbopack step rejects dependency junctions outside its filesystem root, while the webpack production build passes
- browser proof confirmed `App v0.1.0`, extension `v1.0.6`, and the extension link redirecting through login to `/dashboard`

## Operator impact

After merge, the locally loaded extension can be replaced with the packaged v1.0.6 build and reloaded. Deploying the app/API remains a separate approval-gated production step.