### PR TITLE
chore: ignore local browser artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 tests/__results__/
+/.playwright-cli/
+/output/playwright/
+
+# Local extension package output
+/apps/chrome-extension/convolens-extension/
 
 # Turborepo
 .turbo/


### PR DESCRIPTION
## What changed

- ignore local Playwright CLI captures
- ignore local Playwright output under `output/playwright`
- ignore the unpacked Chrome extension package directory

## Why

Browser acceptance and extension packaging runs leave generated screenshots, YAML snapshots, and unpacked bundles in otherwise completed worktrees. These files are local evidence/build output and should not appear as source changes.

## Impact

This keeps post-merge worktrees clean without changing application or extension runtime behavior.

## Validation

- `git diff --check`
- verified the PR contains only `.gitignore`