### PR TITLE
Fix WhatsApp sender identity capture

### DIFF
--- a/apps/api/src/routes/__tests__/chat-export.routes.test.ts
+++ b/apps/api/src/routes/__tests__/chat-export.routes.test.ts
@@ -1,4 +1,4 @@
-import { isValidExtensionChatData } from '../chat-export.routes.js';
+import { getLegacyParticipantLabels, isValidExtensionChatData } from '../chat-export.routes.js';
 
 const v1Payload = {
   chatName: 'Team chat',
@@ -39,5 +39,18 @@ describe('extension chat payload validation', () => {
       participants: [],
       messages: [{ ...v1Payload.messages[0], senderRef: 'participant_missing' }],
     })).toBe(false);
+  });
+
+  it('retains a numbered fallback participant in the legacy list', () => {
+    const payload = {
+      ...v1Payload,
+      payloadVersion: 2 as const,
+      participants: [{
+        ref: 'participant_1', isSelf: false, extractionMethod: 'fallback', confidence: 'low',
+      }],
+      messages: [{ ...v1Payload.messages[0], sender: 'Unidentified participant 1', senderRef: 'participant_1' }],
+    };
+
+    expect(getLegacyParticipantLabels(payload)).toEqual(['Unidentified participant 1']);
   });
 });

--- a/apps/api/src/routes/__tests__/chat-export.routes.test.ts
+++ b/apps/api/src/routes/__tests__/chat-export.routes.test.ts
@@ -1,0 +1,43 @@
+import { isValidExtensionChatData } from '../chat-export.routes.js';
+
+const v1Payload = {
+  chatName: 'Team chat',
+  chatId: 'chat_123',
+  extractedAt: '2026-07-27T10:00:00.000Z',
+  messageCount: 1,
+  messages: [{
+    id: 'message_1', text: 'Hello', sender: 'Sarah', timestamp: '2026-07-27T10:00:00.000Z',
+    isOutgoing: false, isMedia: false,
+  }],
+  source: 'chrome-extension' as const,
+  version: '1.0.6',
+  isGroup: true,
+};
+
+describe('extension chat payload validation', () => {
+  it('keeps v1 extension payloads compatible', () => {
+    expect(isValidExtensionChatData(v1Payload)).toBe(true);
+  });
+
+  it('accepts v2 participant observations with message references', () => {
+    expect(isValidExtensionChatData({
+      ...v1Payload,
+      version: '1.0.7',
+      payloadVersion: 2,
+      participants: [{
+        ref: 'participant_1', rawDisplayName: 'Sarah Mokoena', normalizedPhone: '+27821234567',
+        isSelf: false, extractionMethod: 'metadata', confidence: 'high',
+      }],
+      messages: [{ ...v1Payload.messages[0], senderRef: 'participant_1' }],
+    })).toBe(true);
+  });
+
+  it('rejects a v2 sender reference that has no participant observation', () => {
+    expect(isValidExtensionChatData({
+      ...v1Payload,
+      payloadVersion: 2,
+      participants: [],
+      messages: [{ ...v1Payload.messages[0], senderRef: 'participant_missing' }],
+    })).toBe(false);
+  });
+});

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -115,6 +115,22 @@ function isValidParticipant(value: unknown): value is ExtractedParticipant {
   return ['rawDisplayName', 'rawUsername', 'normalizedPhone', 'platformUserId'].every((field) => participant[field] === undefined || typeof participant[field] === 'string');
 }
 
+/**
+ * Preserve the v1 participant list during the v2 rollout. An observation may
+ * intentionally lack a raw label (for example, a numbered fallback), so use
+ * the corresponding synthesized message sender in that case.
+ */
+export function getLegacyParticipantLabels(chatData: ExtensionChatData): string[] {
+  if (!chatData.participants) {
+    return [...new Set(chatData.messages.map((message) => message.sender))];
+  }
+
+  return [...new Set(chatData.participants
+    .map((participant) => participant.rawDisplayName ||
+      chatData.messages.find((message) => message.senderRef === participant.ref)?.sender)
+    .filter((name): name is string => Boolean(name)))];
+}
+
 function isValidMessage(msg: unknown): msg is ExtractedMessage {
   if (!msg || typeof msg !== 'object') return false;
 
@@ -287,9 +303,7 @@ router.post('/extension', authenticateToken, async (req, res) => {
       isGroup: chatData.isGroup,
       // v2 observations remain raw connector evidence for PR 2. This keeps the
       // v1 persistence and deduplication contract unchanged during rollout.
-      participants: chatData.participants
-        ? [...new Set(chatData.participants.map((participant) => participant.rawDisplayName).filter((name): name is string => Boolean(name)))]
-        : [...new Set(chatData.messages.map((message) => message.sender))],
+      participants: getLegacyParticipantLabels(chatData),
       sourceExtractedAt: new Date(chatData.extractedAt),
       provenance: {
         connectorVersion: chatData.version,

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -37,6 +37,18 @@ interface ExtractedMessage {
   isMedia: boolean;
   mediaType?: 'image' | 'video' | 'audio' | 'document' | 'sticker';
   replyTo?: string;
+  senderRef?: string;
+}
+
+interface ExtractedParticipant {
+  ref: string;
+  rawDisplayName?: string;
+  rawUsername?: string;
+  normalizedPhone?: string;
+  platformUserId?: string;
+  isSelf: boolean;
+  extractionMethod: string;
+  confidence: string;
 }
 
 interface ExtensionChatData {
@@ -48,9 +60,11 @@ interface ExtensionChatData {
   source: 'chrome-extension';
   version: string;
   isGroup: boolean;
+  payloadVersion?: 2;
+  participants?: ExtractedParticipant[];
 }
 
-function isValidExtensionChatData(data: unknown): data is ExtensionChatData {
+export function isValidExtensionChatData(data: unknown): data is ExtensionChatData {
   if (!data || typeof data !== 'object') return false;
 
   const obj = data as Record<string, unknown>;
@@ -78,7 +92,27 @@ function isValidExtensionChatData(data: unknown): data is ExtensionChatData {
     if (!isValidMessage(msg)) return false;
   }
 
+  if (obj.payloadVersion !== undefined && obj.payloadVersion !== 2) return false;
+  if (obj.payloadVersion === 2 && !Array.isArray(obj.participants)) return false;
+  if (obj.participants !== undefined) {
+    if (!Array.isArray(obj.participants)) return false;
+    const refs = new Set<string>();
+    for (const participant of obj.participants) {
+      if (!isValidParticipant(participant) || refs.has(participant.ref)) return false;
+      refs.add(participant.ref);
+    }
+    if (obj.messages.some((message) => message.senderRef && !refs.has(message.senderRef))) return false;
+  }
+
   return true;
+}
+
+function isValidParticipant(value: unknown): value is ExtractedParticipant {
+  if (!value || typeof value !== 'object') return false;
+  const participant = value as Record<string, unknown>;
+  if (typeof participant.ref !== 'string' || participant.ref.length === 0 || typeof participant.isSelf !== 'boolean') return false;
+  if (typeof participant.extractionMethod !== 'string' || typeof participant.confidence !== 'string') return false;
+  return ['rawDisplayName', 'rawUsername', 'normalizedPhone', 'platformUserId'].every((field) => participant[field] === undefined || typeof participant[field] === 'string');
 }
 
 function isValidMessage(msg: unknown): msg is ExtractedMessage {
@@ -104,6 +138,7 @@ function isValidMessage(msg: unknown): msg is ExtractedMessage {
   }
 
   if (obj.replyTo !== undefined && typeof obj.replyTo !== 'string') return false;
+  if (obj.senderRef !== undefined && typeof obj.senderRef !== 'string') return false;
 
   return true;
 }
@@ -250,7 +285,11 @@ router.post('/extension', authenticateToken, async (req, res) => {
       sourceConversationId: chatData.chatId,
       displayName: sanitizedChatName,
       isGroup: chatData.isGroup,
-      participants: [...new Set(chatData.messages.map((message) => message.sender))],
+      // v2 observations remain raw connector evidence for PR 2. This keeps the
+      // v1 persistence and deduplication contract unchanged during rollout.
+      participants: chatData.participants
+        ? [...new Set(chatData.participants.map((participant) => participant.rawDisplayName).filter((name): name is string => Boolean(name)))]
+        : [...new Set(chatData.messages.map((message) => message.sender))],
       sourceExtractedAt: new Date(chatData.extractedAt),
       provenance: {
         connectorVersion: chatData.version,

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
+++ b/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
@@ -1,0 +1,20 @@
+<!-- Direct chat: inbound author comes from the conversation header. -->
+<section data-testid="conversation-panel-messages">
+  <div class="message-in" data-testid="msg-container">
+    <div data-testid="msg-text">Hello</div>
+    <span data-testid="msg-meta">10:01 AM</span>
+  </div>
+</section>
+<header><span data-testid="conversation-info-header-chat-title">+27 82 123 4567</span></header>
+
+<!-- Group chat: metadata is authoritative even when the sender element is absent. -->
+<section data-testid="conversation-panel-messages">
+  <div class="message-in" data-testid="msg-container" data-pre-plain-text="[10:02, 2026-07-27] Sarah Mokoena: ">
+    <div data-testid="msg-text">Morning all</div>
+    <span data-testid="msg-meta">10:02 AM</span>
+  </div>
+  <div class="message-out" data-testid="msg-out">
+    <div data-testid="msg-text">Good morning</div>
+    <span data-testid="msg-meta">10:03 AM</span>
+  </div>
+</section>

--- a/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
+++ b/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
@@ -5,7 +5,10 @@
     <span data-testid="msg-meta">10:01 AM</span>
   </div>
 </section>
-<header><span data-testid="conversation-info-header-chat-title">+27 82 123 4567</span></header>
+<header>
+  <span data-testid="conversation-info-header-chat-title">+27 82 123 4567</span>
+  <span data-testid="conversation-subtitle">online</span>
+</header>
 
 <!-- Group chat: metadata is authoritative even when the sender element is absent. -->
 <section data-testid="conversation-panel-messages">

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -387,6 +387,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
 
   // Detect if this is a group chat
   const isGroup = detectGroupChat();
+  const isDirectChat = detectDirectChat();
 
   // Get message container
   const messageList = findConversationRoot(
@@ -427,7 +428,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
     }
 
     try {
-      const message = extractMessageData(messageContainers[i] as HTMLElement, isGroup, chatName, participants, participantRefs);
+      const message = extractMessageData(messageContainers[i] as HTMLElement, isDirectChat, chatName, participants, participantRefs);
       if (message) {
         messages.push(message);
       }
@@ -461,7 +462,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
  */
 function extractMessageData(
   container: HTMLElement,
-  isGroup: boolean,
+  isDirectChat: boolean,
   chatName: string,
   participants: ExtractedParticipant[],
   participantRefs: Map<string, string>,
@@ -497,7 +498,7 @@ function extractMessageData(
   const isOutgoing =
     container.classList.contains("message-out") ||
     container.closest('[data-testid="msg-out"]') !== null;
-  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isGroup, chatName);
+  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isDirectChat, chatName);
   const senderRef = registerParticipant(identity, participants, participantRefs);
 
   return {
@@ -516,7 +517,7 @@ function extractSenderIdentity(
   container: HTMLElement,
   senderEl: Element | null,
   isOutgoing: boolean,
-  isGroup: boolean,
+  isDirectChat: boolean,
   chatName: string,
 ): Omit<ExtractedParticipant, "ref"> {
   if (isOutgoing) {
@@ -526,7 +527,8 @@ function extractSenderIdentity(
     container.querySelector("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") || "";
   const metadataSender = metadata.match(/\]\s*(.+?):\s*$/)?.[1]?.trim();
   const explicitSender = senderEl?.textContent?.trim();
-  const headerSender = !isGroup
+  // A failure to recognise a group is not proof this is a direct chat.
+  const headerSender = isDirectChat
     ? (querySelector(SELECTORS.primary.contactName, SELECTORS.fallback.contactName)?.textContent?.trim() ||
       (chatName === "Unknown Chat" ? undefined : chatName))
     : undefined;
@@ -580,6 +582,13 @@ function detectGroupChat(): boolean {
   );
   const text = participantInfo?.textContent || "";
   return text.includes("participant") || text.includes("members");
+}
+
+function detectDirectChat(): boolean {
+  const subtitle = document.querySelector('[data-testid="conversation-subtitle"]')?.textContent?.trim().toLowerCase() || "";
+  // These are direct-chat-only states in WhatsApp Web. Do not infer a direct
+  // chat merely because the group detector did not recognise localized UI.
+  return /\bonline\b|\btyping\b|last seen|disappearing messages/.test(subtitle);
 }
 
 function detectMediaMessage(container: HTMLElement): boolean {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -43,6 +43,18 @@ interface ExtractedMessage {
   isMedia: boolean;
   mediaType?: "image" | "video" | "audio" | "document" | "sticker";
   replyTo?: string;
+  senderRef?: string;
+}
+
+interface ExtractedParticipant {
+  ref: string;
+  rawDisplayName?: string;
+  rawUsername?: string;
+  normalizedPhone?: string;
+  platformUserId?: string;
+  isSelf: boolean;
+  extractionMethod: "metadata" | "sender-element" | "conversation-header" | "outgoing" | "fallback";
+  confidence: "high" | "medium" | "low";
 }
 
 interface ExtractedChat {
@@ -54,6 +66,8 @@ interface ExtractedChat {
   source: "chrome-extension";
   version: string;
   isGroup: boolean;
+  payloadVersion: 2;
+  participants: ExtractedParticipant[];
 }
 
 interface ExtractionState {
@@ -395,6 +409,8 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
   );
 
   const messages: ExtractedMessage[] = [];
+  const participants: ExtractedParticipant[] = [];
+  const participantRefs = new Map<string, string>();
   const totalMessages = messageContainers.length;
 
   for (let i = 0; i < messageContainers.length; i++) {
@@ -411,7 +427,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
     }
 
     try {
-      const message = extractMessageData(messageContainers[i] as HTMLElement);
+      const message = extractMessageData(messageContainers[i] as HTMLElement, isGroup, chatName, participants, participantRefs);
       if (message) {
         messages.push(message);
       }
@@ -435,13 +451,21 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
     source: "chrome-extension",
     version: chrome.runtime.getManifest().version,
     isGroup,
+    payloadVersion: 2,
+    participants,
   };
 }
 
 /**
  * Extract data from a single message element
  */
-function extractMessageData(container: HTMLElement): ExtractedMessage | null {
+function extractMessageData(
+  container: HTMLElement,
+  isGroup: boolean,
+  chatName: string,
+  participants: ExtractedParticipant[],
+  participantRefs: Map<string, string>,
+): ExtractedMessage | null {
   // Get message text
   const textEl = findMessageText(
     container,
@@ -468,22 +492,77 @@ function extractMessageData(container: HTMLElement): ExtractedMessage | null {
   const senderEl =
     container.querySelector(SELECTORS.primary.senderName) ||
     container.querySelector(SELECTORS.fallback.senderName);
-  const sender = senderEl?.textContent?.trim() || "Unknown";
 
   // Determine direction
   const isOutgoing =
     container.classList.contains("message-out") ||
     container.closest('[data-testid="msg-out"]') !== null;
+  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isGroup, chatName);
+  const senderRef = registerParticipant(identity, participants, participantRefs);
 
   return {
     id: generateMessageId(),
     text: isMedia && !text ? `[${mediaType || "Media"}]` : text,
-    sender: isOutgoing ? "You" : sender,
+    sender: identity.rawDisplayName || `Unidentified participant ${participants.length || 1}`,
     timestamp: parseTimestamp(timeText),
     isOutgoing,
     isMedia,
     mediaType,
+    senderRef,
   };
+}
+
+function extractSenderIdentity(
+  container: HTMLElement,
+  senderEl: Element | null,
+  isOutgoing: boolean,
+  isGroup: boolean,
+  chatName: string,
+): Omit<ExtractedParticipant, "ref"> {
+  if (isOutgoing) {
+    return { rawDisplayName: "You", isSelf: true, extractionMethod: "outgoing", confidence: "high" };
+  }
+  const metadata = container.getAttribute("data-pre-plain-text") ||
+    container.querySelector("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") || "";
+  const metadataSender = metadata.match(/\]\s*(.+?):\s*$/)?.[1]?.trim();
+  const explicitSender = senderEl?.textContent?.trim();
+  const headerSender = !isGroup
+    ? (querySelector(SELECTORS.primary.contactName, SELECTORS.fallback.contactName)?.textContent?.trim() ||
+      (chatName === "Unknown Chat" ? undefined : chatName))
+    : undefined;
+  const rawDisplayName = metadataSender || explicitSender || headerSender;
+  const rawUsername = rawDisplayName?.match(/^@[^\s]+$/)?.[0];
+  const phoneSource = rawDisplayName?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0];
+  const normalizedPhone = phoneSource ? phoneSource.replace(/[^0-9+]/g, "") : undefined;
+  // data-id identifies an individual message in WhatsApp Web, not its sender.
+  const platformUserId = container.getAttribute("data-contact-id") ||
+    container.closest("[data-contact-id]")?.getAttribute("data-contact-id") || undefined;
+  const extractionMethod = metadataSender ? "metadata" : explicitSender ? "sender-element" : headerSender ? "conversation-header" : "fallback";
+  return {
+    rawDisplayName,
+    rawUsername,
+    normalizedPhone,
+    platformUserId,
+    isSelf: false,
+    extractionMethod,
+    confidence: extractionMethod === "metadata" ? "high" : extractionMethod === "fallback" ? "low" : "medium",
+  };
+}
+
+function registerParticipant(
+  identity: Omit<ExtractedParticipant, "ref">,
+  participants: ExtractedParticipant[],
+  participantRefs: Map<string, string>,
+): string {
+  const stableKey = identity.isSelf
+    ? "self"
+    : identity.platformUserId || identity.normalizedPhone || identity.rawUsername || identity.rawDisplayName || `unidentified-${participants.length + 1}`;
+  const existing = participantRefs.get(stableKey);
+  if (existing) return existing;
+  const ref = `participant_${participants.length + 1}`;
+  participants.push({ ref, ...identity });
+  participantRefs.set(stableKey, ref);
+  return ref;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- capture WhatsApp metadata, sender elements, direct-chat headers, self messages, and numbered fallbacks
- add backward-compatible extension payload v2 with participant observations and sender references
- validate v1/v2 API contracts and release extension manifest/package version 1.0.7

## Validation
- pnpm --filter @convolens/chrome-extension build
- pnpm --dir apps/api run test -- --runInBand --runTestsByPath src/routes/__tests__/chat-export.routes.test.ts