### PR TITLE
Preserve WhatsApp sender metadata and dates

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
+++ b/apps/chrome-extension/src/__fixtures__/whatsapp-sender-capture.html
@@ -12,7 +12,8 @@
 
 <!-- Group chat: metadata is authoritative even when the sender element is absent. -->
 <section data-testid="conversation-panel-messages">
-  <div class="message-in" data-testid="msg-container" data-pre-plain-text="[10:02, 2026-07-27] Sarah Mokoena: ">
+  <div class="message-in" data-testid="msg-container" data-pre-plain-text="[19:10, 06/07/2026] ~ Shane: ">
+    <span>~ Shane</span><span>+27 79 505 1948</span>
     <div data-testid="msg-text">Morning all</div>
     <span data-testid="msg-meta">10:02 AM</span>
   </div>

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -24,6 +24,7 @@ import {
   type SetAuthTokenMessage,
   type CheckStatusData,
 } from "./config";
+import { parseWhatsAppMessageMetadata } from "./whatsapp-metadata";
 import {
   findConversationRoot,
   findMessageContainers,
@@ -498,14 +499,15 @@ function extractMessageData(
   const isOutgoing =
     container.classList.contains("message-out") ||
     container.closest('[data-testid="msg-out"]') !== null;
-  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isDirectChat, chatName);
+  const metadata = getMessageMetadata(container);
+  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isDirectChat, chatName, metadata);
   const senderRef = registerParticipant(identity, participants, participantRefs);
 
   return {
     id: generateMessageId(),
     text: isMedia && !text ? `[${mediaType || "Media"}]` : text,
     sender: identity.rawDisplayName || `Unidentified participant ${participants.length || 1}`,
-    timestamp: parseTimestamp(timeText),
+    timestamp: parseTimestamp(timeText, metadata),
     isOutgoing,
     isMedia,
     mediaType,
@@ -519,13 +521,12 @@ function extractSenderIdentity(
   isOutgoing: boolean,
   isDirectChat: boolean,
   chatName: string,
+  metadata: string,
 ): Omit<ExtractedParticipant, "ref"> {
   if (isOutgoing) {
     return { rawDisplayName: "You", isSelf: true, extractionMethod: "outgoing", confidence: "high" };
   }
-  const metadata = container.getAttribute("data-pre-plain-text") ||
-    container.querySelector("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") || "";
-  const metadataSender = metadata.match(/\]\s*(.+?):\s*$/)?.[1]?.trim();
+  const metadataSender = parseWhatsAppMessageMetadata(metadata).sender;
   const explicitSender = senderEl?.textContent?.trim();
   // A failure to recognise a group is not proof this is a direct chat.
   const headerSender = isDirectChat
@@ -534,7 +535,11 @@ function extractSenderIdentity(
     : undefined;
   const rawDisplayName = metadataSender || explicitSender || headerSender;
   const rawUsername = rawDisplayName?.match(/^@[^\s]+$/)?.[0];
-  const phoneSource = rawDisplayName?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0];
+  // WhatsApp commonly renders the phone alongside the sender label. It is
+  // capture-scoped evidence, never a contact-book scrape.
+  const phoneSource = [rawDisplayName, senderEl?.parentElement?.textContent, container.textContent]
+    .map((value) => value?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0])
+    .find((value): value is string => Boolean(value));
   const normalizedPhone = phoneSource ? phoneSource.replace(/[^0-9+]/g, "") : undefined;
   // data-id identifies an individual message in WhatsApp Web, not its sender.
   const platformUserId = container.getAttribute("data-contact-id") ||
@@ -549,6 +554,12 @@ function extractSenderIdentity(
     extractionMethod,
     confidence: extractionMethod === "metadata" ? "high" : extractionMethod === "fallback" ? "low" : "medium",
   };
+}
+
+function getMessageMetadata(container: HTMLElement): string {
+  return container.getAttribute("data-pre-plain-text") ||
+    container.closest("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") ||
+    container.querySelector("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") || "";
 }
 
 function registerParticipant(
@@ -621,8 +632,11 @@ function getMediaType(
   return undefined;
 }
 
-function parseTimestamp(timeText: string): string {
+function parseTimestamp(timeText: string, metadata: string = ""): string {
   const now = new Date();
+
+  const metadataTimestamp = parseWhatsAppMessageMetadata(metadata).timestamp;
+  if (metadataTimestamp) return metadataTimestamp;
 
   if (!timeText) return now.toISOString();
 

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -526,7 +526,7 @@ function extractSenderIdentity(
   if (isOutgoing) {
     return { rawDisplayName: "You", isSelf: true, extractionMethod: "outgoing", confidence: "high" };
   }
-  const metadataSender = parseWhatsAppMessageMetadata(metadata).sender;
+  const metadataSender = parseWhatsAppMessageMetadata(metadata, document.documentElement.lang || navigator.language).sender;
   const explicitSender = senderEl?.textContent?.trim();
   // A failure to recognise a group is not proof this is a direct chat.
   const headerSender = isDirectChat
@@ -537,9 +537,7 @@ function extractSenderIdentity(
   const rawUsername = rawDisplayName?.match(/^@[^\s]+$/)?.[0];
   // WhatsApp commonly renders the phone alongside the sender label. It is
   // capture-scoped evidence, never a contact-book scrape.
-  const phoneSource = [rawDisplayName, senderEl?.parentElement?.textContent, container.textContent]
-    .map((value) => value?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0])
-    .find((value): value is string => Boolean(value));
+  const phoneSource = rawDisplayName?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0];
   const normalizedPhone = phoneSource ? phoneSource.replace(/[^0-9+]/g, "") : undefined;
   // data-id identifies an individual message in WhatsApp Web, not its sender.
   const platformUserId = container.getAttribute("data-contact-id") ||
@@ -635,7 +633,7 @@ function getMediaType(
 function parseTimestamp(timeText: string, metadata: string = ""): string {
   const now = new Date();
 
-  const metadataTimestamp = parseWhatsAppMessageMetadata(metadata).timestamp;
+  const metadataTimestamp = parseWhatsAppMessageMetadata(metadata, document.documentElement.lang || navigator.language).timestamp;
   if (metadataTimestamp) return metadataTimestamp;
 
   if (!timeText) return now.toISOString();

--- a/apps/chrome-extension/src/whatsapp-metadata.ts
+++ b/apps/chrome-extension/src/whatsapp-metadata.ts
@@ -4,24 +4,28 @@ export interface WhatsAppMessageMetadata {
 }
 
 /** Parse WhatsApp's `[time, date] sender:` accessibility metadata. */
-export function parseWhatsAppMessageMetadata(value: string): WhatsAppMessageMetadata {
+export function parseWhatsAppMessageMetadata(
+  value: string,
+  locale?: string,
+): WhatsAppMessageMetadata {
   const match = value.match(/^\[([^\]]+)\]\s*(.+?):\s*$/);
   if (!match) return {};
 
   return {
     sender: match[2].trim() || undefined,
-    timestamp: parseWhatsAppMetadataTimestamp(match[1]),
+    timestamp: parseWhatsAppMetadataTimestamp(match[1], locale),
   };
 }
 
-function parseWhatsAppMetadataTimestamp(value: string): string | undefined {
+function parseWhatsAppMetadataTimestamp(value: string, locale?: string): string | undefined {
   const dayFirstDate = value.match(/(\d{1,2})[\/.\-](\d{1,2})[\/.\-](\d{4})/);
   const yearFirstDate = value.match(/(\d{4})[\/.\-](\d{1,2})[\/.\-](\d{1,2})/);
   const time = value.match(/(?:^|,\s*)(\d{1,2}):(\d{2})(?:\s*(AM|PM))?/i);
   if ((!dayFirstDate && !yearFirstDate) || !time) return undefined;
 
-  const day = Number(yearFirstDate?.[3] || dayFirstDate?.[1]);
-  const month = Number(yearFirstDate?.[2] || dayFirstDate?.[2]);
+  const numericDateIsMonthFirst = !yearFirstDate && isMonthFirstLocale(locale);
+  const day = Number(yearFirstDate?.[3] || (numericDateIsMonthFirst ? dayFirstDate?.[2] : dayFirstDate?.[1]));
+  const month = Number(yearFirstDate?.[2] || (numericDateIsMonthFirst ? dayFirstDate?.[1] : dayFirstDate?.[2]));
   const year = Number(yearFirstDate?.[1] || dayFirstDate?.[3]);
   let hours = Number(time[1]);
   const minutes = Number(time[2]);
@@ -29,6 +33,27 @@ function parseWhatsAppMetadataTimestamp(value: string): string | undefined {
   if (period === "PM" && hours !== 12) hours += 12;
   if (period === "AM" && hours === 12) hours = 0;
 
-  const parsed = new Date(year, month - 1, day, hours, minutes, 0, 0);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  // WhatsApp's accessibility label has no timezone. Preserve its displayed
+  // calendar date and clock time rather than letting the browser timezone
+  // shift historical messages across a UTC date boundary.
+  const parsed = new Date(Date.UTC(year, month - 1, day, hours, minutes, 0, 0));
+  return Number.isNaN(parsed.getTime()) ||
+      parsed.getUTCFullYear() !== year ||
+      parsed.getUTCMonth() !== month - 1 ||
+      parsed.getUTCDate() !== day ||
+      parsed.getUTCHours() !== hours ||
+      parsed.getUTCMinutes() !== minutes
+    ? undefined
+    : parsed.toISOString();
+}
+
+function isMonthFirstLocale(locale?: string): boolean {
+  if (!locale) return false;
+
+  const parts = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+  }).formatToParts(new Date(2001, 10, 23));
+  return parts.filter((part) => part.type === "day" || part.type === "month" || part.type === "year")[0]?.type === "month";
 }

--- a/apps/chrome-extension/src/whatsapp-metadata.ts
+++ b/apps/chrome-extension/src/whatsapp-metadata.ts
@@ -1,0 +1,34 @@
+export interface WhatsAppMessageMetadata {
+  sender?: string;
+  timestamp?: string;
+}
+
+/** Parse WhatsApp's `[time, date] sender:` accessibility metadata. */
+export function parseWhatsAppMessageMetadata(value: string): WhatsAppMessageMetadata {
+  const match = value.match(/^\[([^\]]+)\]\s*(.+?):\s*$/);
+  if (!match) return {};
+
+  return {
+    sender: match[2].trim() || undefined,
+    timestamp: parseWhatsAppMetadataTimestamp(match[1]),
+  };
+}
+
+function parseWhatsAppMetadataTimestamp(value: string): string | undefined {
+  const dayFirstDate = value.match(/(\d{1,2})[\/.\-](\d{1,2})[\/.\-](\d{4})/);
+  const yearFirstDate = value.match(/(\d{4})[\/.\-](\d{1,2})[\/.\-](\d{1,2})/);
+  const time = value.match(/(?:^|,\s*)(\d{1,2}):(\d{2})(?:\s*(AM|PM))?/i);
+  if ((!dayFirstDate && !yearFirstDate) || !time) return undefined;
+
+  const day = Number(yearFirstDate?.[3] || dayFirstDate?.[1]);
+  const month = Number(yearFirstDate?.[2] || dayFirstDate?.[2]);
+  const year = Number(yearFirstDate?.[1] || dayFirstDate?.[3]);
+  let hours = Number(time[1]);
+  const minutes = Number(time[2]);
+  const period = time[3]?.toUpperCase();
+  if (period === "PM" && hours !== 12) hours += 12;
+  if (period === "AM" && hours === 12) hours = 0;
+
+  const parsed = new Date(year, month - 1, day, hours, minutes, 0, 0);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.6");
+  assert.equal(manifest.version, "1.0.8");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/apps/chrome-extension/tests/whatsapp-metadata.test.ts
+++ b/apps/chrome-extension/tests/whatsapp-metadata.test.ts
@@ -3,10 +3,22 @@ import test from "node:test";
 import { parseWhatsAppMessageMetadata } from "../src/whatsapp-metadata.ts";
 
 test("preserves the sender and historical date from WhatsApp pre-plain-text metadata", () => {
-  const metadata = parseWhatsAppMessageMetadata("[19:10, 06/07/2026] ~ Shane: ");
+  const metadata = parseWhatsAppMessageMetadata("[19:10, 06/07/2026] ~ Shane: ", "en-ZA");
 
   assert.equal(metadata.sender, "~ Shane");
   assert.ok(metadata.timestamp?.startsWith("2026-07-06T"));
+});
+
+test("uses the source locale for month-first WhatsApp metadata", () => {
+  const metadata = parseWhatsAppMessageMetadata("[7:10 PM, 7/27/2026] Sarah Mokoena: ", "en-US");
+
+  assert.ok(metadata.timestamp?.startsWith("2026-07-27T19:10:00"));
+});
+
+test("rejects invalid metadata dates instead of normalizing them", () => {
+  const metadata = parseWhatsAppMessageMetadata("[19:10, 31/13/2026] ~ Shane: ", "en-ZA");
+
+  assert.equal(metadata.timestamp, undefined);
 });
 
 test("supports WhatsApp metadata that places the date before the time", () => {

--- a/apps/chrome-extension/tests/whatsapp-metadata.test.ts
+++ b/apps/chrome-extension/tests/whatsapp-metadata.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseWhatsAppMessageMetadata } from "../src/whatsapp-metadata.ts";
+
+test("preserves the sender and historical date from WhatsApp pre-plain-text metadata", () => {
+  const metadata = parseWhatsAppMessageMetadata("[19:10, 06/07/2026] ~ Shane: ");
+
+  assert.equal(metadata.sender, "~ Shane");
+  assert.ok(metadata.timestamp?.startsWith("2026-07-06T"));
+});
+
+test("supports WhatsApp metadata that places the date before the time", () => {
+  const metadata = parseWhatsAppMessageMetadata("[2026-07-27, 10:02] Sarah Mokoena: ");
+
+  assert.equal(metadata.sender, "Sarah Mokoena");
+  assert.ok(metadata.timestamp?.startsWith("2026-07-27T"));
+});

--- a/docs/HANDOFF-2026-07-27-WHATSAPP-METADATA-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-WHATSAPP-METADATA-PLAN.md
@@ -1,0 +1,110 @@
+# WhatsApp metadata capture and consented enrichment plan — 2026-07-27
+
+## Status and boundary
+
+PR #142 contains the immediate v1.0.8 repair: sender metadata can be read from a message ancestor, historical date/time is preserved from `data-pre-plain-text`, and visible phone evidence is captured as raw participant evidence. It is not production acceptance: an operator must reload the unpacked extension and send an authorized chat.
+
+This plan has two intentionally separate tracks:
+
+1. **Core capture** records evidence already exposed by the user-selected conversation. It is part of normal extension intake.
+2. **Optional enrichment** may capture profile/contact/location/address-book data only after a granular explicit opt-in. It is off by default and must never be enabled implicitly by core capture, an update, or an organization setting.
+
+Neither track may rewrite message text, raw sender labels, source IDs, or deduplication hashes. Do not scrape the wider WhatsApp UI/contact book during core capture.
+
+## Core capture delivery plan
+
+### 1. Stable WhatsApp message identity
+
+- Capture a raw message `data-id` (or equivalent message-scoped source ID) when it is present.
+- Keep the generated connector ID only as a fallback; record `sourceIdMethod` and confidence.
+- Use the raw source ID for `sourceMessageId`, reply links, and idempotency correlation without making it a person identity.
+- Preserve the raw attribute as evidence; do not log it.
+
+**Gate:** sending the same selected conversation twice yields stable source-message references and the existing duplicate-ingest behavior remains correct.
+
+### 2. Stable conversation identity
+
+- Prefer a WhatsApp chat/group/contact identifier exposed on the selected conversation element.
+- Keep the existing title/time-derived chat ID only as a low-confidence fallback.
+- Persist `sourceConversationIdMethod`; never infer a conversation identity from its visible title alone.
+
+**Gate:** renaming a chat does not create a new conversation when a stable source ID is available.
+
+### 3. Raw metadata and sender evidence
+
+- Preserve raw `data-pre-plain-text` alongside parsed sender/date/time.
+- Search message element, ancestor, and descendant for metadata; retain the extraction path and confidence.
+- Preserve raw display label, visible phone, handle, and platform/contact ID in separate nullable fields.
+- Treat `You` and `System` as special actors; never create directory people for them.
+
+**Gate:** group messages such as `~ Shane · +27 …` render a useful raw source identity even before linking to People Directory.
+
+### 4. Historical timestamp and date-divider context
+
+- Prefer complete timestamp metadata.
+- Record raw timestamp text, parsed ISO timestamp, source locale/order, and timezone assumption.
+- When metadata is absent, associate the nearest WhatsApp date divider with subsequent time-only messages; mark it medium/low confidence.
+- Never silently assign today when historical date evidence is available.
+
+**Gate:** a July 2026 message imported today retains its July 2026 timestamp; date-only fallback is visibly lower confidence.
+
+### 5. Message state and relationships
+
+- Capture reply/quoted-message source ID only when visible in the selected conversation.
+- Capture forwarded marker, edited/deleted/revoked state, outgoing/self, system event, and media type.
+- Preserve original text and media placeholder; do not download media, query message history, or fabricate relationships.
+
+**Gate:** quoted, forwarded, edited, and revoked fixtures round-trip with their raw evidence and without changing existing message rendering.
+
+### 6. Provenance, contracts, and safety
+
+- Add a backward-compatible extension payload version for raw source ID, raw metadata, timestamp provenance, and message state.
+- Validate field lengths/types server-side; dual-write only fields accepted by the current durable schema until the participant-persistence PR lands.
+- Keep raw PII out of telemetry and logs. Use aggregate metrics only: metadata-found rate, date-fallback rate, and unidentified-participant rate.
+- Add direct/group/localized DOM fixtures, deterministic parser tests, SQLite/PostgreSQL ingest coverage, duplicate-ingest coverage, and restart/deletion regression tests.
+
+**Gate:** v1 remains accepted, v2/v3 payloads are schema-valid, no raw contact/message data appears in logs, and production browser acceptance proves capture, deduplication, restart persistence, and owner isolation.
+
+## Optional enrichment: consented profile/contact/location/address-book capture
+
+### Product and authorization model
+
+- Add a **Privacy and enrichment** settings page. Every category starts disabled.
+- Present four independent toggles: profile photo, profile/contact details, shared location, and wider address book.
+- Each toggle must explain exact data, source, purpose, retention, visibility, and how to revoke/delete it. The default is `off`.
+- Require a fresh confirmation for address-book access and any scope increase. No bulk enablement, pre-checked boxes, or consent inherited from normal chat intake.
+- Scope consent to the authenticated ConvoLens user; organization sharing is a separate future authorization decision.
+
+### Capture rules by category
+
+| Category | Allowed scope after opt-in | Explicit exclusions |
+| --- | --- | --- |
+| Profile photo | Profile photo of a participant in a user-selected conversation, on user action | Background/profile crawl; automatic refresh |
+| Profile/contact details | Fields visibly exposed for that selected participant, on user action | Hidden contact data; inferred details; wider contact list |
+| Location | Location attachment intentionally included in a selected message, on user action | Live location tracking; background polling; deriving location from text |
+| Wider address book | A user-initiated, previewed import with selectable records | Silent collection; auto-linking/merging; contacts not previewed by the user |
+
+### Data handling and retention
+
+- Store enrichment separately from raw conversation evidence and People Directory identity links.
+- Encrypt sensitive values at rest; use least-privilege owner-scoped APIs; no enrichment in telemetry, analytics, or error logs.
+- Profile photos require content-type/size limits, malware scanning, private object storage, signed owner-only reads, and a placeholder on failure.
+- Location requires precise-vs-approximate labeling, minimization, and an optional retention period. Never expose exact coordinates in lists by default.
+- Address-book records begin as reviewable suggestions. Names never auto-merge; only exact stable identifiers may auto-link under the existing conservative matching rules.
+- Add owner-controlled delete/export per enrichment item and a "revoke consent and delete captured data" action. Revocation stops future capture immediately.
+
+### Rollout gates
+
+1. Threat model, privacy copy, data inventory, retention/deletion design, and authorization review.
+2. Settings toggles and immutable consent audit events; tests prove default-off and user boundary behavior.
+3. One category at a time, starting with profile photo for selected participants; private-storage and deletion proof.
+4. Message-attached location only; no live tracking; masking/reveal tests.
+5. Address-book preview/import with explicit confirmation, selection, duplicate review, and no automatic People Directory merge.
+6. Production acceptance with a legitimate user session, audit/export/deletion proof, and PII-safe telemetry review.
+
+## Immediate next actions
+
+1. Merge PR #142 only after CI/review threads are clean.
+2. Reload the v1.0.8 unpacked extension and reproduce the screenshot conversation; record the returned conversation ID and captured sender/timestamp evidence.
+3. Start core item 1 in a separate PR; do not mix optional enrichment with it.
+4. Open a separate privacy/design decision before any optional enrichment implementation.


### PR DESCRIPTION
## Summary
- parse WhatsApp message metadata from message ancestors as well as descendants
- preserve historical message dates instead of assigning today
- capture visible phone evidence and release extension v1.0.8

## Validation
- npm test (10 passing)
- npm run typecheck
- npm run package