### PR TITLE
Add safe WhatsApp extraction diagnostics

### DIFF
--- a/apps/api/src/routes/__tests__/chat-export.routes.test.ts
+++ b/apps/api/src/routes/__tests__/chat-export.routes.test.ts
@@ -5,10 +5,16 @@ const v1Payload = {
   chatId: 'chat_123',
   extractedAt: '2026-07-27T10:00:00.000Z',
   messageCount: 1,
-  messages: [{
-    id: 'message_1', text: 'Hello', sender: 'Sarah', timestamp: '2026-07-27T10:00:00.000Z',
-    isOutgoing: false, isMedia: false,
-  }],
+  messages: [
+    {
+      id: 'message_1',
+      text: 'Hello',
+      sender: 'Sarah',
+      timestamp: '2026-07-27T10:00:00.000Z',
+      isOutgoing: false,
+      isMedia: false,
+    },
+  ],
   source: 'chrome-extension' as const,
   version: '1.0.6',
   isGroup: true,
@@ -20,35 +26,79 @@ describe('extension chat payload validation', () => {
   });
 
   it('accepts v2 participant observations with message references', () => {
-    expect(isValidExtensionChatData({
-      ...v1Payload,
-      version: '1.0.7',
-      payloadVersion: 2,
-      participants: [{
-        ref: 'participant_1', rawDisplayName: 'Sarah Mokoena', normalizedPhone: '+27821234567',
-        isSelf: false, extractionMethod: 'metadata', confidence: 'high',
-      }],
-      messages: [{ ...v1Payload.messages[0], senderRef: 'participant_1' }],
-    })).toBe(true);
+    expect(
+      isValidExtensionChatData({
+        ...v1Payload,
+        version: '1.0.7',
+        payloadVersion: 2,
+        participants: [
+          {
+            ref: 'participant_1',
+            rawDisplayName: 'Sarah Mokoena',
+            normalizedPhone: '+27821234567',
+            isSelf: false,
+            extractionMethod: 'metadata',
+            confidence: 'high',
+          },
+        ],
+        messages: [{ ...v1Payload.messages[0], senderRef: 'participant_1' }],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts aggregate-only extraction diagnostics', () => {
+    expect(
+      isValidExtensionChatData({
+        ...v1Payload,
+        payloadVersion: 2,
+        participants: [],
+        diagnostics: {
+          messageContainerCount: 20,
+          extractedMessageCount: 20,
+          metadataPathCounts: { container: 0, ancestor: 0, descendant: 0, none: 20 },
+          senderMethodCounts: {
+            metadata: 0,
+            'sender-element': 0,
+            'conversation-header': 0,
+            outgoing: 0,
+            fallback: 20,
+          },
+          timestampMethodCounts: { metadata: 0, 'visible-time': 0, fallback: 20 },
+        },
+      })
+    ).toBe(true);
   });
 
   it('rejects a v2 sender reference that has no participant observation', () => {
-    expect(isValidExtensionChatData({
-      ...v1Payload,
-      payloadVersion: 2,
-      participants: [],
-      messages: [{ ...v1Payload.messages[0], senderRef: 'participant_missing' }],
-    })).toBe(false);
+    expect(
+      isValidExtensionChatData({
+        ...v1Payload,
+        payloadVersion: 2,
+        participants: [],
+        messages: [{ ...v1Payload.messages[0], senderRef: 'participant_missing' }],
+      })
+    ).toBe(false);
   });
 
   it('retains a numbered fallback participant in the legacy list', () => {
     const payload = {
       ...v1Payload,
       payloadVersion: 2 as const,
-      participants: [{
-        ref: 'participant_1', isSelf: false, extractionMethod: 'fallback', confidence: 'low',
-      }],
-      messages: [{ ...v1Payload.messages[0], sender: 'Unidentified participant 1', senderRef: 'participant_1' }],
+      participants: [
+        {
+          ref: 'participant_1',
+          isSelf: false,
+          extractionMethod: 'fallback',
+          confidence: 'low',
+        },
+      ],
+      messages: [
+        {
+          ...v1Payload.messages[0],
+          sender: 'Unidentified participant 1',
+          senderRef: 'participant_1',
+        },
+      ],
     };
 
     expect(getLegacyParticipantLabels(payload)).toEqual(['Unidentified participant 1']);

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -62,6 +62,18 @@ interface ExtensionChatData {
   isGroup: boolean;
   payloadVersion?: 2;
   participants?: ExtractedParticipant[];
+  diagnostics?: ExtractionDiagnostics;
+}
+
+interface ExtractionDiagnostics {
+  messageContainerCount: number;
+  extractedMessageCount: number;
+  metadataPathCounts: Record<'container' | 'ancestor' | 'descendant' | 'none', number>;
+  senderMethodCounts: Record<
+    'metadata' | 'sender-element' | 'conversation-header' | 'outgoing' | 'fallback',
+    number
+  >;
+  timestampMethodCounts: Record<'metadata' | 'visible-time' | 'fallback', number>;
 }
 
 export function isValidExtensionChatData(data: unknown): data is ExtensionChatData {
@@ -101,18 +113,65 @@ export function isValidExtensionChatData(data: unknown): data is ExtensionChatDa
       if (!isValidParticipant(participant) || refs.has(participant.ref)) return false;
       refs.add(participant.ref);
     }
-    if (obj.messages.some((message) => message.senderRef && !refs.has(message.senderRef))) return false;
+    if (obj.messages.some((message) => message.senderRef && !refs.has(message.senderRef)))
+      return false;
   }
+  if (obj.diagnostics !== undefined && !isValidExtractionDiagnostics(obj.diagnostics)) return false;
 
   return true;
+}
+
+function isValidExtractionDiagnostics(value: unknown): value is ExtractionDiagnostics {
+  if (!value || typeof value !== 'object') return false;
+  const diagnostics = value as Record<string, unknown>;
+  if (
+    !isNonNegativeInteger(diagnostics.messageContainerCount) ||
+    !isNonNegativeInteger(diagnostics.extractedMessageCount)
+  )
+    return false;
+  return (
+    isCountMap(diagnostics.metadataPathCounts, ['container', 'ancestor', 'descendant', 'none']) &&
+    isCountMap(diagnostics.senderMethodCounts, [
+      'metadata',
+      'sender-element',
+      'conversation-header',
+      'outgoing',
+      'fallback',
+    ]) &&
+    isCountMap(diagnostics.timestampMethodCounts, ['metadata', 'visible-time', 'fallback'])
+  );
+}
+
+function isCountMap(value: unknown, keys: string[]): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const counts = value as Record<string, unknown>;
+  return (
+    Object.keys(counts).every((key) => keys.includes(key)) &&
+    keys.every((key) => isNonNegativeInteger(counts[key]))
+  );
+}
+
+function isNonNegativeInteger(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }
 
 function isValidParticipant(value: unknown): value is ExtractedParticipant {
   if (!value || typeof value !== 'object') return false;
   const participant = value as Record<string, unknown>;
-  if (typeof participant.ref !== 'string' || participant.ref.length === 0 || typeof participant.isSelf !== 'boolean') return false;
-  if (typeof participant.extractionMethod !== 'string' || typeof participant.confidence !== 'string') return false;
-  return ['rawDisplayName', 'rawUsername', 'normalizedPhone', 'platformUserId'].every((field) => participant[field] === undefined || typeof participant[field] === 'string');
+  if (
+    typeof participant.ref !== 'string' ||
+    participant.ref.length === 0 ||
+    typeof participant.isSelf !== 'boolean'
+  )
+    return false;
+  if (
+    typeof participant.extractionMethod !== 'string' ||
+    typeof participant.confidence !== 'string'
+  )
+    return false;
+  return ['rawDisplayName', 'rawUsername', 'normalizedPhone', 'platformUserId'].every(
+    (field) => participant[field] === undefined || typeof participant[field] === 'string'
+  );
 }
 
 /**
@@ -125,10 +184,17 @@ export function getLegacyParticipantLabels(chatData: ExtensionChatData): string[
     return [...new Set(chatData.messages.map((message) => message.sender))];
   }
 
-  return [...new Set(chatData.participants
-    .map((participant) => participant.rawDisplayName ||
-      chatData.messages.find((message) => message.senderRef === participant.ref)?.sender)
-    .filter((name): name is string => Boolean(name)))];
+  return [
+    ...new Set(
+      chatData.participants
+        .map(
+          (participant) =>
+            participant.rawDisplayName ||
+            chatData.messages.find((message) => message.senderRef === participant.ref)?.sender
+        )
+        .filter((name): name is string => Boolean(name))
+    ),
+  ];
 }
 
 function isValidMessage(msg: unknown): msg is ExtractedMessage {
@@ -287,12 +353,23 @@ router.post('/extension', authenticateToken, async (req, res) => {
       });
     }
 
-    // Limit the connector-provided label before logging and persistence.
+    // Limit the connector-provided label before persistence. It is never logged.
     const sanitizedChatName = sanitizeString(chatData.chatName, 200);
 
-    logger.info(
-      `Received extension chat data: ${sanitizedChatName} with ${chatData.messages.length} messages from user ${userId}`
-    );
+    logger.info('Received extension chat data', {
+      source: chatData.source,
+      connectorVersion: chatData.version,
+      payloadVersion: chatData.payloadVersion || 1,
+      messageCount: chatData.messages.length,
+      isGroup: chatData.isGroup,
+    });
+    if (chatData.diagnostics) {
+      logger.info('Extension intake diagnostics', {
+        source: chatData.source,
+        connectorVersion: chatData.version,
+        diagnostics: chatData.diagnostics,
+      });
+    }
 
     const saved = await conversationIntakeService.save({
       userId,

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -54,8 +54,24 @@ interface ExtractedParticipant {
   normalizedPhone?: string;
   platformUserId?: string;
   isSelf: boolean;
-  extractionMethod: "metadata" | "sender-element" | "conversation-header" | "outgoing" | "fallback";
+  extractionMethod:
+    | "metadata"
+    | "sender-element"
+    | "conversation-header"
+    | "outgoing"
+    | "fallback";
   confidence: "high" | "medium" | "low";
+}
+
+type MetadataPath = "container" | "ancestor" | "descendant" | "none";
+type TimestampMethod = "metadata" | "visible-time" | "fallback";
+
+interface ExtractionDiagnostics {
+  messageContainerCount: number;
+  extractedMessageCount: number;
+  metadataPathCounts: Record<MetadataPath, number>;
+  senderMethodCounts: Record<ExtractedParticipant["extractionMethod"], number>;
+  timestampMethodCounts: Record<TimestampMethod, number>;
 }
 
 interface ExtractedChat {
@@ -69,6 +85,7 @@ interface ExtractedChat {
   isGroup: boolean;
   payloadVersion: 2;
   participants: ExtractedParticipant[];
+  diagnostics: ExtractionDiagnostics;
 }
 
 interface ExtractionState {
@@ -414,6 +431,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
   const participants: ExtractedParticipant[] = [];
   const participantRefs = new Map<string, string>();
   const totalMessages = messageContainers.length;
+  const diagnostics = createExtractionDiagnostics(totalMessages);
 
   for (let i = 0; i < messageContainers.length; i++) {
     // Update progress
@@ -429,7 +447,14 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
     }
 
     try {
-      const message = extractMessageData(messageContainers[i] as HTMLElement, isDirectChat, chatName, participants, participantRefs);
+      const message = extractMessageData(
+        messageContainers[i] as HTMLElement,
+        isDirectChat,
+        chatName,
+        participants,
+        participantRefs,
+        diagnostics,
+      );
       if (message) {
         messages.push(message);
       }
@@ -455,6 +480,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
     isGroup,
     payloadVersion: 2,
     participants,
+    diagnostics,
   };
 }
 
@@ -467,6 +493,7 @@ function extractMessageData(
   chatName: string,
   participants: ExtractedParticipant[],
   participantRefs: Map<string, string>,
+  diagnostics: ExtractionDiagnostics,
 ): ExtractedMessage | null {
   // Get message text
   const textEl = findMessageText(
@@ -500,14 +527,33 @@ function extractMessageData(
     container.classList.contains("message-out") ||
     container.closest('[data-testid="msg-out"]') !== null;
   const metadata = getMessageMetadata(container);
-  const identity = extractSenderIdentity(container, senderEl, isOutgoing, isDirectChat, chatName, metadata);
-  const senderRef = registerParticipant(identity, participants, participantRefs);
+  const identity = extractSenderIdentity(
+    container,
+    senderEl,
+    isOutgoing,
+    isDirectChat,
+    chatName,
+    metadata.value,
+  );
+  const senderRef = registerParticipant(
+    identity,
+    participants,
+    participantRefs,
+  );
+  const timestamp = parseTimestamp(timeText, metadata.value);
+
+  diagnostics.extractedMessageCount += 1;
+  diagnostics.metadataPathCounts[metadata.path] += 1;
+  diagnostics.senderMethodCounts[identity.extractionMethod] += 1;
+  diagnostics.timestampMethodCounts[timestamp.method] += 1;
 
   return {
     id: generateMessageId(),
     text: isMedia && !text ? `[${mediaType || "Media"}]` : text,
-    sender: identity.rawDisplayName || `Unidentified participant ${participants.length || 1}`,
-    timestamp: parseTimestamp(timeText, metadata),
+    sender:
+      identity.rawDisplayName ||
+      `Unidentified participant ${participants.length || 1}`,
+    timestamp: timestamp.value,
     isOutgoing,
     isMedia,
     mediaType,
@@ -524,25 +570,46 @@ function extractSenderIdentity(
   metadata: string,
 ): Omit<ExtractedParticipant, "ref"> {
   if (isOutgoing) {
-    return { rawDisplayName: "You", isSelf: true, extractionMethod: "outgoing", confidence: "high" };
+    return {
+      rawDisplayName: "You",
+      isSelf: true,
+      extractionMethod: "outgoing",
+      confidence: "high",
+    };
   }
-  const metadataSender = parseWhatsAppMessageMetadata(metadata, document.documentElement.lang || navigator.language).sender;
+  const metadataSender = parseWhatsAppMessageMetadata(
+    metadata,
+    document.documentElement.lang || navigator.language,
+  ).sender;
   const explicitSender = senderEl?.textContent?.trim();
   // A failure to recognise a group is not proof this is a direct chat.
   const headerSender = isDirectChat
-    ? (querySelector(SELECTORS.primary.contactName, SELECTORS.fallback.contactName)?.textContent?.trim() ||
-      (chatName === "Unknown Chat" ? undefined : chatName))
+    ? querySelector(
+        SELECTORS.primary.contactName,
+        SELECTORS.fallback.contactName,
+      )?.textContent?.trim() ||
+      (chatName === "Unknown Chat" ? undefined : chatName)
     : undefined;
   const rawDisplayName = metadataSender || explicitSender || headerSender;
   const rawUsername = rawDisplayName?.match(/^@[^\s]+$/)?.[0];
   // WhatsApp commonly renders the phone alongside the sender label. It is
   // capture-scoped evidence, never a contact-book scrape.
   const phoneSource = rawDisplayName?.match(/\+?[0-9][0-9\s().-]{5,}/)?.[0];
-  const normalizedPhone = phoneSource ? phoneSource.replace(/[^0-9+]/g, "") : undefined;
+  const normalizedPhone = phoneSource
+    ? phoneSource.replace(/[^0-9+]/g, "")
+    : undefined;
   // data-id identifies an individual message in WhatsApp Web, not its sender.
-  const platformUserId = container.getAttribute("data-contact-id") ||
-    container.closest("[data-contact-id]")?.getAttribute("data-contact-id") || undefined;
-  const extractionMethod = metadataSender ? "metadata" : explicitSender ? "sender-element" : headerSender ? "conversation-header" : "fallback";
+  const platformUserId =
+    container.getAttribute("data-contact-id") ||
+    container.closest("[data-contact-id]")?.getAttribute("data-contact-id") ||
+    undefined;
+  const extractionMethod = metadataSender
+    ? "metadata"
+    : explicitSender
+      ? "sender-element"
+      : headerSender
+        ? "conversation-header"
+        : "fallback";
   return {
     rawDisplayName,
     rawUsername,
@@ -550,14 +617,34 @@ function extractSenderIdentity(
     platformUserId,
     isSelf: false,
     extractionMethod,
-    confidence: extractionMethod === "metadata" ? "high" : extractionMethod === "fallback" ? "low" : "medium",
+    confidence:
+      extractionMethod === "metadata"
+        ? "high"
+        : extractionMethod === "fallback"
+          ? "low"
+          : "medium",
   };
 }
 
-function getMessageMetadata(container: HTMLElement): string {
-  return container.getAttribute("data-pre-plain-text") ||
-    container.closest("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") ||
-    container.querySelector("[data-pre-plain-text]")?.getAttribute("data-pre-plain-text") || "";
+function getMessageMetadata(container: HTMLElement): {
+  value: string;
+  path: MetadataPath;
+} {
+  const containerMetadata = container.getAttribute("data-pre-plain-text");
+  if (containerMetadata) return { value: containerMetadata, path: "container" };
+
+  const ancestorMetadata = container
+    .closest("[data-pre-plain-text]")
+    ?.getAttribute("data-pre-plain-text");
+  if (ancestorMetadata) return { value: ancestorMetadata, path: "ancestor" };
+
+  const descendantMetadata = container
+    .querySelector("[data-pre-plain-text]")
+    ?.getAttribute("data-pre-plain-text");
+  if (descendantMetadata)
+    return { value: descendantMetadata, path: "descendant" };
+
+  return { value: "", path: "none" };
 }
 
 function registerParticipant(
@@ -567,7 +654,11 @@ function registerParticipant(
 ): string {
   const stableKey = identity.isSelf
     ? "self"
-    : identity.platformUserId || identity.normalizedPhone || identity.rawUsername || identity.rawDisplayName || `unidentified-${participants.length + 1}`;
+    : identity.platformUserId ||
+      identity.normalizedPhone ||
+      identity.rawUsername ||
+      identity.rawDisplayName ||
+      `unidentified-${participants.length + 1}`;
   const existing = participantRefs.get(stableKey);
   if (existing) return existing;
   const ref = `participant_${participants.length + 1}`;
@@ -594,7 +685,11 @@ function detectGroupChat(): boolean {
 }
 
 function detectDirectChat(): boolean {
-  const subtitle = document.querySelector('[data-testid="conversation-subtitle"]')?.textContent?.trim().toLowerCase() || "";
+  const subtitle =
+    document
+      .querySelector('[data-testid="conversation-subtitle"]')
+      ?.textContent?.trim()
+      .toLowerCase() || "";
   // These are direct-chat-only states in WhatsApp Web. Do not infer a direct
   // chat merely because the group detector did not recognise localized UI.
   return /\bonline\b|\btyping\b|last seen|disappearing messages/.test(subtitle);
@@ -630,13 +725,20 @@ function getMediaType(
   return undefined;
 }
 
-function parseTimestamp(timeText: string, metadata: string = ""): string {
+function parseTimestamp(
+  timeText: string,
+  metadata: string = "",
+): { value: string; method: TimestampMethod } {
   const now = new Date();
 
-  const metadataTimestamp = parseWhatsAppMessageMetadata(metadata, document.documentElement.lang || navigator.language).timestamp;
-  if (metadataTimestamp) return metadataTimestamp;
+  const metadataTimestamp = parseWhatsAppMessageMetadata(
+    metadata,
+    document.documentElement.lang || navigator.language,
+  ).timestamp;
+  if (metadataTimestamp)
+    return { value: metadataTimestamp, method: "metadata" };
 
-  if (!timeText) return now.toISOString();
+  if (!timeText) return { value: now.toISOString(), method: "fallback" };
 
   // Handle "HH:MM AM/PM" format
   if (timeText.match(/^\d{1,2}:\d{2}\s*(AM|PM)?$/i)) {
@@ -650,22 +752,40 @@ function parseTimestamp(timeText: string, metadata: string = ""): string {
       if (period === "AM" && hours === 12) hours = 0;
 
       now.setHours(hours, minutes, 0, 0);
-      return now.toISOString();
+      return { value: now.toISOString(), method: "visible-time" };
     }
   }
 
   // Handle "Yesterday" format
   if (timeText.toLowerCase().includes("yesterday")) {
     now.setDate(now.getDate() - 1);
-    return now.toISOString();
+    return { value: now.toISOString(), method: "visible-time" };
   }
 
   // Try parsing as date
   try {
-    return new Date(timeText).toISOString();
+    return { value: new Date(timeText).toISOString(), method: "visible-time" };
   } catch {
-    return now.toISOString();
+    return { value: now.toISOString(), method: "fallback" };
   }
+}
+
+function createExtractionDiagnostics(
+  messageContainerCount: number,
+): ExtractionDiagnostics {
+  return {
+    messageContainerCount,
+    extractedMessageCount: 0,
+    metadataPathCounts: { container: 0, ancestor: 0, descendant: 0, none: 0 },
+    senderMethodCounts: {
+      metadata: 0,
+      "sender-element": 0,
+      "conversation-header": 0,
+      outgoing: 0,
+      fallback: 0,
+    },
+    timestampMethodCounts: { metadata: 0, "visible-time": 0, fallback: 0 },
+  };
 }
 
 function generateMessageId(): string {

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.8");
+  assert.equal(manifest.version, "1.0.9");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {


### PR DESCRIPTION
## Summary\n- emit aggregate-only metadata, sender, and timestamp extraction counters with each extension upload\n- validate and log those counters server-side with the request correlation context\n- remove chat title and user identifier from extension intake logs\n- release extension v1.0.9\n\n## Validation\n- pnpm --filter @convolens/chrome-extension test\n- pnpm --filter @convolens/chrome-extension typecheck\n- pnpm --dir apps/api run test -- --runInBand --runTestsByPath C:\\Users\\smitj\\repos\\convolens\\apps\\api\\src\\routes\\__tests__\\chat-export.routes.test.ts\n- pnpm --dir apps/api run build\n- pnpm --filter @convolens/chrome-extension package