### PR TITLE
Normalize WhatsApp message records before extraction

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -28,6 +28,7 @@ import { parseWhatsAppMessageMetadata } from "./whatsapp-metadata";
 import {
   findConversationRoot,
   findMessageContainers,
+  findMessageRecord,
   findMessageText,
 } from "./dom-selectors";
 
@@ -495,9 +496,11 @@ function extractMessageData(
   participantRefs: Map<string, string>,
   diagnostics: ExtractionDiagnostics,
 ): ExtractedMessage | null {
+  const messageRecord = findMessageRecord(container);
+
   // Get message text
   const textEl = findMessageText(
-    container,
+    messageRecord,
     SELECTORS.primary.messageText,
     SELECTORS.fallback.messageText,
   );
@@ -505,30 +508,30 @@ function extractMessageData(
   const text = textEl?.textContent?.trim() || "";
 
   // Check for media messages
-  const isMedia = detectMediaMessage(container);
-  const mediaType = isMedia ? getMediaType(container) : undefined;
+  const isMedia = detectMediaMessage(messageRecord);
+  const mediaType = isMedia ? getMediaType(messageRecord) : undefined;
 
   // Skip if no text and no media
   if (!text && !isMedia) return null;
 
   // Get timestamp
   const timeEl =
-    container.querySelector(SELECTORS.primary.messageTime) ||
-    container.querySelector(SELECTORS.fallback.messageTime);
+    messageRecord.querySelector(SELECTORS.primary.messageTime) ||
+    messageRecord.querySelector(SELECTORS.fallback.messageTime);
   const timeText = timeEl?.textContent?.trim() || "";
 
   // Get sender (for group chats)
   const senderEl =
-    container.querySelector(SELECTORS.primary.senderName) ||
-    container.querySelector(SELECTORS.fallback.senderName);
+    messageRecord.querySelector(SELECTORS.primary.senderName) ||
+    messageRecord.querySelector(SELECTORS.fallback.senderName);
 
   // Determine direction
   const isOutgoing =
-    container.classList.contains("message-out") ||
-    container.closest('[data-testid="msg-out"]') !== null;
-  const metadata = getMessageMetadata(container);
+    messageRecord.classList.contains("message-out") ||
+    messageRecord.closest('[data-testid="msg-out"]') !== null;
+  const metadata = getMessageMetadata(messageRecord);
   const identity = extractSenderIdentity(
-    container,
+    messageRecord,
     senderEl,
     isOutgoing,
     isDirectChat,

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -61,6 +61,18 @@ export function findMessageContainers(
   return Array.from(containers);
 }
 
+/**
+ * A visual message bubble can be nested inside WhatsApp's actual message
+ * record. Normalize to that record before reading metadata or sender fields,
+ * because those fields may be siblings of the bubble rather than descendants.
+ */
+export function findMessageRecord(element: HTMLElement): HTMLElement {
+  return (
+    (element.closest('[data-id], [role="row"]') as HTMLElement | null) ||
+    element
+  );
+}
+
 export function findMessageText(
   container: Element,
   primarySelector: string,

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   findConversationRoot,
   findMessageContainers,
+  findMessageRecord,
   findMessageText,
   MESSAGE_TEXT_SELECTOR,
 } from "../src/dom-selectors.ts";
@@ -83,4 +84,11 @@ test("reads text through the generic selector used for container discovery", () 
     ),
     genericText,
   );
+});
+
+test("normalizes a visual bubble to its enclosing WhatsApp message record", () => {
+  const record = {};
+  const bubble = { closest: () => record };
+
+  assert.equal(findMessageRecord(bubble as unknown as HTMLElement), record);
 });

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.9");
+  assert.equal(manifest.version, "1.0.10");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {


### PR DESCRIPTION
## Summary\n- normalize visual WhatsApp bubbles to their enclosing message record before extraction\n- read sender, timestamp, and data-pre-plain-text metadata from that record\n- release extension v1.0.10\n\n## Evidence\nThe v1.0.9 retry logged 10 of 11 message records with no metadata and 10 fallback participants, which showed extraction was occurring on nested visual nodes.\n\n## Validation\n- pnpm --filter @convolens/chrome-extension test (13 passed)\n- pnpm --filter @convolens/chrome-extension typecheck\n- pnpm --filter @convolens/chrome-extension package