### PR TITLE
Preserve outgoing WhatsApp message direction

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -530,7 +530,8 @@ function extractMessageData(
     container.classList.contains("message-out") ||
     container.closest('[data-testid="msg-out"]') !== null ||
     messageRecord.classList.contains("message-out") ||
-    messageRecord.closest('[data-testid="msg-out"]') !== null;
+    messageRecord.closest('[data-testid="msg-out"]') !== null ||
+    messageRecord.querySelector('[data-testid="msg-out"]') !== null;
   const metadata = getMessageMetadata(messageRecord);
   const identity = extractSenderIdentity(
     messageRecord,

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -527,6 +527,8 @@ function extractMessageData(
 
   // Determine direction
   const isOutgoing =
+    container.classList.contains("message-out") ||
+    container.closest('[data-testid="msg-out"]') !== null ||
     messageRecord.classList.contains("message-out") ||
     messageRecord.closest('[data-testid="msg-out"]') !== null;
   const metadata = getMessageMetadata(messageRecord);

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -92,3 +92,19 @@ test("normalizes a visual bubble to its enclosing WhatsApp message record", () =
 
   assert.equal(findMessageRecord(bubble as unknown as HTMLElement), record);
 });
+
+test("keeps the original visual bubble when detecting outgoing messages", () => {
+  const contentSource = readFileSync(
+    new URL("../src/content.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    contentSource,
+    /container\.classList\.contains\("message-out"\)/,
+  );
+  assert.match(
+    contentSource,
+    /container\.closest\('\[data-testid="msg-out"\]'\)/,
+  );
+});

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -107,4 +107,8 @@ test("keeps the original visual bubble when detecting outgoing messages", () => 
     contentSource,
     /container\.closest\('\[data-testid="msg-out"\]'\)/,
   );
+  assert.match(
+    contentSource,
+    /messageRecord\.querySelector\('\[data-testid="msg-out"\]'\)/,
+  );
 });

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.10");
+  assert.equal(manifest.version, "1.0.11");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {


### PR DESCRIPTION
## Summary\n- retain original bubble direction after normalizing to a WhatsApp message record\n- release v1.0.11\n\n## Validation\n- pnpm --filter @convolens/chrome-extension test (14 passed)\n- pnpm --filter @convolens/chrome-extension typecheck\n- pnpm --filter @convolens/chrome-extension package