### PR TITLE
Plan the WhatsApp extension capture experience

### DIFF
--- a/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
+++ b/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
@@ -204,6 +204,14 @@ Deliverables:
 - Prefer a non-phone display name for the name field while retaining the phone separately.
 - Derive `Name · phone`, name-only, phone-only, or unidentified labels using section 4.1.
 - Preserve message-to-participant references through the API and durable conversation projection.
+- Preserve deduplication across sender-label upgrades with an explicit compatibility contract:
+  - keep the existing v1 content hash unchanged for already persisted intakes;
+  - add a versioned v2 exact hash for new captures that excludes mutable presentation labels and uses stable participant evidence only when available;
+  - add an owner-scoped compatibility fingerprint over the ordered semantic message stream (`content`, timestamp, direction, media flag/type), excluding generated source IDs and sender display labels;
+  - backfill or lazily derive that compatibility fingerprint for existing durable intakes before relying on it during rollout;
+  - look up the exact v2 hash first, then accept a compatibility match only when exactly one owner-scoped intake has the same ordered semantic stream;
+  - treat multiple compatibility candidates as ambiguous and do not silently collapse them;
+  - allow sender evidence to be enriched without rewriting the historical raw label or creating a second conversation.
 - Add fixtures for:
   - name and phone both present;
   - phone in metadata and name in the visible sender element;
@@ -211,6 +219,11 @@ Deliverables:
   - media-only group messages;
   - missing sender metadata;
   - direct-chat, outgoing, and system actors.
+- Add compatibility fixtures for:
+  - a pre-upgrade phone-only intake followed by an otherwise identical `Name · phone` capture;
+  - a pre-upgrade unidentified sender followed by a capture with newly available raw evidence;
+  - two distinct group captures whose messages look similar but whose exact stable evidence differs;
+  - multiple compatibility candidates, which must remain unresolved instead of being auto-deduplicated.
 - Detect video before image when both kinds of indicators occur in a thumbnail subtree.
 - Prefer semantic elements and accessible metadata (`video`, audio player, document/sticker markers) before generic image thumbnails.
 - Render a neutral media-type badge from persisted `isMedia` and `mediaType`.
@@ -224,7 +237,8 @@ Exit gate:
 - Media-only messages retain the correct sender whenever WhatsApp exposes one.
 - A video thumbnail with an image descendant is stored and displayed as `Video`, not `Image`.
 - Image and video messages display intentional labels rather than raw lowercase placeholders.
-- Existing content-hash deduplication remains deterministic.
+- Re-capturing a pre-upgrade phone-only conversation after the label becomes `Name · phone` returns the original intake as a duplicate rather than persisting a second conversation.
+- Existing v1 hashes remain valid, v2 hashes are deterministic, and ambiguous compatibility matches fail conservatively.
 - No raw participant or message evidence is added to logs.
 
 ### Phase 3 — Shared operation state
@@ -417,7 +431,7 @@ This document is the plan PR. Implementation should remain split into reviewable
 
 1. **PR A:** console attribution ledger, messaging audit, and reproduction fixtures.
 2. **PR B:** truthful loaded-count and progress hotfix.
-3. **PR C:** sender name/phone preservation and neutral media-type rendering.
+3. **PR C:** sender name/phone preservation, hash compatibility, and neutral media-type rendering.
 4. **PR D:** shared capture operation state.
 5. **PR E:** compact draggable launcher.
 6. **PR F:** preview and loaded-message mode.
@@ -436,6 +450,8 @@ Each implementation PR must preserve unrelated work, validate the exact changed 
 - Never capture other chats or the broader contact book as a side effect.
 - Never discard an available display name merely because a phone appears in higher-priority metadata.
 - Never infer a person link from a display name or phone fallback.
+- Never change a rendered sender label in a way that silently bypasses duplicate-ingest protection.
+- Never collapse ambiguous compatibility matches; require exact evidence or explicit reconciliation.
 - Never label a video as an image solely because its thumbnail contains an image element.
 - Never imply that a media marker means ConvoLens downloaded or retained the attachment.
 - Never log message text, raw sender/contact values, tokens, cookies, or session/runtime identifiers.

--- a/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
+++ b/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
@@ -1,0 +1,467 @@
+# ConvoLens WhatsApp capture experience plan
+
+**Status:** Proposed implementation plan
+
+**Date:** 2026-07-27
+
+**Scope:** Chrome extension capture truth, progress/state consistency, launcher UX, guided and automatic scrolled capture, console diagnostics, operational actions, and production acceptance
+
+## 1. Outcome and product decisions
+
+ConvoLens will offer three explicit WhatsApp capture modes:
+
+1. **Loaded messages** captures only the messages WhatsApp currently renders.
+2. **Capture as I scroll** accumulates virtualized message windows while the user scrolls.
+3. **Load older messages for me** scrolls the conversation under explicit user control until a chosen boundary or a safe stop condition.
+
+The extension must never describe the currently rendered messages as the complete chat unless it has positively verified the top of the conversation. Nothing is uploaded until the user reviews the capture scope and confirms the send.
+
+The current permanent pill will become a compact, movable launcher. Its expanded panel will provide capture scope, preview, operation status, queue/retry actions, and at most two clearly secondary `Soon` capabilities.
+
+## 2. Confirmed current behaviour
+
+### 2.1 Only rendered messages are captured
+
+WhatsApp Web virtualizes long conversations. The current extractor finds message containers in the active conversation DOM and does not load older history. The existing history-scroll call in `apps/chrome-extension/src/content.ts` is commented out, and there is no implemented history collector behind it.
+
+Therefore a long chat can contain hundreds of messages while only 16 are currently rendered and sent. The API is correctly acknowledging the 16-message payload; the extension copy is wrong when it implies that this represents the complete current chat.
+
+### 2.2 Popup extraction leaves the page progress bar partially filled
+
+The popup and in-page button currently split operation ownership:
+
+1. The popup asks the WhatsApp content script for `GET_CURRENT_CHAT`.
+2. `extractCurrentChat()` updates the in-page progress UI while iterating rendered messages.
+3. The popup receives the extracted data and independently asks the background worker to send it.
+4. The in-page operation never reaches its own upload-completion and progress-reset path.
+
+For 16 rendered messages, the last periodic progress update occurs at message 10:
+
+```text
+10 + (10 / 16 * 50) = 41.25%
+```
+
+That explains the approximately half-filled bar observed after a successful popup send.
+
+### 2.3 Overlay ordering is not controlled by Chrome
+
+The right-edge controls visible inside WhatsApp are independent page overlays injected by different extensions. Chrome lets users order pinned browser-toolbar icons, but it does not provide an ordering or collision-negotiation API for page overlays. ConvoLens must provide its own compact placement, drag, snap, and persistence behaviour.
+
+### 2.4 Sender and media fidelity is incomplete
+
+The supplied WhatsApp-versus-ConvoLens screenshots expose two additional capture defects:
+
+- WhatsApp can visibly provide both a sender name and phone number, while ConvoLens stores only the phone number.
+- A media-only message can arrive as `Unidentified participant N` even when WhatsApp visibly associates it with a sender.
+- Video thumbnails can contain image-like DOM descendants. The current media detector checks image indicators before video indicators, so a video can be mislabeled as an image.
+- The dashboard renders only `message.content`; it does not use the already persisted `isMedia` and `mediaType` fields to give media a deliberate presentation.
+
+The sender issue is caused by treating metadata, sender-element text, and the conversation header as mutually exclusive fallbacks. These sources can contain complementary evidence: one can hold the phone while another holds the display name. Core capture must collect all message-scoped evidence first, classify each value, and only then derive a display label.
+
+For the initial experience, media will remain a non-downloadable evidence marker:
+
+- `Image`
+- `Video`
+- `Audio`
+- `Document`
+- `Sticker`
+- `Media` only when the type cannot be determined
+
+If a media message also has a caption, the dashboard will show the media marker and caption separately. ConvoLens will not download, proxy, or imply retention of the WhatsApp attachment in this phase.
+
+## 3. Console signal attribution
+
+The supplied console output must be attributed before it becomes implementation scope. Similar filenames such as `content.js` are used by many extensions and do not identify ConvoLens by themselves.
+
+| Signal                                                             | Initial classification                               | Required evidence and action                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------------------ | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Loading Agent Desktop browser Extension content script`           | Foreign-extension informational log                  | The string does not exist in this repository. Expand the source link and record the full `chrome-extension://<id>/...` URL; map the ID in `chrome://extensions`. Do not change ConvoLens for this message.                                                                                                                        |
+| `Frame is not Agent Desktop, not initializing helper extension`    | Foreign-extension informational log                  | Treat as the Agent Desktop extension declining to initialize in a non-target frame. Confirm the source extension ID, then exclude it from ConvoLens defect counts.                                                                                                                                                                |
+| `storage.js ... Agent Desktop ... Runtime ID ...`                  | Foreign-extension informational log                  | Attribute by full source URL. Do not copy runtime/session material into issues or telemetry.                                                                                                                                                                                                                                      |
+| `content.js:7370 Uncaught (in promise) Object`                     | Likely foreign, not yet proven                       | Capture the full source URL, selected DevTools execution context, expanded rejection value, and stack with pause-on-uncaught enabled. If it belongs to Agent Desktop, isolate it there. If it belongs to ConvoLens, reject with an `Error`, catch at the sender, and attach an operation ID without message content.              |
+| `dashboard:1 Uncaught (in promise) Object`                         | Ambiguous                                            | Reproduce in a profile containing only ConvoLens and again with no extensions. Use the Network initiator and Sources call stack to decide whether this is the web app, ConvoLens, or another injected script. A `dashboard:1` label alone is not attribution.                                                                     |
+| Unused preload warnings                                            | Probably web/framework performance warnings          | Record each real resource URL, resource type, `<link rel="preload">` initiator, `as` value, and whether/when it is consumed. Remove or correct only ConvoLens-owned preloads. Measure the relevant page before claiming performance impact.                                                                                       |
+| `A listener indicated an asynchronous response ... channel closed` | Extension messaging lifecycle failure; owner unknown | Record the source extension ID and triggering action. Audit ConvoLens listeners and senders only if reproduced with ConvoLens as the sole extension. Ensure every handled async request responds, every sender catches rejection, and navigation/popup closure is represented as cancellation rather than an unhandled rejection. |
+
+Chrome's messaging contract requires an asynchronous listener that returns literal `true` to eventually call `sendResponse`; otherwise the sender can lose the channel. ConvoLens currently uses this pattern in both the background worker and content script, so it remains an explicit audit item even though the supplied `dashboard` errors are not yet attributable to ConvoLens.
+
+### 3.1 Attribution protocol
+
+For each signal:
+
+1. Clear the console and enable **Preserve log**.
+2. Enable pause on uncaught exceptions and promise rejections.
+3. Record the selected execution context: top page or named extension.
+4. Open the source link and capture the complete source URL and stack.
+5. If the URL begins `chrome-extension://`, map the ID through `chrome://extensions`.
+6. Record the user action immediately preceding the signal.
+7. Repeat with this profile matrix:
+   - Normal operator profile with all installed extensions.
+   - Agent Desktop disabled, ConvoLens enabled.
+   - Clean test profile with only the packaged ConvoLens extension.
+   - Clean profile with no extensions for dashboard-only warnings.
+8. Classify the signal as ConvoLens extension, ConvoLens web, third-party extension, browser/framework, or unresolved.
+
+Do not capture authentication tokens, cookies, message text, contact details, or runtime/session values in screenshots, issue bodies, logs, or Baton.
+
+## 4. Capture and operation model
+
+Both the popup and in-page launcher will render one shared capture operation:
+
+```text
+idle
+  -> inspecting
+  -> collecting
+  -> ready-for-review
+  -> uploading
+  -> received | duplicate | queued | failed | cancelled
+```
+
+Each operation contains:
+
+- operation ID;
+- tab and chat identity;
+- capture mode;
+- rendered, collected, extracted, skipped, and media counts;
+- oldest and newest detected timestamps;
+- collection stop reason;
+- upload result and resulting conversation URL;
+- start and completion timestamps;
+- safe error or cancellation reason.
+
+Raw captured content remains in the WhatsApp tab's memory until confirmed or cancelled. Initial delivery must not persist raw messages in `chrome.storage.local`. Only non-sensitive operation metadata may be retained for popup reopening and support diagnostics.
+
+### 4.1 Sender display fallback
+
+Message-scoped sender evidence will remain structured and unmerged:
+
+- raw metadata sender;
+- raw visible sender element;
+- raw display name when one is present;
+- raw phone display and normalized phone when present;
+- platform/contact ID when exposed on the selected message;
+- extraction path and confidence for every value.
+
+The initial user-facing label will be deterministic:
+
+1. `Display name · phone` when both are present.
+2. `Display name` when only the name is present.
+3. `Phone` when only the phone is present.
+4. `Unidentified participant N` only when neither exists.
+5. `You` and `System` remain special actors.
+
+This display fallback is not identity resolution. Names and phones must not be silently merged into People Directory records.
+
+## 5. Phased implementation
+
+### Phase 0 — Diagnostic baseline and attribution
+
+**Purpose:** Establish which console signals belong to ConvoLens before changing runtime code.
+
+Deliverables:
+
+- A reproducible console-attribution checklist based on section 3.1.
+- A signal ledger containing source owner, trigger, profile matrix result, severity, and disposition.
+- Explicit separation of Agent Desktop logs from ConvoLens defects.
+- Captured real URLs and initiators for preload warnings, with sensitive query values redacted.
+- A focused audit inventory of every ConvoLens `runtime.onMessage`, `tabs.sendMessage`, and `runtime.sendMessage` path.
+
+Exit gate:
+
+- Every supplied console signal is attributed or marked unresolved with the exact missing evidence.
+- No third-party signal is accepted as a ConvoLens defect without a ConvoLens source URL or clean-profile reproduction.
+- No sensitive browser/session material is stored in the evidence.
+
+### Phase 1 — Truthful count and progress hotfix
+
+**Purpose:** Correct the misleading and stuck UI before adding capture modes.
+
+Deliverables:
+
+- Extraction accepts an optional progress reporter.
+- Popup `GET_CURRENT_CHAT` extraction does not mutate the in-page launcher.
+- The in-page path resets progress on success, duplicate, queued, error, empty extraction, and cancellation.
+- Unknown-duration work uses an indeterminate indicator.
+- `Send Current Chat` becomes `Send Loaded Messages`.
+- Success becomes `<n> loaded messages received by ConvoLens`.
+- Copy states that older messages not loaded by WhatsApp were excluded.
+- Messaging senders catch and classify channel closure instead of producing unhandled promise rejections.
+
+Exit gate:
+
+- A 16-node fixture sends and persists exactly 16 messages.
+- Popup initiation leaves the in-page progress UI idle after completion.
+- Both surfaces show the same terminal result.
+- No UI calls the loaded subset the complete chat.
+
+### Phase 2 — Sender and media fidelity
+
+**Purpose:** Preserve the WhatsApp evidence visible in the supplied comparison screenshots.
+
+Deliverables:
+
+- Parse metadata sender, visible sender element, and message-scoped phone evidence independently instead of selecting the first non-empty string.
+- Prefer a non-phone display name for the name field while retaining the phone separately.
+- Derive `Name · phone`, name-only, phone-only, or unidentified labels using section 4.1.
+- Preserve message-to-participant references through the API and durable conversation projection.
+- Add fixtures for:
+  - name and phone both present;
+  - phone in metadata and name in the visible sender element;
+  - name in metadata and phone in a sibling/ancestor element;
+  - media-only group messages;
+  - missing sender metadata;
+  - direct-chat, outgoing, and system actors.
+- Detect video before image when both kinds of indicators occur in a thumbnail subtree.
+- Prefer semantic elements and accessible metadata (`video`, audio player, document/sticker markers) before generic image thumbnails.
+- Render a neutral media-type badge from persisted `isMedia` and `mediaType`.
+- Show a media caption separately when present.
+- Do not fetch or render the attachment itself.
+
+Exit gate:
+
+- A WhatsApp message showing `Greg Wright` and `+27 76 138 8725` renders both in ConvoLens.
+- Name-only and phone-only messages retain their available evidence.
+- Media-only messages retain the correct sender whenever WhatsApp exposes one.
+- A video thumbnail with an image descendant is stored and displayed as `Video`, not `Image`.
+- Image and video messages display intentional labels rather than raw lowercase placeholders.
+- Existing content-hash deduplication remains deterministic.
+- No raw participant or message evidence is added to logs.
+
+### Phase 3 — Shared operation state
+
+**Purpose:** Remove duplicated orchestration from the popup and page UI.
+
+Deliverables:
+
+- One capture command and operation state machine for both surfaces.
+- One active operation per WhatsApp tab.
+- Popup reopening displays the active or most recent operation.
+- Chat navigation cancels collection safely.
+- Double activation cannot create concurrent sends.
+- Every handled async message receives a serialized success, failure, or cancellation response.
+- Background and content-script teardown are treated as explicit lifecycle outcomes.
+
+Exit gate:
+
+- Start in either surface and observe the same state in the other.
+- Close the popup during upload; the operation continues and remains observable.
+- All operation paths terminate without an unhandled rejection or open message channel.
+
+### Phase 4 — Compact movable launcher
+
+**Purpose:** Prevent collisions with other page overlays and create a stable home for the workflow.
+
+Deliverables:
+
+- Compact 40-44px launcher instead of the permanent full-width pill.
+- Vertical drag with left/right edge snapping.
+- Upper, middle, and lower presets.
+- Persisted position, constrained to the current viewport.
+- Expanded panel that opens inward and remains on-screen.
+- Ready, collecting, review-count, received, queued, and attention states.
+- Keyboard, focus, reduced-motion, forced-colour, and narrow-window support.
+
+Exit gate:
+
+- Launcher position survives reload.
+- It does not cover the WhatsApp composer when collapsed.
+- The user can move it away from Agent Desktop or other extension overlays.
+- Expanded content remains usable at supported window sizes.
+
+### Phase 5 — Preview and capture-mode selection
+
+**Purpose:** Make capture scope explicit before data leaves WhatsApp.
+
+Deliverables:
+
+- Chat name and currently loaded message count.
+- Oldest/newest detected timestamps.
+- Detected participant-label, media, skipped, and unreadable counts.
+- Capture-mode choices:
+  - `Loaded messages`;
+  - `Capture as I scroll`;
+  - `Load older messages for me` marked `Soon` until Phase 7.
+- Review step showing exactly what will be uploaded.
+- Explicit confirm and cancel actions.
+
+Exit gate:
+
+- Preview count equals payload count.
+- Switching modes discards the prior unconfirmed buffer.
+- Cancel sends nothing.
+- Scope and exclusions remain visible through confirmation.
+
+### Phase 6 — Guided `Capture as I scroll`
+
+**Purpose:** Accumulate WhatsApp's virtualized message windows without taking control of the user's scroll.
+
+Deliverables:
+
+- User-initiated collection that observes the active conversation while the user scrolls upward.
+- Incremental extraction before WhatsApp removes old DOM windows.
+- Stable local fingerprints for overlap deduplication without changing the API's content-hash contract.
+- Running unique count and oldest captured date.
+- `Stop and review` and `Cancel` controls.
+- Abort on chat change, tab teardown, DOM failure, timeout, or safety limit.
+- Explicit stop reason in the review.
+
+Exit gate:
+
+- A 200-message virtualized fixture with 16 mounted nodes collects all 200 across guided windows.
+- Window overlap creates no duplicates.
+- Repeated text at different times remains distinct.
+- Incoming/outgoing direction, sender evidence, timestamps, and media markers survive collection.
+- Chat switching cannot mix two conversations.
+
+### Phase 7 — Automatic `Load older messages for me`
+
+**Purpose:** Add opt-in automatic history loading after guided collection is proven.
+
+Deliverables:
+
+- Confirmation that WhatsApp will scroll while collection runs.
+- Boundaries for last 7 days, last 30 days, message limit, or verified top.
+- Pause, resume, stop-and-review, and cancel.
+- DOM stabilization waits and no-progress detection.
+- Approximate restoration of the user's original scroll anchor.
+- Initial 500-message safety cap until proxy, API, database, and dashboard performance are verified.
+- Truthful completion reasons such as top reached, date boundary reached, cap reached, no progress, or cancelled.
+
+Exit gate:
+
+- Guided and automatic collection produce the same ordered result over the same range.
+- Cancellation stops automatic scrolling promptly.
+- `Complete conversation` appears only after verified top-of-history detection.
+- Large-capture validation shows the exact confirmed count in the API and dashboard.
+
+### Phase 8 — Operational actions and roadmap preview
+
+**Purpose:** Complete the practical capture loop without overloading the launcher.
+
+Live actions, in order:
+
+1. Open the received ConvoLens conversation.
+2. Display new-versus-duplicate result.
+3. Show queued upload count and retry safely.
+4. Display last capture count and time.
+5. Export the reviewed capture locally.
+6. Remember the preferred capture mode.
+7. Add a browser-toolbar badge for queue or attention state.
+
+Initial planned actions:
+
+- `Select individual messages` — `Soon`.
+- `Match participants` — `Soon`.
+
+Later planned actions, only after contracts exist:
+
+- `Draft follow-up` — `Soon`.
+- `Create ticket candidate` — `Soon`.
+
+Rules:
+
+- Show no more than two `Soon` actions at once.
+- Keep them inside the expanded panel, not on the launcher.
+- Clearly describe them as unavailable.
+- Identity matching remains conservative and user-confirmed.
+- Ticket and follow-up output remains draft-only and human-reviewed.
+- Do not advertise background automatic synchronization.
+
+Exit gate:
+
+- Retry cannot create unexpected duplicate conversations.
+- Queue state survives service-worker restart without persisting raw capture content unnecessarily.
+- Result links open the exact persisted conversation.
+- Local export matches the reviewed payload.
+
+### Phase 9 — Hardening, release, and authentic acceptance
+
+Automated matrix:
+
+- popup and launcher initiation;
+- all operation terminal states;
+- loaded-only, guided, and automatic collection;
+- virtual-window overlap and repeated messages;
+- direct and group conversations;
+- sender direction and identity evidence;
+- localized timestamps;
+- image/video/audio/document/sticker classification, captions, and unreadable-message accounting;
+- name-plus-phone, name-only, phone-only, and unidentified sender projection;
+- cancellation, navigation, popup closure, tab reload, and service-worker restart;
+- offline queue and retry;
+- API new-versus-duplicate response;
+- messaging-channel teardown without unhandled promise rejection;
+- preload inventory and web performance baseline;
+- extension tests, typecheck, build, package, version alignment, and ZIP inspection.
+
+Operator acceptance on an authorized long conversation:
+
+1. Record the initially loaded count.
+2. Send loaded-only mode and verify the exact persisted count.
+3. Run guided scrolled capture and record the increased count and range.
+4. Run automatic capture over the same boundary and compare results.
+5. Review and confirm the payload before sending.
+6. Verify API acknowledgement and the resulting dashboard conversation.
+7. Verify representative old/new messages and the exact persisted count.
+8. Re-send the identical capture and verify deterministic deduplication.
+9. Restart the API through the approved operation and verify persistence.
+10. Verify cross-user isolation and authenticated deletion.
+11. Repeat the console-attribution profile matrix and close only ConvoLens-owned errors.
+12. Record screenshots, safe IDs, timestamps, loaded extension version, build identity, and acceptance owner.
+
+Packaging, CI, health checks, synthetic fixtures, or a popup success message do not independently satisfy this operator gate.
+
+## 6. Planned implementation PR sequence
+
+This document is the plan PR. Implementation should remain split into reviewable follow-ups:
+
+1. **PR A:** console attribution ledger, messaging audit, and reproduction fixtures.
+2. **PR B:** truthful loaded-count and progress hotfix.
+3. **PR C:** sender name/phone preservation and neutral media-type rendering.
+4. **PR D:** shared capture operation state.
+5. **PR E:** compact draggable launcher.
+6. **PR F:** preview and loaded-message mode.
+7. **PR G:** guided `Capture as I scroll`.
+8. **PR H:** automatic older-history loading.
+9. **PR I:** queue, retry, result links, local export, and toolbar badge.
+10. **PR J:** carefully labelled future-action previews.
+11. **PR K:** release evidence, operator acceptance, and durable closeout.
+
+Each implementation PR must preserve unrelated work, validate the exact changed surface, and update the durable handoff with what is implemented, what is deployed, and what remains operator-held.
+
+## 7. Guardrails
+
+- Never claim full-history capture without verified top-of-conversation evidence.
+- Never upload while merely previewing or collecting.
+- Never capture other chats or the broader contact book as a side effect.
+- Never discard an available display name merely because a phone appears in higher-priority metadata.
+- Never infer a person link from a display name or phone fallback.
+- Never label a video as an image solely because its thumbnail contains an image element.
+- Never imply that a media marker means ConvoLens downloaded or retained the attachment.
+- Never log message text, raw sender/contact values, tokens, cookies, or session/runtime identifiers.
+- Never attribute a third-party extension error to ConvoLens from a generic filename alone.
+- Never turn `Soon` capabilities into implied live functionality.
+- Never silently merge participant identities.
+- Never turn a deterministic ticket candidate into automatic publishing.
+- Never call packaging, deployment health, or synthetic browser execution authentic operator acceptance.
+
+## 8. Primary code surfaces for implementation
+
+- `apps/chrome-extension/src/content.ts`
+- `apps/chrome-extension/src/content.css`
+- `apps/chrome-extension/src/background.ts`
+- `apps/chrome-extension/src/config.ts`
+- `apps/chrome-extension/src/dom-selectors.ts`
+- `apps/chrome-extension/popup/popup.js`
+- `apps/chrome-extension/popup/popup.html`
+- `apps/chrome-extension/tests/`
+- `apps/api/src/routes/chat-export.routes.ts`
+- `apps/api/src/services/conversation-intake.service.ts`
+- `apps/web/src/app/dashboard/conversations/[id]/page.tsx`
+
+## 9. Reference documentation
+
+- Chrome extension messaging: <https://developer.chrome.com/docs/extensions/develop/concepts/messaging>
+- Chrome extension debugging: <https://developer.chrome.com/docs/extensions/get-started/tutorial/debug>
+- Chrome content-script execution contexts: <https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts>
+- Preload warning interpretation: <https://web.dev/articles/codelab-preload-critical-assets>

--- a/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
+++ b/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
@@ -16,7 +16,7 @@ ConvoLens will offer three explicit WhatsApp capture modes:
 
 The extension must never describe the currently rendered messages as the complete chat unless it has positively verified the top of the conversation. Nothing is uploaded until the user reviews the capture scope and confirms the send.
 
-The current permanent pill will become a compact, movable launcher. Its expanded panel will provide capture scope, preview, operation status, queue/retry actions, and at most two clearly secondary `Soon` capabilities.
+The current permanent pill will become a compact, movable launcher. Its expanded panel will provide capture scope, preview, operation status, safe retry actions, and at most two clearly secondary `Soon` capabilities.
 
 ## 2. Confirmed current behaviour
 
@@ -114,7 +114,7 @@ idle
   -> collecting
   -> ready-for-review
   -> uploading
-  -> received | duplicate | queued | failed | cancelled
+  -> received | duplicate | retry-required | failed | cancelled
 ```
 
 Each operation contains:
@@ -129,7 +129,20 @@ Each operation contains:
 - start and completion timestamps;
 - safe error or cancellation reason.
 
-Raw captured content remains in the WhatsApp tab's memory until confirmed or cancelled. Initial delivery must not persist raw messages in `chrome.storage.local`. Only non-sensitive operation metadata may be retained for popup reopening and support diagnostics.
+The current extension's offline queue stores complete `chatData` payloads in `chrome.storage.local`. That existing behaviour conflicts with the target privacy boundary and must be migrated explicitly rather than ignored.
+
+For the initial target:
+
+- raw captured content remains in the WhatsApp tab's memory until confirmed, sent, failed, or cancelled;
+- new raw payloads are not added to `chrome.storage.local`;
+- a network/rate failure becomes `retry-required`, not a durable raw-message queue entry;
+- retry while the tab is alive may reuse the in-memory reviewed payload;
+- retry after tab reload requires the user to recapture and review;
+- only non-sensitive operation metadata may be retained for popup reopening and support diagnostics.
+
+On upgrade, legacy `pendingUploads` require a one-time migration surface. Automatic retry pauses until the authenticated user chooses **Retry now** or **Delete local queue**. The UI must disclose that these entries contain locally stored conversation data, show only safe counts/timestamps before confirmation, remove successfully sent or deleted entries, and remove the legacy storage key once empty. No legacy entry is silently uploaded, discarded, or copied into a new queue format.
+
+Durable offline message queuing remains unavailable until a separate threat model, explicit opt-in, encryption/key-management design, retention/expiry policy, deletion flow, and operator acceptance are approved. A future queue must not be implied by the initial launcher UI.
 
 ### 4.1 Sender display fallback
 
@@ -165,6 +178,7 @@ Deliverables:
 - Explicit separation of Agent Desktop logs from ConvoLens defects.
 - Captured real URLs and initiators for preload warnings, with sensitive query values redacted.
 - A focused audit inventory of every ConvoLens `runtime.onMessage`, `tabs.sendMessage`, and `runtime.sendMessage` path.
+- An inventory of legacy `pendingUploads`, automatic retry triggers, raw fields persisted locally, and the migration/removal path.
 
 Exit gate:
 
@@ -180,12 +194,14 @@ Deliverables:
 
 - Extraction accepts an optional progress reporter.
 - Popup `GET_CURRENT_CHAT` extraction does not mutate the in-page launcher.
-- The in-page path resets progress on success, duplicate, queued, error, empty extraction, and cancellation.
+- The in-page path resets progress on success, duplicate, retry-required, error, empty extraction, and cancellation.
 - Unknown-duration work uses an indeterminate indicator.
 - `Send Current Chat` becomes `Send Loaded Messages`.
 - Success becomes `<n> loaded messages received by ConvoLens`.
 - Copy states that older messages not loaded by WhatsApp were excluded.
 - Messaging senders catch and classify channel closure instead of producing unhandled promise rejections.
+- Stop adding new raw payloads to `pendingUploads`; network/rate failures become user-visible `retry-required` outcomes.
+- Add the one-time legacy-queue migration surface defined in section 4 before claiming the no-raw-local-persistence boundary.
 
 Exit gate:
 
@@ -206,11 +222,13 @@ Deliverables:
 - Preserve message-to-participant references through the API and durable conversation projection.
 - Preserve deduplication across sender-label upgrades with an explicit compatibility contract:
   - keep the existing v1 content hash unchanged for already persisted intakes;
-  - add a versioned v2 exact hash for new captures that excludes mutable presentation labels and uses stable participant evidence only when available;
-  - add an owner-scoped compatibility fingerprint over the ordered semantic message stream (`content`, timestamp, direction, media flag/type), excluding generated source IDs and sender display labels;
-  - backfill or lazily derive that compatibility fingerprint for existing durable intakes before relying on it during rollout;
-  - look up the exact v2 hash first, then accept a compatibility match only when exactly one owner-scoped intake has the same ordered semantic stream;
-  - treat multiple compatibility candidates as ambiguous and do not silently collapse them;
+  - capture a stable source-conversation identity before enabling automatic sender-label compatibility;
+  - add a versioned v2 exact hash for new captures, scoped by owner, source platform, and stable source-conversation identity, that excludes mutable presentation labels and uses stable participant evidence only when available;
+  - add a scoped compatibility fingerprint over the ordered semantic message stream (`content`, timestamp, direction, media flag/type), excluding generated source IDs and sender display labels;
+  - backfill or lazily derive that compatibility fingerprint for existing durable intakes, but accept it automatically only when the stable source-conversation identity also matches;
+  - look up the exact v2 hash first, then accept a compatibility match only when exactly one owner/platform/source-conversation-scoped intake has the same ordered semantic stream;
+  - treat missing stable conversation identity, multiple candidates, or conflicting stable participant evidence as ambiguous and do not silently collapse them;
+  - surface historical intakes without stable source-conversation identity as explicit reconciliation candidates rather than deduplicating them from message similarity alone;
   - allow sender evidence to be enriched without rewriting the historical raw label or creating a second conversation.
 - Add fixtures for:
   - name and phone both present;
@@ -220,9 +238,10 @@ Deliverables:
   - missing sender metadata;
   - direct-chat, outgoing, and system actors.
 - Add compatibility fixtures for:
-  - a pre-upgrade phone-only intake followed by an otherwise identical `Name · phone` capture;
-  - a pre-upgrade unidentified sender followed by a capture with newly available raw evidence;
-  - two distinct group captures whose messages look similar but whose exact stable evidence differs;
+  - a stable-conversation-scoped phone-only intake followed by an otherwise identical `Name · phone` capture;
+  - a historical intake without stable conversation identity followed by a capture with newly available raw evidence, which must require reconciliation;
+  - two distinct source conversations owned by the same user with identical ordered message tuples, which must remain distinct;
+  - matching message tuples with conflicting stable participant evidence, which must remain unresolved;
   - multiple compatibility candidates, which must remain unresolved instead of being auto-deduplicated.
 - Detect video before image when both kinds of indicators occur in a thumbnail subtree.
 - Prefer semantic elements and accessible metadata (`video`, audio player, document/sticker markers) before generic image thumbnails.
@@ -237,8 +256,10 @@ Exit gate:
 - Media-only messages retain the correct sender whenever WhatsApp exposes one.
 - A video thumbnail with an image descendant is stored and displayed as `Video`, not `Image`.
 - Image and video messages display intentional labels rather than raw lowercase placeholders.
-- Re-capturing a pre-upgrade phone-only conversation after the label becomes `Name · phone` returns the original intake as a duplicate rather than persisting a second conversation.
-- Existing v1 hashes remain valid, v2 hashes are deterministic, and ambiguous compatibility matches fail conservatively.
+- Re-capturing a stable-conversation-scoped phone-only intake after the label becomes `Name · phone` returns the original intake as a duplicate rather than persisting a second conversation.
+- Two distinct chats with identical ordered semantic messages do not collapse into one intake.
+- Historical intakes without stable source-conversation identity require explicit reconciliation.
+- Existing v1 hashes remain valid, v2 hashes are deterministic, and unscoped or ambiguous compatibility matches fail conservatively.
 - No raw participant or message evidence is added to logs.
 
 ### Phase 3 — Shared operation state
@@ -272,7 +293,7 @@ Deliverables:
 - Upper, middle, and lower presets.
 - Persisted position, constrained to the current viewport.
 - Expanded panel that opens inward and remains on-screen.
-- Ready, collecting, review-count, received, queued, and attention states.
+- Ready, collecting, review-count, received, retry-required, legacy-queue-migration, and attention states.
 - Keyboard, focus, reduced-motion, forced-colour, and narrow-window support.
 
 Exit gate:
@@ -356,11 +377,11 @@ Live actions, in order:
 
 1. Open the received ConvoLens conversation.
 2. Display new-versus-duplicate result.
-3. Show queued upload count and retry safely.
+3. Show retry-required state and retry safely while the reviewed in-memory payload remains available.
 4. Display last capture count and time.
 5. Export the reviewed capture locally.
 6. Remember the preferred capture mode.
-7. Add a browser-toolbar badge for queue or attention state.
+7. Add a browser-toolbar badge for retry-required, legacy-migration, or attention state.
 
 Initial planned actions:
 
@@ -384,7 +405,9 @@ Rules:
 Exit gate:
 
 - Retry cannot create unexpected duplicate conversations.
-- Queue state survives service-worker restart without persisting raw capture content unnecessarily.
+- Retry-required state survives service-worker restart only as non-sensitive metadata; raw retry after tab loss requires recapture and review.
+- Legacy raw queue entries are sent or deleted only after user confirmation and are removed from local storage afterward.
+- No new raw-message queue is introduced without the separate durable-queue approval defined in section 4.
 - Result links open the exact persisted conversation.
 - Local export matches the reviewed payload.
 
@@ -402,7 +425,7 @@ Automated matrix:
 - image/video/audio/document/sticker classification, captions, and unreadable-message accounting;
 - name-plus-phone, name-only, phone-only, and unidentified sender projection;
 - cancellation, navigation, popup closure, tab reload, and service-worker restart;
-- offline queue and retry;
+- legacy raw-queue migration, in-memory retry, tab loss, and recapture-required behaviour;
 - API new-versus-duplicate response;
 - messaging-channel teardown without unhandled promise rejection;
 - preload inventory and web performance baseline;
@@ -437,7 +460,7 @@ This document is the plan PR. Implementation should remain split into reviewable
 6. **PR F:** preview and loaded-message mode.
 7. **PR G:** guided `Capture as I scroll`.
 8. **PR H:** automatic older-history loading.
-9. **PR I:** queue, retry, result links, local export, and toolbar badge.
+9. **PR I:** safe retry, legacy-queue migration, result links, local export, and toolbar badge.
 10. **PR J:** carefully labelled future-action previews.
 11. **PR K:** release evidence, operator acceptance, and durable closeout.
 
@@ -451,9 +474,12 @@ Each implementation PR must preserve unrelated work, validate the exact changed 
 - Never discard an available display name merely because a phone appears in higher-priority metadata.
 - Never infer a person link from a display name or phone fallback.
 - Never change a rendered sender label in a way that silently bypasses duplicate-ingest protection.
-- Never collapse ambiguous compatibility matches; require exact evidence or explicit reconciliation.
+- Never deduplicate across chats from semantic message similarity alone; require matching stable source-conversation scope.
+- Never collapse unscoped or ambiguous compatibility matches; require exact evidence or explicit reconciliation.
 - Never label a video as an image solely because its thumbnail contains an image element.
 - Never imply that a media marker means ConvoLens downloaded or retained the attachment.
+- Never claim raw capture content is memory-only while a code path still writes it to `chrome.storage.local`.
+- Never silently upload or delete a legacy locally queued conversation during migration.
 - Never log message text, raw sender/contact values, tokens, cookies, or session/runtime identifiers.
 - Never attribute a third-party extension error to ConvoLens from a generic filename alone.
 - Never turn `Soon` capabilities into implied live functionality.

--- a/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
+++ b/docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md
@@ -202,6 +202,8 @@ Deliverables:
 - Messaging senders catch and classify channel closure instead of producing unhandled promise rejections.
 - Stop adding new raw payloads to `pendingUploads`; network/rate failures become user-visible `retry-required` outcomes.
 - Add the one-time legacy-queue migration surface defined in section 4 before claiming the no-raw-local-persistence boundary.
+- Disable every legacy automatic-retry trigger in the same hotfix before exposing migration: update/install lifecycle retry, periodic alarm retry, browser-online retry, and login/authentication retry.
+- Permit legacy payload transmission only from the authenticated migration surface after the user selects **Retry now**; no background trigger may call `retryPendingUploads()` during or after migration.
 
 Exit gate:
 
@@ -314,7 +316,7 @@ Deliverables:
 - Detected participant-label, media, skipped, and unreadable counts.
 - Capture-mode choices:
   - `Loaded messages`;
-  - `Capture as I scroll`;
+  - `Capture as I scroll` marked `Soon` and disabled until Phase 6 ships;
   - `Load older messages for me` marked `Soon` until Phase 7.
 - Review step showing exactly what will be uploaded.
 - Explicit confirm and cancel actions.
@@ -325,6 +327,7 @@ Exit gate:
 - Switching modes discards the prior unconfirmed buffer.
 - Cancel sends nothing.
 - Scope and exclusions remain visible through confirmation.
+- Disabled future modes cannot start collection and clearly identify their delivery phase.
 
 ### Phase 6 — Guided `Capture as I scroll`
 
@@ -334,7 +337,14 @@ Deliverables:
 
 - User-initiated collection that observes the active conversation while the user scrolls upward.
 - Incremental extraction before WhatsApp removes old DOM windows.
-- Stable local fingerprints for overlap deduplication without changing the API's content-hash contract.
+- Occurrence-safe overlap identity without changing the API's content-hash contract:
+  - prefer a stable WhatsApp message-scoped `data-id` or equivalent raw source ID when present;
+  - never use generated connector IDs for overlap deduplication;
+  - never globally collapse messages by sender/text/minute or another semantic `Set` key;
+  - when stable IDs are absent, treat each rendered window as an ordered sequence and merge it through maximal suffix/prefix overlap alignment, preserving repeated-token multiplicity and occurrence order;
+  - include raw metadata, direction, sender evidence, media type, and neighboring sequence context in fallback alignment;
+  - use smaller scroll increments when repeated sequences make the overlap ambiguous;
+  - if ambiguity remains, retain the candidate occurrences and surface a review warning rather than silently dropping a legitimate message.
 - Running unique count and oldest captured date.
 - `Stop and review` and `Cancel` controls.
 - Abort on chat change, tab teardown, DOM failure, timeout, or safety limit.
@@ -345,6 +355,9 @@ Exit gate:
 - A 200-message virtualized fixture with 16 mounted nodes collects all 200 across guided windows.
 - Window overlap creates no duplicates.
 - Repeated text at different times remains distinct.
+- Two messages from the same sender with identical text in the same timestamp minute both remain present.
+- The same repeated-message window observed twice does not create extra copies.
+- An overlap that cannot be aligned unambiguously is flagged for review rather than silently deduplicated.
 - Incoming/outgoing direction, sender evidence, timestamps, and media markers survive collection.
 - Chat switching cannot mix two conversations.
 
@@ -453,14 +466,14 @@ Packaging, CI, health checks, synthetic fixtures, or a popup success message do 
 This document is the plan PR. Implementation should remain split into reviewable follow-ups:
 
 1. **PR A:** console attribution ledger, messaging audit, and reproduction fixtures.
-2. **PR B:** truthful loaded-count and progress hotfix.
+2. **PR B:** truthful loaded-count/progress hotfix, automatic legacy-retry shutdown, and user-confirmed `pendingUploads` migration.
 3. **PR C:** sender name/phone preservation, hash compatibility, and neutral media-type rendering.
 4. **PR D:** shared capture operation state.
 5. **PR E:** compact draggable launcher.
 6. **PR F:** preview and loaded-message mode.
 7. **PR G:** guided `Capture as I scroll`.
 8. **PR H:** automatic older-history loading.
-9. **PR I:** safe retry, legacy-queue migration, result links, local export, and toolbar badge.
+9. **PR I:** safe in-memory retry, result links, local export, and toolbar badge; legacy raw-queue migration already ships in PR B.
 10. **PR J:** carefully labelled future-action previews.
 11. **PR K:** release evidence, operator acceptance, and durable closeout.
 

--- a/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
@@ -41,6 +41,7 @@ Canonical plan:
 6. ConvoLens still requires its own messaging audit because its listeners use asynchronous response channels.
 7. The comparison screenshots show that sender sources are complementary: ConvoLens can retain a phone while dropping the visible name because the extractor chooses one sender source by precedence.
 8. Media-only messages need sender-preservation fixtures, and video detection must take precedence over generic image-thumbnail evidence.
+9. Review on PR #146 identified that upgrading a stored sender from phone-only to `Name · phone` changes the existing sender-inclusive content hash and can create a duplicate intake unless compatibility is designed explicitly.
 
 ## Immediate next implementation slice
 
@@ -59,9 +60,11 @@ Then implement the sender/media fidelity slice before the shared operation-state
 1. Collect metadata sender, visible sender, and phone evidence independently.
 2. Render `Name · phone`, name-only, phone-only, or `Unidentified participant N` deterministically.
 3. Preserve the message participant reference through persistence and read projection.
-4. Detect video before image when both indicators exist.
-5. Render neutral `Image`, `Video`, `Audio`, `Document`, `Sticker`, or `Media` badges.
-6. Show captions separately and do not download attachments.
+4. Keep the v1 hash valid while introducing a versioned exact v2 hash and an owner-scoped semantic compatibility fingerprint that excludes mutable sender labels and generated source IDs.
+5. Prove a phone-only pre-upgrade intake and a later `Name · phone` recapture resolve to the original intake; ambiguous candidates must not auto-collapse.
+6. Detect video before image when both indicators exist.
+7. Render neutral `Image`, `Video`, `Audio`, `Document`, `Sticker`, or `Media` badges.
+8. Show captions separately and do not download attachments.
 
 Do not start automatic scrolling in the hotfix PR.
 
@@ -90,6 +93,8 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 - Do not expose raw message or identity evidence in logs.
 - Do not discard a name because a phone was found in another sender source.
 - Do not silently link People Directory identities from captured labels.
+- Do not let sender-label enrichment create a second intake for the same ordered semantic message stream.
+- Do not silently collapse ambiguous hash-compatibility candidates.
 - Do not imply that a media badge represents a retained attachment.
 - Do not show more than two secondary `Soon` capabilities.
 - Do not claim authentic acceptance until the authorized long-chat, persistence, deduplication, restart, isolation, and deletion sequence passes.
@@ -104,5 +109,5 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 ## Copy-paste continuation
 
 ```text
-Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck the live draft PR, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console attribution; do not assume generic content.js/dashboard errors belong to ConvoLens. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, detect video before image, and render neutral media badges without downloading attachments. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
+Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck live PR #146, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console attribution; do not assume generic content.js/dashboard errors belong to ConvoLens. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, add versioned exact and compatibility hashes so label enrichment cannot duplicate a pre-upgrade intake, detect video before image, and render neutral media badges without downloading attachments. Compatibility matches must be owner-scoped and ambiguity must fail conservatively. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
 ```

--- a/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
@@ -13,7 +13,7 @@ A repository-backed phased plan now covers the full extension discussion:
 - neutral image/video/audio/document/sticker markers without attachment download;
 - guided `Capture as I scroll`;
 - automatic older-history loading;
-- queue, retry, export, and result navigation;
+- safe retry, legacy raw-queue migration, export, and result navigation;
 - carefully labelled `Soon` functions;
 - console-source attribution for Agent Desktop, promise, preload, and message-channel signals;
 - authentic long-chat production acceptance.
@@ -42,6 +42,8 @@ Canonical plan:
 7. The comparison screenshots show that sender sources are complementary: ConvoLens can retain a phone while dropping the visible name because the extractor chooses one sender source by precedence.
 8. Media-only messages need sender-preservation fixtures, and video detection must take precedence over generic image-thumbnail evidence.
 9. Review on PR #146 identified that upgrading a stored sender from phone-only to `Name · phone` changes the existing sender-inclusive content hash and can create a duplicate intake unless compatibility is designed explicitly.
+10. Re-review identified that semantic-message compatibility must also match a stable source-conversation identity; otherwise two distinct chats with identical messages can be collapsed incorrectly.
+11. Re-review identified that the current `pendingUploads` queue persists complete payloads in `chrome.storage.local`, contradicting a memory-only raw-content target unless queue migration/removal is a prerequisite.
 
 ## Immediate next implementation slice
 
@@ -61,10 +63,19 @@ Then implement the sender/media fidelity slice before the shared operation-state
 2. Render `Name · phone`, name-only, phone-only, or `Unidentified participant N` deterministically.
 3. Preserve the message participant reference through persistence and read projection.
 4. Keep the v1 hash valid while introducing a versioned exact v2 hash and an owner-scoped semantic compatibility fingerprint that excludes mutable sender labels and generated source IDs.
-5. Prove a phone-only pre-upgrade intake and a later `Name · phone` recapture resolve to the original intake; ambiguous candidates must not auto-collapse.
-6. Detect video before image when both indicators exist.
-7. Render neutral `Image`, `Video`, `Audio`, `Document`, `Sticker`, or `Media` badges.
-8. Show captions separately and do not download attachments.
+5. Require matching owner, platform, and stable source-conversation identity before accepting a compatibility match; legacy intakes without that scope require explicit reconciliation.
+6. Prove a scoped phone-only intake and later `Name · phone` recapture resolve to the original intake, while two distinct chats with identical messages remain distinct.
+7. Detect video before image when both indicators exist.
+8. Render neutral `Image`, `Video`, `Audio`, `Document`, `Sticker`, or `Media` badges.
+9. Show captions separately and do not download attachments.
+
+Before claiming raw capture content is memory-only:
+
+1. Stop adding new full payloads to `chrome.storage.local`.
+2. Represent network/rate failures as retry-required, with in-memory retry while the tab remains alive.
+3. Add a one-time authenticated migration UI for existing `pendingUploads`: user-confirmed retry or deletion, followed by removal from local storage.
+4. Require recapture/review after tab loss rather than silently persisting a new raw queue.
+5. Keep any future durable offline queue behind a separate threat model, opt-in, encryption, retention, deletion, and operator-acceptance decision.
 
 Do not start automatic scrolling in the hotfix PR.
 
@@ -94,7 +105,10 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 - Do not discard a name because a phone was found in another sender source.
 - Do not silently link People Directory identities from captured labels.
 - Do not let sender-label enrichment create a second intake for the same ordered semantic message stream.
-- Do not silently collapse ambiguous hash-compatibility candidates.
+- Do not match compatibility candidates across different or unknown source-conversation identities.
+- Do not silently collapse unscoped or ambiguous hash-compatibility candidates.
+- Do not claim memory-only raw capture while `pendingUploads` still contains full payloads.
+- Do not silently retry or delete legacy queued payloads during migration.
 - Do not imply that a media badge represents a retained attachment.
 - Do not show more than two secondary `Soon` capabilities.
 - Do not claim authentic acceptance until the authorized long-chat, persistence, deduplication, restart, isolation, and deletion sequence passes.
@@ -109,5 +123,5 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 ## Copy-paste continuation
 
 ```text
-Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck live PR #146, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console attribution; do not assume generic content.js/dashboard errors belong to ConvoLens. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, add versioned exact and compatibility hashes so label enrichment cannot duplicate a pre-upgrade intake, detect video before image, and render neutral media badges without downloading attachments. Compatibility matches must be owner-scoped and ambiguity must fail conservatively. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
+Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck live PR #146, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console and local-storage attribution; do not assume generic content.js/dashboard errors belong to ConvoLens, and inventory the complete-payload `pendingUploads` path. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, no new raw local queue entries, a user-confirmed legacy queue migration, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, establish stable source-conversation identity, and add scoped versioned exact/compatibility hashes so label enrichment cannot duplicate a scoped intake or collapse two distinct chats. Legacy intakes without stable conversation identity require explicit reconciliation. Detect video before image and render neutral media badges without downloading attachments. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
 ```

--- a/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
@@ -44,6 +44,9 @@ Canonical plan:
 9. Review on PR #146 identified that upgrading a stored sender from phone-only to `Name · phone` changes the existing sender-inclusive content hash and can create a duplicate intake unless compatibility is designed explicitly.
 10. Re-review identified that semantic-message compatibility must also match a stable source-conversation identity; otherwise two distinct chats with identical messages can be collapsed incorrectly.
 11. Re-review identified that the current `pendingUploads` queue persists complete payloads in `chrome.storage.local`, contradicting a memory-only raw-content target unless queue migration/removal is a prerequisite.
+12. Follow-up review requires Phase 1 to disable update/alarm/online/login automatic retry triggers and ship legacy migration immediately, rather than leaving migration for the later operations PR.
+13. `Capture as I scroll` must remain disabled and marked `Soon` until its collector ships.
+14. Guided overlap merging must preserve same-sender, same-text, same-minute occurrences; generated IDs and global semantic-set deduplication are not acceptable.
 
 ## Immediate next implementation slice
 
@@ -73,9 +76,18 @@ Before claiming raw capture content is memory-only:
 
 1. Stop adding new full payloads to `chrome.storage.local`.
 2. Represent network/rate failures as retry-required, with in-memory retry while the tab remains alive.
-3. Add a one-time authenticated migration UI for existing `pendingUploads`: user-confirmed retry or deletion, followed by removal from local storage.
-4. Require recapture/review after tab loss rather than silently persisting a new raw queue.
-5. Keep any future durable offline queue behind a separate threat model, opt-in, encryption, retention, deletion, and operator-acceptance decision.
+3. Disable every automatic `retryPendingUploads()` trigger in the Phase 1 hotfix, including update, periodic alarm, online, and login/authentication paths.
+4. Add a one-time authenticated migration UI for existing `pendingUploads`: user-confirmed retry or deletion, followed by removal from local storage.
+5. Require recapture/review after tab loss rather than silently persisting a new raw queue.
+6. Keep any future durable offline queue behind a separate threat model, opt-in, encryption, retention, deletion, and operator-acceptance decision.
+
+Before enabling guided capture:
+
+1. Keep `Capture as I scroll` disabled and marked `Soon` in the preview-only release.
+2. Prefer stable WhatsApp message-scoped IDs for window overlap.
+3. When stable IDs are absent, merge ordered windows with occurrence-aware suffix/prefix alignment rather than a semantic `Set`.
+4. Preserve two legitimate same-sender, same-text, same-minute messages.
+5. Surface unresolved overlap ambiguity for review instead of silently dropping occurrences.
 
 Do not start automatic scrolling in the hotfix PR.
 
@@ -109,6 +121,9 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 - Do not silently collapse unscoped or ambiguous hash-compatibility candidates.
 - Do not claim memory-only raw capture while `pendingUploads` still contains full payloads.
 - Do not silently retry or delete legacy queued payloads during migration.
+- Do not leave an automatic legacy retry trigger active while migration requires user confirmation.
+- Do not enable a capture mode before its implementation phase ships.
+- Do not deduplicate virtualized windows with generated IDs or a global semantic-message set.
 - Do not imply that a media badge represents a retained attachment.
 - Do not show more than two secondary `Soon` capabilities.
 - Do not claim authentic acceptance until the authorized long-chat, persistence, deduplication, restart, isolation, and deletion sequence passes.
@@ -123,5 +138,5 @@ Redact tokens, cookies, message/contact data, and runtime/session values.
 ## Copy-paste continuation
 
 ```text
-Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck live PR #146, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console and local-storage attribution; do not assume generic content.js/dashboard errors belong to ConvoLens, and inventory the complete-payload `pendingUploads` path. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, no new raw local queue entries, a user-confirmed legacy queue migration, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, establish stable source-conversation identity, and add scoped versioned exact/compatibility hashes so label enrichment cannot duplicate a scoped intake or collapse two distinct chats. Legacy intakes without stable conversation identity require explicit reconciliation. Detect video before image and render neutral media badges without downloading attachments. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
+Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck live PR #146, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console and local-storage attribution; do not assume generic content.js/dashboard errors belong to ConvoLens, and inventory the complete-payload `pendingUploads` path. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, no new raw local queue entries, disable update/alarm/online/login automatic legacy retries, ship a user-confirmed legacy queue migration, and add focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, establish stable source-conversation identity, and add scoped versioned exact/compatibility hashes so label enrichment cannot duplicate a scoped intake or collapse two distinct chats. Legacy intakes without stable conversation identity require explicit reconciliation. Detect video before image and render neutral media badges without downloading attachments. Keep guided capture disabled/`Soon` until its phase ships; its collector must prefer stable message IDs and otherwise use occurrence-aware ordered-window alignment that preserves same-sender, same-text, same-minute messages. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
 ```

--- a/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
@@ -28,7 +28,7 @@ Canonical plan:
 - Base branch: `main`
 - Base commit: `2f8ab1a5895b92ed999934f33e52ac8e88324f9c`
 - Plan branch: `agent/extension-capture-plan`
-- Plan PR: populated after draft PR creation
+- Plan PR: [#146](https://github.com/neuralliquid/convolens/pull/146) (draft)
 - The primary checkout's untracked `docs/HANDOFF-2026-07-24-EXTENSION-RUNTIME.md` was left untouched.
 
 ## Confirmed findings

--- a/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
+++ b/docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md
@@ -1,0 +1,108 @@
+# ConvoLens extension capture plan handoff — 2026-07-27
+
+## Outcome
+
+A repository-backed phased plan now covers the full extension discussion:
+
+- truthful loaded-message capture;
+- the popup/in-page progress mismatch;
+- one shared operation state;
+- compact draggable launcher placement;
+- pre-send preview;
+- sender name-plus-phone preservation;
+- neutral image/video/audio/document/sticker markers without attachment download;
+- guided `Capture as I scroll`;
+- automatic older-history loading;
+- queue, retry, export, and result navigation;
+- carefully labelled `Soon` functions;
+- console-source attribution for Agent Desktop, promise, preload, and message-channel signals;
+- authentic long-chat production acceptance.
+
+Canonical plan:
+
+- `docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md`
+
+## Repository state at plan creation
+
+- Repository: `neuralliquid/convolens`
+- Base branch: `main`
+- Base commit: `2f8ab1a5895b92ed999934f33e52ac8e88324f9c`
+- Plan branch: `agent/extension-capture-plan`
+- Plan PR: populated after draft PR creation
+- The primary checkout's untracked `docs/HANDOFF-2026-07-24-EXTENSION-RUNTIME.md` was left untouched.
+
+## Confirmed findings
+
+1. The current extractor captures only messages rendered in WhatsApp's virtualized DOM. History scrolling is not implemented.
+2. The popup extraction path updates the in-page progress bar but performs upload outside the in-page operation, so the in-page reset path does not run.
+3. For 16 rendered messages, the final periodic extraction update is approximately 41%, matching the observed stuck bar.
+4. The `Agent Desktop` strings supplied by the operator do not occur in this repository and must be attributed to their owning extension ID.
+5. Generic `content.js`, `dashboard:1`, promise rejection, preload, and closed-channel messages are not sufficient attribution by themselves.
+6. ConvoLens still requires its own messaging audit because its listeners use asynchronous response channels.
+7. The comparison screenshots show that sender sources are complementary: ConvoLens can retain a phone while dropping the visible name because the extractor chooses one sender source by precedence.
+8. Media-only messages need sender-preservation fixtures, and video detection must take precedence over generic image-thumbnail evidence.
+
+## Immediate next implementation slice
+
+Start with the plan's Phase 0 and Phase 1 as separate reviewable changes:
+
+1. Capture the console profile matrix and attribute each supplied signal.
+2. Inventory ConvoLens message listeners and senders.
+3. Add a fixture representing 16 rendered messages from a longer virtualized chat.
+4. Make popup extraction UI-silent in the page.
+5. Guarantee progress reset for every in-page outcome.
+6. Rename the action to `Send Loaded Messages` and make exclusions explicit.
+7. Catch and classify expected message-channel teardown.
+
+Then implement the sender/media fidelity slice before the shared operation-state and launcher work:
+
+1. Collect metadata sender, visible sender, and phone evidence independently.
+2. Render `Name · phone`, name-only, phone-only, or `Unidentified participant N` deterministically.
+3. Preserve the message participant reference through persistence and read projection.
+4. Detect video before image when both indicators exist.
+5. Render neutral `Image`, `Video`, `Audio`, `Document`, `Sticker`, or `Media` badges.
+6. Show captions separately and do not download attachments.
+
+Do not start automatic scrolling in the hotfix PR.
+
+## Required evidence for console signals
+
+For every error or warning, record:
+
+- full source URL and extension ID when present;
+- selected DevTools execution context;
+- expanded stack or promise rejection;
+- triggering user action;
+- normal-profile result;
+- Agent-Desktop-disabled result;
+- ConvoLens-only clean-profile result;
+- no-extension dashboard result where relevant;
+- owner, severity, and disposition.
+
+Redact tokens, cookies, message/contact data, and runtime/session values.
+
+## Guardrails
+
+- Do not treat Agent Desktop logs as ConvoLens failures.
+- Do not call 16 rendered messages the complete chat.
+- Do not upload during preview or scrolled collection.
+- Do not scrape the broader WhatsApp contact surface.
+- Do not expose raw message or identity evidence in logs.
+- Do not discard a name because a phone was found in another sender source.
+- Do not silently link People Directory identities from captured labels.
+- Do not imply that a media badge represents a retained attachment.
+- Do not show more than two secondary `Soon` capabilities.
+- Do not claim authentic acceptance until the authorized long-chat, persistence, deduplication, restart, isolation, and deletion sequence passes.
+
+## Validation for this plan-only change
+
+- Confirm Markdown formatting and repository links.
+- Run `git diff --check`.
+- Confirm the diff contains documentation only.
+- Confirm the primary checkout remains unchanged.
+
+## Copy-paste continuation
+
+```text
+Continue ConvoLens extension work from docs/EXTENSION-CAPTURE-EXPERIENCE-PLAN.md and docs/HANDOFF-2026-07-27-EXTENSION-CAPTURE-PLAN.md. Recheck the live draft PR, current origin/main, checks, reviews, and worktree state. Preserve unrelated work. Begin with Phase 0 console attribution; do not assume generic content.js/dashboard errors belong to ConvoLens. Then implement Phase 1 as a narrow PR: truthful loaded-message wording, popup extraction that does not mutate page progress, terminal progress reset, safe messaging-channel handling, and focused 16-rendered-message regression coverage. Follow with the sender/media fidelity slice: collect visible name and phone independently, preserve participant references, detect video before image, and render neutral media badges without downloading attachments. Do not implement automatic scrolling in the hotfix. Keep production acceptance operator-held until the full authorized sequence passes.
+```


### PR DESCRIPTION
## What changed

- add a phased implementation plan for truthful loaded-message capture, guided and automatic scrolled capture, and one shared popup/launcher operation
- plan a compact draggable launcher with preview, queue/retry actions, and carefully labelled future functions
- add a sender/media fidelity phase for name-plus-phone preservation and neutral Image/Video/Audio/Document/Sticker markers
- add a source-attribution matrix for Agent Desktop logs, generic promise failures, unused preloads, and closed Chrome message channels
- add a durable handoff with the next implementation slice and guardrails

## Why

The current popup can report 16 received messages from a much longer WhatsApp conversation because it only reads rendered DOM nodes. Popup-triggered extraction also updates the in-page progress bar without running that surface's reset path, leaving it around 41%. Comparison screenshots additionally show dropped display names when a phone is retained, unidentified media senders, and video/image ambiguity.

The supplied console output mixes clearly foreign Agent Desktop logs with generic failures that cannot be assigned to ConvoLens from a filename alone. The plan requires extension-ID and clean-profile attribution before runtime fixes.

## Impact

Documentation only. No runtime, API, database, deployment, or production state changes.

## Validation

- `git diff --check`
- Prettier check for both Markdown files
- confirmed the diff contains only the plan and handoff
- created from current `origin/main` in an isolated worktree; the primary checkout's existing untracked handoff remains untouched
