### PR TITLE
Add loaded-message capture confirmation

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {
@@ -11,13 +11,7 @@
     "128": "icons/icon-128.png"
   },
 
-  "permissions": [
-    "storage",
-    "activeTab",
-    "scripting",
-    "alarms",
-    "notifications"
-  ],
+  "permissions": ["storage", "activeTab", "scripting", "notifications"],
 
   "host_permissions": [
     "https://web.whatsapp.com/*",

--- a/apps/chrome-extension/options/options.html
+++ b/apps/chrome-extension/options/options.html
@@ -84,6 +84,22 @@
       color: #666;
     }
 
+    .migration-copy {
+      color: #4b5563;
+      font-size: 13px;
+      line-height: 1.5;
+      margin-bottom: 12px;
+    }
+
+    .migration-meta {
+      padding: 12px;
+      border-radius: 8px;
+      background: #f3f4f6;
+      color: #374151;
+      font-size: 13px;
+      margin-bottom: 12px;
+    }
+
     .setting-control {
       margin-left: 16px;
     }
@@ -407,7 +423,7 @@
         </div>
         <div class="stat-item">
           <div class="stat-value" id="pendingUploads">0</div>
-          <div class="stat-label">Pending Uploads</div>
+          <div class="stat-label">Legacy Local Captures</div>
         </div>
         <div class="stat-item">
           <div class="stat-value" id="totalMessages">0</div>
@@ -424,11 +440,25 @@
       </div>
     </div>
 
+    <!-- Legacy queue migration -->
+    <div class="card">
+      <h2>Legacy Local Capture Migration</h2>
+      <p class="migration-copy">
+        Older extension versions may have stored complete captures without a trustworthy account owner.
+        ConvoLens will never upload those entries under the current account. You can export a local backup
+        or delete the local queue after confirmation.
+      </p>
+      <div class="migration-meta" id="legacyQueueSummary">No legacy local captures found.</div>
+      <div class="button-row" id="legacyQueueActions" style="display: none;">
+        <button class="btn btn-secondary" id="exportPending">Export Local Queue</button>
+        <button class="btn btn-danger" id="deletePending">Delete Local Queue</button>
+      </div>
+    </div>
+
     <!-- Data Management -->
     <div class="card">
       <h2>Data Management</h2>
       <div class="button-row">
-        <button class="btn btn-secondary" id="retryPending">Retry Pending Uploads</button>
         <button class="btn btn-danger" id="clearData">Clear All Data</button>
       </div>
       <div class="status" id="statusMessage"></div>

--- a/apps/chrome-extension/options/options.js
+++ b/apps/chrome-extension/options/options.js
@@ -48,7 +48,10 @@ const elements = {
   historyList: document.getElementById("historyList"),
 
   // Actions
-  retryPending: document.getElementById("retryPending"),
+  legacyQueueSummary: document.getElementById("legacyQueueSummary"),
+  legacyQueueActions: document.getElementById("legacyQueueActions"),
+  exportPending: document.getElementById("exportPending"),
+  deletePending: document.getElementById("deletePending"),
   clearData: document.getElementById("clearData"),
   statusMessage: document.getElementById("statusMessage"),
 
@@ -57,6 +60,35 @@ const elements = {
   helpLink: document.getElementById("helpLink"),
   privacyLink: document.getElementById("privacyLink"),
 };
+
+function normalizeExtensionError(error) {
+  const message =
+    typeof error === "string"
+      ? error
+      : error?.message || "Extension unavailable";
+  if (
+    /message port closed|receiving end does not exist|context invalidated/i.test(
+      message,
+    )
+  ) {
+    return "The extension channel closed. Reopen settings and try again.";
+  }
+  return message;
+}
+
+async function sendRuntimeMessage(message) {
+  try {
+    return await chrome.runtime.sendMessage(message);
+  } catch (error) {
+    throw new Error(normalizeExtensionError(error));
+  }
+}
+
+function runAction(action) {
+  Promise.resolve()
+    .then(action)
+    .catch((error) => showStatus(normalizeExtensionError(error), "error"));
+}
 
 // =============================================================================
 // Initialization
@@ -83,18 +115,31 @@ async function init() {
 function setupEventListeners() {
   // Auth buttons
   elements.loginBtn.addEventListener("click", handleLogin);
-  elements.logoutBtn.addEventListener("click", handleLogout);
+  elements.logoutBtn.addEventListener("click", () => runAction(handleLogout));
 
   // Settings changes
-  elements.showNotifications.addEventListener("change", saveSettings);
-  elements.extractMediaMetadata.addEventListener("change", saveSettings);
-  elements.theme.addEventListener("change", saveSettings);
-  elements.apiEndpoint.addEventListener("blur", saveSettings);
-  elements.maxStoredExtractions.addEventListener("change", saveSettings);
+  elements.showNotifications.addEventListener("change", () =>
+    runAction(saveSettings),
+  );
+  elements.extractMediaMetadata.addEventListener("change", () =>
+    runAction(saveSettings),
+  );
+  elements.theme.addEventListener("change", () => runAction(saveSettings));
+  elements.apiEndpoint.addEventListener("blur", () => runAction(saveSettings));
+  elements.maxStoredExtractions.addEventListener("change", () =>
+    runAction(saveSettings),
+  );
 
   // Actions
-  elements.retryPending.addEventListener("click", handleRetryPending);
-  elements.clearData.addEventListener("click", handleClearData);
+  elements.exportPending.addEventListener("click", () =>
+    runAction(handleExportPending),
+  );
+  elements.deletePending.addEventListener("click", () =>
+    runAction(handleDeletePending),
+  );
+  elements.clearData.addEventListener("click", () =>
+    runAction(handleClearData),
+  );
 }
 
 // =============================================================================
@@ -102,7 +147,7 @@ function setupEventListeners() {
 // =============================================================================
 
 async function loadAuthStatus() {
-  const response = await chrome.runtime.sendMessage({
+  const response = await sendRuntimeMessage({
     action: "GET_AUTH_STATUS",
   });
 
@@ -121,7 +166,7 @@ function handleLogin() {
 }
 
 async function handleLogout() {
-  await chrome.runtime.sendMessage({ action: "LOGOUT" });
+  await sendRuntimeMessage({ action: "LOGOUT" });
   await loadAuthStatus();
   showStatus("Logged out successfully", "success");
 }
@@ -131,7 +176,7 @@ async function handleLogout() {
 // =============================================================================
 
 async function loadSettings() {
-  const response = await chrome.runtime.sendMessage({ action: "GET_SETTINGS" });
+  const response = await sendRuntimeMessage({ action: "GET_SETTINGS" });
   const settings = response.data || DEFAULT_SETTINGS;
 
   elements.showNotifications.checked = settings.showNotifications;
@@ -151,7 +196,7 @@ async function saveSettings() {
     maxStoredExtractions: parseInt(elements.maxStoredExtractions.value, 10),
   };
 
-  const response = await chrome.runtime.sendMessage({
+  const response = await sendRuntimeMessage({
     action: "UPDATE_SETTINGS",
     settings,
   });
@@ -178,6 +223,21 @@ async function loadStats() {
 
   elements.totalExtractions.textContent = history.length.toString();
   elements.pendingUploads.textContent = pending.length.toString();
+
+  if (pending.length === 0) {
+    elements.legacyQueueSummary.textContent = "No legacy local captures found.";
+    elements.legacyQueueActions.style.display = "none";
+  } else {
+    const queuedTimes = pending
+      .map((item) => Number(item?.queuedAt))
+      .filter((value) => Number.isFinite(value) && value > 0)
+      .sort((a, b) => a - b);
+    const timeSummary = queuedTimes.length
+      ? ` Stored between ${new Date(queuedTimes[0]).toLocaleString()} and ${new Date(queuedTimes[queuedTimes.length - 1]).toLocaleString()}.`
+      : " Stored time is unavailable.";
+    elements.legacyQueueSummary.textContent = `${pending.length} unowned legacy local capture${pending.length === 1 ? "" : "s"}.${timeSummary}`;
+    elements.legacyQueueActions.style.display = "flex";
+  }
 
   // Calculate total messages
   const totalMessages = history.reduce(
@@ -256,30 +316,65 @@ function formatDate(isoString) {
 // Actions
 // =============================================================================
 
-async function handleRetryPending() {
-  elements.retryPending.disabled = true;
-  elements.retryPending.textContent = "Retrying...";
+async function handleExportPending() {
+  elements.exportPending.disabled = true;
+  try {
+    const stored = await chrome.storage.local.get([
+      STORAGE_KEYS.pendingUploads,
+    ]);
+    const pending = stored[STORAGE_KEYS.pendingUploads] || [];
+    if (pending.length === 0) {
+      showStatus("No legacy local captures to export", "error");
+      return;
+    }
+
+    const blob = new Blob(
+      [
+        JSON.stringify(
+          { exportedAt: new Date().toISOString(), pendingUploads: pending },
+          null,
+          2,
+        ),
+      ],
+      {
+        type: "application/json",
+      },
+    );
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `convolens-legacy-local-captures-${new Date().toISOString().slice(0, 10)}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    showStatus(
+      "Local queue exported. It remains stored until you delete it.",
+      "success",
+    );
+  } catch (error) {
+    showStatus(normalizeExtensionError(error), "error");
+  } finally {
+    elements.exportPending.disabled = false;
+  }
+}
+
+async function handleDeletePending() {
+  const stored = await chrome.storage.local.get([STORAGE_KEYS.pendingUploads]);
+  const pending = stored[STORAGE_KEYS.pendingUploads] || [];
+  if (pending.length === 0) return;
+  if (
+    !confirm(
+      `Delete ${pending.length} unowned legacy local capture${pending.length === 1 ? "" : "s"}? Export first if you need a backup. This cannot be undone.`,
+    )
+  ) {
+    return;
+  }
 
   try {
-    const response = await chrome.runtime.sendMessage({
-      action: "RETRY_PENDING_UPLOADS",
-    });
-
-    if (response.success) {
-      const { processed, failed, remaining } = response.data;
-      showStatus(
-        `Processed: ${processed}, Failed: ${failed}, Remaining: ${remaining}`,
-        processed > 0 ? "success" : "error",
-      );
-      await loadStats();
-    } else {
-      showStatus(response.error || "Failed to retry uploads", "error");
-    }
+    await chrome.storage.local.remove(STORAGE_KEYS.pendingUploads);
+    showStatus("Legacy local queue deleted", "success");
+    await loadStats();
   } catch (error) {
-    showStatus("Error: " + error.message, "error");
-  } finally {
-    elements.retryPending.disabled = false;
-    elements.retryPending.textContent = "Retry Pending Uploads";
+    showStatus(normalizeExtensionError(error), "error");
   }
 }
 
@@ -298,7 +393,6 @@ async function handleClearData() {
     // Re-initialize default settings
     await chrome.storage.local.set({
       [STORAGE_KEYS.settings]: DEFAULT_SETTINGS,
-      [STORAGE_KEYS.pendingUploads]: [],
       [STORAGE_KEYS.extractionHistory]: [],
     });
 
@@ -328,4 +422,6 @@ function showStatus(message, type) {
 // Initialize
 // =============================================================================
 
-init();
+init().catch((error) => {
+  showStatus(normalizeExtensionError(error), "error");
+});

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -207,6 +207,60 @@
         background: #fef2f2;
       }
 
+      .capture-preview {
+        display: none;
+        padding: 12px;
+        border: 1px solid #bbf7d0;
+        border-radius: 10px;
+        background: #f0fdf4;
+        font-size: 12px;
+        color: #374151;
+      }
+
+      .capture-preview.show {
+        display: block;
+      }
+
+      .capture-preview h4 {
+        margin-bottom: 6px;
+        color: #14532d;
+        font-size: 13px;
+      }
+
+      .capture-scope {
+        margin: 8px 0;
+        color: #4b5563;
+        line-height: 1.4;
+      }
+
+      .capture-modes {
+        display: grid;
+        gap: 5px;
+        margin: 8px 0 10px;
+      }
+
+      .capture-mode {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .capture-mode span:last-child {
+        color: #6b7280;
+        font-weight: 600;
+      }
+
+      .preview-actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .preview-actions button {
+        padding: 9px 10px;
+        font-size: 12px;
+      }
+
       .user-info {
         display: flex;
         align-items: center;
@@ -331,8 +385,33 @@
               Open Dashboard
             </button>
             <button class="btn-secondary" id="extractBtn">
-              Send Current Chat
+              Review loaded messages
             </button>
+            <div class="capture-preview" id="capturePreview">
+              <h4>Loaded-message review</h4>
+              <div id="captureSummary"></div>
+              <p class="capture-scope">
+                Only messages currently loaded by WhatsApp will be uploaded.
+                Unloaded older messages are excluded.
+              </p>
+              <div class="capture-modes" aria-label="Capture modes">
+                <div class="capture-mode">
+                  <span>Loaded messages</span><span>Selected</span>
+                </div>
+                <div class="capture-mode">
+                  <span>Capture as I scroll</span><span>Soon</span>
+                </div>
+                <div class="capture-mode">
+                  <span>Load older messages for me</span><span>Soon</span>
+                </div>
+              </div>
+              <div class="preview-actions">
+                <button class="btn-primary" id="confirmCapture">
+                  Confirm upload
+                </button>
+                <button class="btn-secondary" id="cancelCapture">Cancel</button>
+              </div>
+            </div>
             <button class="btn-secondary" id="logoutBtn">Sign Out</button>
             <div
               class="action-status"

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -281,21 +281,24 @@ extractBtn.addEventListener("click", async () => {
 
 confirmCapture.addEventListener("click", async () => {
   if (!pendingCapture) return;
+  const captureToSend = pendingCapture;
   confirmCapture.disabled = true;
   cancelCapture.disabled = true;
+  extractBtn.disabled = true;
+  logoutBtn.disabled = true;
   setActionStatus(
-    `Sending ${pendingCapture.messages.length} loaded messages…`,
+    `Sending ${captureToSend.messages.length} loaded messages…`,
     "info",
   );
 
   try {
     const sendResult = await sendRuntimeMessage({
       action: "SEND_CHAT_DATA",
-      data: pendingCapture,
+      data: captureToSend,
     });
     if (sendResult.success) {
-      const messageCount = pendingCapture.messages.length;
-      clearCapturePreview();
+      const messageCount = captureToSend.messages.length;
+      if (pendingCapture === captureToSend) clearCapturePreview();
       setActionStatus(
         `${messageCount} loaded message${messageCount === 1 ? "" : "s"} received by ConvoLens.`,
         "success",
@@ -314,6 +317,8 @@ confirmCapture.addEventListener("click", async () => {
   } finally {
     confirmCapture.disabled = false;
     cancelCapture.disabled = false;
+    extractBtn.disabled = false;
+    logoutBtn.disabled = false;
   }
 });
 

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -21,6 +21,12 @@ const userAvatar = document.getElementById("userAvatar");
 const actionStatus = document.getElementById("actionStatus");
 const extensionVersion = document.getElementById("extensionVersion");
 const dashboardLink = document.getElementById("dashboardLink");
+const capturePreview = document.getElementById("capturePreview");
+const captureSummary = document.getElementById("captureSummary");
+const confirmCapture = document.getElementById("confirmCapture");
+const cancelCapture = document.getElementById("cancelCapture");
+
+let pendingCapture = null;
 
 extensionVersion.textContent = `v${chrome.runtime.getManifest().version}`;
 dashboardLink.href = `${DASHBOARD_URL}/dashboard`;
@@ -30,6 +36,43 @@ function setActionStatus(message = "", type = "info") {
   actionStatus.className = message
     ? `action-status show ${type}`
     : "action-status";
+}
+
+function normalizeExtensionError(error) {
+  const message =
+    typeof error === "string"
+      ? error
+      : error?.message || "Extension unavailable";
+  if (
+    /message port closed|receiving end does not exist|context invalidated|tab was closed/i.test(
+      message,
+    )
+  ) {
+    return "The extension channel closed. Reopen the popup and review the loaded messages again.";
+  }
+  return message;
+}
+
+async function sendRuntimeMessage(message) {
+  try {
+    return await chrome.runtime.sendMessage(message);
+  } catch (error) {
+    const normalized = new Error(normalizeExtensionError(error));
+    normalized.code = "channel-closed";
+    throw normalized;
+  }
+}
+
+function openTab(url) {
+  chrome.tabs
+    .create({ url })
+    .catch((error) => setActionStatus(normalizeExtensionError(error), "error"));
+}
+
+function clearCapturePreview() {
+  pendingCapture = null;
+  captureSummary.textContent = "";
+  capturePreview.classList.remove("show");
 }
 
 function isWhatsAppTab(tab) {
@@ -75,7 +118,7 @@ async function sendToWhatsApp(tabId, message) {
 // Initialize popup
 async function init() {
   // Check auth status
-  const authStatus = await chrome.runtime.sendMessage({
+  const authStatus = await sendRuntimeMessage({
     action: "GET_AUTH_STATUS",
   });
 
@@ -143,40 +186,50 @@ loginBtn.addEventListener("click", async () => {
   loginBtn.textContent = "Connecting…";
   loginBtn.disabled = true;
 
-  const result = await chrome.runtime.sendMessage({
-    action: "SYNC_MYSTIRA_AUTH",
-  });
-
-  loginBtn.textContent = "I've signed in — connect";
-  loginBtn.disabled = false;
-
-  if (result.success) {
-    showLoggedIn(result.data?.user);
-    loginError.textContent = "";
-    setActionStatus("Connected. Choose a WhatsApp chat to send.", "success");
-  } else {
-    loginError.textContent =
-      result.error || "Complete sign in, then try again.";
-    chrome.tabs.create({
-      url: `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
-    });
+  try {
+    const result = await sendRuntimeMessage({ action: "SYNC_MYSTIRA_AUTH" });
+    if (result.success) {
+      showLoggedIn(result.data?.user);
+      loginError.textContent = "";
+      setActionStatus(
+        "Connected. Choose a WhatsApp chat and review its loaded messages.",
+        "success",
+      );
+    } else {
+      loginError.textContent =
+        result.error || "Complete sign in, then try again.";
+      openTab(
+        `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
+      );
+    }
+  } catch (error) {
+    loginError.textContent = normalizeExtensionError(error);
+  } finally {
+    loginBtn.textContent = "I've signed in — connect";
+    loginBtn.disabled = false;
   }
 });
 
 signupBtn.addEventListener("click", () => {
-  chrome.tabs.create({
-    url: `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
-  });
+  openTab(
+    `${DASHBOARD_URL}/login?callbackUrl=${encodeURIComponent("/dashboard/import")}`,
+  );
 });
 
 logoutBtn.addEventListener("click", async () => {
-  await chrome.runtime.sendMessage({ action: "LOGOUT" });
-  showLoggedOut();
+  try {
+    await sendRuntimeMessage({ action: "LOGOUT" });
+    clearCapturePreview();
+    showLoggedOut();
+  } catch (error) {
+    setActionStatus(normalizeExtensionError(error), "error");
+  }
 });
 
 extractBtn.addEventListener("click", async () => {
-  const defaultLabel = "Send Current Chat";
+  const defaultLabel = "Review loaded messages";
   setActionStatus("");
+  clearCapturePreview();
 
   try {
     const tab = await getWhatsAppTab();
@@ -186,7 +239,7 @@ extractBtn.addEventListener("click", async () => {
       return;
     }
 
-    extractBtn.textContent = "Reading chat…";
+    extractBtn.textContent = "Reading loaded messages…";
     extractBtn.disabled = true;
 
     const response = await sendToWhatsApp(tab.id, {
@@ -194,28 +247,21 @@ extractBtn.addEventListener("click", async () => {
     });
 
     if (response.success) {
-      const sendResult = await chrome.runtime.sendMessage({
-        action: "SEND_CHAT_DATA",
-        data: response.data,
-      });
-
-      if (sendResult.success) {
-        extractBtn.textContent = "Sent";
-        const messageCount = response.data?.messages?.length;
+      const messageCount = response.data?.messages?.length || 0;
+      if (!messageCount) {
         setActionStatus(
-          messageCount
-            ? `${messageCount} messages received by ConvoLens.`
-            : "Chat received by ConvoLens.",
-          "success",
+          "No readable loaded messages were found in the selected chat.",
+          "error",
         );
-      } else {
-        const wasSaved = sendResult.error?.toLowerCase().includes("saved");
-        setActionStatus(
-          sendResult.error ||
-            "ConvoLens could not receive this chat. Please try again.",
-          wasSaved ? "info" : "error",
-        );
+        return;
       }
+      pendingCapture = response.data;
+      captureSummary.textContent = `${messageCount} loaded message${messageCount === 1 ? "" : "s"} from ${response.data.chatName || "the selected chat"}.`;
+      capturePreview.classList.add("show");
+      setActionStatus(
+        "Review the loaded-message scope, then confirm or cancel.",
+        "info",
+      );
     } else {
       setActionStatus(
         response.error ||
@@ -224,16 +270,7 @@ extractBtn.addEventListener("click", async () => {
       );
     }
   } catch (error) {
-    const receiverUnavailable = error?.message?.includes(
-      "Receiving end does not exist",
-    );
-    setActionStatus(
-      receiverUnavailable
-        ? "Refresh WhatsApp Web once, then reopen the chat."
-        : error?.message ||
-            "The extension could not read this chat. Please try again.",
-      "error",
-    );
+    setActionStatus(normalizeExtensionError(error), "error");
   } finally {
     window.setTimeout(() => {
       extractBtn.textContent = defaultLabel;
@@ -242,9 +279,54 @@ extractBtn.addEventListener("click", async () => {
   }
 });
 
+confirmCapture.addEventListener("click", async () => {
+  if (!pendingCapture) return;
+  confirmCapture.disabled = true;
+  cancelCapture.disabled = true;
+  setActionStatus(
+    `Sending ${pendingCapture.messages.length} loaded messages…`,
+    "info",
+  );
+
+  try {
+    const sendResult = await sendRuntimeMessage({
+      action: "SEND_CHAT_DATA",
+      data: pendingCapture,
+    });
+    if (sendResult.success) {
+      const messageCount = pendingCapture.messages.length;
+      clearCapturePreview();
+      setActionStatus(
+        `${messageCount} loaded message${messageCount === 1 ? "" : "s"} received by ConvoLens.`,
+        "success",
+      );
+    } else {
+      setActionStatus(
+        sendResult.retryRequired
+          ? "Upload not sent. Keep this popup open to retry, or recapture and review again."
+          : sendResult.error ||
+              "ConvoLens could not receive these loaded messages.",
+        "error",
+      );
+    }
+  } catch (error) {
+    setActionStatus(normalizeExtensionError(error), "error");
+  } finally {
+    confirmCapture.disabled = false;
+    cancelCapture.disabled = false;
+  }
+});
+
+cancelCapture.addEventListener("click", () => {
+  clearCapturePreview();
+  setActionStatus("Upload cancelled. Nothing was sent.", "info");
+});
+
 openDashboard.addEventListener("click", () => {
-  chrome.tabs.create({ url: `${DASHBOARD_URL}/dashboard` });
+  openTab(`${DASHBOARD_URL}/dashboard`);
 });
 
 // Initialize
-init();
+init().catch((error) => {
+  setActionStatus(normalizeExtensionError(error), "error");
+});

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -33,6 +33,16 @@ interface RateLimitState {
   resetTime: number;
 }
 
+class HttpRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "HttpRequestError";
+  }
+}
+
 // Storage key for persistent rate limiting
 const RATE_LIMIT_STORAGE_KEY = "ws_rate_limit_state";
 
@@ -194,7 +204,7 @@ async function sendChatData(chatData: any): Promise<ExtensionResponse> {
   } catch (error) {
     console.error("[Background] Send failed; recapture is required");
 
-    if (isNetworkError(error)) {
+    if (isNetworkError(error) || isRateLimitError(error)) {
       return {
         success: false,
         code: "retry-required",
@@ -252,13 +262,15 @@ async function fetchWithRetry(
           response.status < 500 &&
           response.status !== 429
         ) {
-          throw new Error(
+          throw new HttpRequestError(
             errorData.message || `Request failed: ${response.status}`,
+            response.status,
           );
         }
 
-        throw new Error(
+        throw new HttpRequestError(
           errorData.message || `Request failed: ${response.status}`,
+          response.status,
         );
       }
 
@@ -304,6 +316,10 @@ function isNetworkError(error: any): boolean {
     error.message?.includes("network") ||
     error.message?.includes("offline")
   );
+}
+
+function isRateLimitError(error: unknown): boolean {
+  return error instanceof HttpRequestError && error.status === 429;
 }
 
 // =============================================================================

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -4,7 +4,7 @@
  * Handles all background operations for the extension:
  * - API communication with retry logic
  * - Authentication state management
- * - Offline queue processing
+ * - Explicit retry-required responses without persisting new raw captures
  * - Settings management
  * - Error tracking
  */
@@ -28,12 +28,6 @@ import {
 // Types
 // =============================================================================
 
-interface PendingUpload {
-  data: any;
-  queuedAt: number;
-  attempts: number;
-}
-
 interface RateLimitState {
   apiCallCount: number;
   resetTime: number;
@@ -53,11 +47,33 @@ chrome.runtime.onMessage.addListener(
     sendResponse: (response: ExtensionResponse) => void,
   ) => {
     handleMessage(message, sender)
-      .then(sendResponse)
-      .catch((error) => sendResponse({ success: false, error: error.message }));
+      .then((response) => respondSafely(sendResponse, response))
+      .catch((error) =>
+        respondSafely(sendResponse, {
+          success: false,
+          error: normalizeErrorMessage(error),
+        }),
+      );
     return true; // Indicates async response
   },
 );
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return "The extension operation could not be completed.";
+}
+
+function respondSafely(
+  sendResponse: (response: ExtensionResponse) => void,
+  response: ExtensionResponse,
+): void {
+  try {
+    sendResponse(response);
+  } catch {
+    // The popup, tab, or frame can close while an async response is pending.
+  }
+}
 
 async function handleMessage(
   message: ExtensionMessage,
@@ -105,9 +121,6 @@ async function handleMessage(
       return await updateSettings(typedMessage.settings);
     }
 
-    case "RETRY_PENDING_UPLOADS":
-      return await retryPendingUploads();
-
     case "CLEAR_PENDING_UPLOADS":
       return await clearPendingUploads();
 
@@ -150,9 +163,13 @@ async function sendChatData(chatData: any): Promise<ExtensionResponse> {
     // Check rate limiting (persistent across service worker restarts)
     const canProceed = await checkApiRateLimit();
     if (!canProceed) {
-      // Queue for later
-      await queuePendingUpload(chatData);
-      return { success: false, error: "Rate limited. Queued for later." };
+      return {
+        success: false,
+        code: "retry-required",
+        retryRequired: true,
+        error:
+          "Upload not sent because the extension is rate limited. Retry from this WhatsApp tab after reviewing the loaded messages again.",
+      };
     }
 
     // Send with retry (include tracing headers for distributed tracing)
@@ -175,21 +192,19 @@ async function sendChatData(chatData: any): Promise<ExtensionResponse> {
 
     return { success: true, data: result };
   } catch (error) {
-    console.error("[Background] Send error:", error);
+    console.error("[Background] Send failed; recapture is required");
 
-    // Queue for offline sync if network error
     if (isNetworkError(error)) {
-      await queuePendingUpload(chatData);
       return {
         success: false,
+        code: "retry-required",
+        retryRequired: true,
         error:
-          (error as Error).name === "TimeoutError"
-            ? "ConvoLens took too long to respond. This chat was saved for automatic retry."
-            : "Connection lost. This chat was saved for automatic retry.",
+          "Upload not sent. Retry from this WhatsApp tab after reviewing the loaded messages again.",
       };
     }
 
-    return { success: false, error: (error as Error).message };
+    return { success: false, error: normalizeErrorMessage(error) };
   }
 }
 
@@ -252,7 +267,7 @@ async function fetchWithRetry(
       const normalizedError = didTimeout
         ? Object.assign(
             new Error(
-              "ConvoLens took too long to respond. The chat was saved for automatic retry.",
+              "ConvoLens took too long to respond. The upload was not sent.",
             ),
             { name: "TimeoutError" },
           )
@@ -448,9 +463,6 @@ async function handleLogin(
 
     await notifyContentScripts(token);
 
-    // Process any pending uploads
-    retryPendingUploads().catch(console.error);
-
     return { success: true, data: { user } };
   } catch (error) {
     return { success: false, error: (error as Error).message };
@@ -505,91 +517,11 @@ async function getApiConfig() {
 }
 
 // =============================================================================
-// Pending Uploads (Offline Queue)
+// Legacy Pending Upload Migration
 // =============================================================================
 
-async function queuePendingUpload(data: any): Promise<void> {
-  const stored = await chrome.storage.local.get([STORAGE_KEYS.pendingUploads]);
-  const pending: PendingUpload[] = stored[STORAGE_KEYS.pendingUploads] || [];
-
-  pending.push({
-    data,
-    queuedAt: Date.now(),
-    attempts: 0,
-  });
-
-  // Keep only last 20 pending uploads, warn if dropping
-  let dropped = 0;
-  while (pending.length > 20) {
-    pending.shift();
-    dropped++;
-  }
-
-  if (dropped > 0) {
-    console.warn(
-      `[Background] Queue full. Dropped ${dropped} oldest upload(s) to make room.`,
-    );
-  }
-
-  await chrome.storage.local.set({ [STORAGE_KEYS.pendingUploads]: pending });
-  console.log("[Background] Queued pending upload. Total:", pending.length);
-}
-
-async function retryPendingUploads(): Promise<ExtensionResponse> {
-  const stored = await chrome.storage.local.get([
-    STORAGE_KEYS.pendingUploads,
-    STORAGE_KEYS.authToken,
-  ]);
-
-  if (!stored[STORAGE_KEYS.authToken]) {
-    return { success: false, error: "Not authenticated" };
-  }
-
-  const pending: PendingUpload[] = stored[STORAGE_KEYS.pendingUploads] || [];
-  if (pending.length === 0) {
-    return { success: true, data: { processed: 0 } };
-  }
-
-  let processed = 0;
-  let failed = 0;
-  const remaining: PendingUpload[] = [];
-
-  for (const upload of pending) {
-    // Skip if too many attempts
-    if (upload.attempts >= 5) {
-      console.warn("[Background] Dropping upload after max attempts");
-      continue;
-    }
-
-    try {
-      const result = await sendChatData(upload.data);
-      if (result.success) {
-        processed++;
-      } else {
-        upload.attempts++;
-        remaining.push(upload);
-        failed++;
-      }
-    } catch (error) {
-      upload.attempts++;
-      remaining.push(upload);
-      failed++;
-    }
-
-    // Small delay between retries
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-
-  await chrome.storage.local.set({ [STORAGE_KEYS.pendingUploads]: remaining });
-
-  return {
-    success: true,
-    data: { processed, failed, remaining: remaining.length },
-  };
-}
-
 async function clearPendingUploads(): Promise<ExtensionResponse> {
-  await chrome.storage.local.set({ [STORAGE_KEYS.pendingUploads]: [] });
+  await chrome.storage.local.remove(STORAGE_KEYS.pendingUploads);
   return { success: true };
 }
 
@@ -697,26 +629,6 @@ chrome.runtime.onInstalled.addListener(async (details) => {
       url: `${config.dashboardUrl}/extension-welcome`,
     });
   }
-
-  if (details.reason === "update") {
-    // Process any pending uploads after update
-    setTimeout(() => retryPendingUploads().catch(console.error), 5000);
-  }
-});
-
-// Periodic sync of pending uploads
-chrome.alarms.create("syncPendingUploads", { periodInMinutes: 5 });
-
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === "syncPendingUploads") {
-    retryPendingUploads().catch(console.error);
-  }
-});
-
-// Listen for network status changes
-self.addEventListener("online", () => {
-  console.log("[Background] Back online, syncing pending uploads");
-  retryPendingUploads().catch(console.error);
 });
 
 console.log("[Background] Service worker initialized");

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -210,10 +210,6 @@ export interface ClearPendingUploadsMessage {
   action: "CLEAR_PENDING_UPLOADS";
 }
 
-export interface RetryPendingUploadsMessage {
-  action: "RETRY_PENDING_UPLOADS";
-}
-
 // Union type of all message types
 export type ExtensionMessage =
   | GetCurrentChatMessage
@@ -227,8 +223,7 @@ export type ExtensionMessage =
   | LogoutMessage
   | GetSettingsMessage
   | UpdateSettingsMessage
-  | ClearPendingUploadsMessage
-  | RetryPendingUploadsMessage;
+  | ClearPendingUploadsMessage;
 
 // Helper type to extract action names
 export type MessageAction = ExtensionMessage["action"];
@@ -242,6 +237,8 @@ export interface SuccessResponse<T = unknown> {
 export interface ErrorResponse {
   success: false;
   error: string;
+  code?: "retry-required" | "channel-closed";
+  retryRequired?: boolean;
 }
 
 export type ExtensionResponse<T = unknown> = SuccessResponse<T> | ErrorResponse;
@@ -260,10 +257,4 @@ export interface CheckStatusData {
   isWhatsAppWeb: boolean;
   isLoggedIn: boolean;
   isExtracting: boolean;
-}
-
-export interface PendingUploadsData {
-  processed: number;
-  failed?: number;
-  remaining?: number;
 }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -112,6 +112,7 @@ let currentChatId: string | null = null;
 let statusUI: HTMLElement | null = null;
 let chatObserver: MutationObserver | null = null;
 let isInitialized = false;
+let reviewedCapture: ExtractedChat | null = null;
 
 // =============================================================================
 // Initialization
@@ -224,7 +225,7 @@ function injectUI(): void {
     <div id="ws-progress" class="ws-progress ws-hidden">
       <div class="ws-progress-bar"></div>
     </div>
-    <button id="ws-extract-btn" class="ws-fab-btn" title="Send the selected chat to ConvoLens">
+    <button id="ws-extract-btn" class="ws-fab-btn" title="Review the messages currently loaded in this chat">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
         <polyline points="14 2 14 8 20 8"></polyline>
@@ -232,7 +233,7 @@ function injectUI(): void {
         <line x1="16" y1="17" x2="8" y2="17"></line>
         <polyline points="10 9 9 9 8 9"></polyline>
       </svg>
-      <span class="ws-fab-text">Send to ConvoLens</span>
+      <span class="ws-fab-text">Review loaded messages</span>
     </button>
   `;
 
@@ -303,31 +304,44 @@ async function handleExtractClick(): Promise<void> {
   // Check rate limiting
   if (!checkRateLimit()) {
     const waitTime = Math.ceil((state.rateLimitResetTime - Date.now()) / 1000);
-    updateStatus(`Rate limited. Please wait ${waitTime}s`, "error");
+    updateStatus(`Please wait ${waitTime}s before reviewing again`, "error");
+    updateProgress(0);
     return;
   }
 
   // Prevent concurrent extractions
   if (state.isExtracting) {
-    updateStatus("Extraction already in progress...", "info");
+    updateStatus("A loaded-message review is already in progress", "info");
     return;
   }
 
   state.isExtracting = true;
-  updateStatus("Extracting messages...", "loading");
+  updateStatus("Reading loaded messages…", "loading");
   updateProgress(10);
 
   try {
     const chatData = await extractCurrentChatWithRetry();
 
     if (!chatData || chatData.messages.length === 0) {
-      updateStatus("No messages found", "error");
+      updateStatus("No readable loaded messages found", "error");
       return;
     }
 
     updateProgress(60);
+    reviewedCapture = chatData;
+
+    const confirmed = window.confirm(
+      `Send ${chatData.messages.length} loaded message${chatData.messages.length === 1 ? "" : "s"} from “${chatData.chatName}” to ConvoLens?\n\nOlder messages that WhatsApp has not loaded are excluded. Capture as I scroll and automatic older-message loading are coming soon.`,
+    );
+
+    if (!confirmed) {
+      reviewedCapture = null;
+      updateStatus("Upload cancelled. Nothing was sent.", "info");
+      return;
+    }
+
     updateStatus(
-      `Found ${chatData.messages.length} messages. Sending…`,
+      `Sending ${chatData.messages.length} loaded messages…`,
       "loading",
     );
 
@@ -340,28 +354,32 @@ async function handleExtractClick(): Promise<void> {
     updateProgress(100);
 
     if (response.success) {
-      updateStatus(`${chatData.messages.length} messages received`, "success");
+      reviewedCapture = null;
+      updateStatus(
+        `${chatData.messages.length} loaded messages received by ConvoLens`,
+        "success",
+      );
       state.lastExtraction = Date.now();
       state.extractionCount++;
 
       // Optionally open dashboard
       if (response.data?.openDashboard) {
-        chrome.runtime.sendMessage({ action: "OPEN_DASHBOARD" });
+        try {
+          await chrome.runtime.sendMessage({ action: "OPEN_DASHBOARD" });
+        } catch {
+          // The service worker can disappear after the upload has succeeded.
+        }
       }
     } else {
-      // The background worker owns the persistent upload queue.
-      if (
-        response.error?.toLowerCase().includes("saved") ||
-        response.error?.toLowerCase().includes("queued")
-      ) {
-        updateStatus(response.error, "info");
-      } else {
-        updateStatus(response.error || "Failed to send", "error");
-      }
+      updateStatus(
+        response.retryRequired
+          ? "Upload not sent. Review the loaded messages and try again from this tab."
+          : response.error || "Failed to send loaded messages",
+        "error",
+      );
     }
   } catch (error) {
-    console.error("[ConvoLens] Extraction error:", error);
-    updateStatus(`Error: ${(error as Error).message}`, "error");
+    updateStatus(normalizeErrorMessage(error), "error");
   } finally {
     state.isExtracting = false;
     updateProgress(0);
@@ -373,12 +391,13 @@ async function handleExtractClick(): Promise<void> {
  */
 async function extractCurrentChatWithRetry(
   attempts: number = EXTRACTION_CONFIG.retryAttempts,
+  silent: boolean = false,
 ): Promise<ExtractedChat | null> {
   let lastError: Error | null = null;
 
   for (let i = 0; i < attempts; i++) {
     try {
-      return await extractCurrentChat();
+      return await extractCurrentChat(silent);
     } catch (error) {
       lastError = error as Error;
       console.warn(`[ConvoLens] Extraction attempt ${i + 1} failed:`, error);
@@ -396,7 +415,9 @@ async function extractCurrentChatWithRetry(
 /**
  * Extract messages from the current chat
  */
-async function extractCurrentChat(): Promise<ExtractedChat> {
+async function extractCurrentChat(
+  silent: boolean = false,
+): Promise<ExtractedChat> {
   // Get chat name
   const chatHeader = querySelector(
     SELECTORS.primary.contactName,
@@ -436,7 +457,7 @@ async function extractCurrentChat(): Promise<ExtractedChat> {
 
   for (let i = 0; i < messageContainers.length; i++) {
     // Update progress
-    if (i % 10 === 0) {
+    if (!silent && i % 10 === 0) {
       updateProgress(10 + (i / totalMessages) * 50);
     }
 
@@ -893,10 +914,16 @@ function handleMessage(
 ): boolean {
   switch (message.action) {
     case "GET_CURRENT_CHAT":
-      extractCurrentChatWithRetry()
-        .then((data) => sendResponse({ success: true, data }))
+      extractCurrentChatWithRetry(EXTRACTION_CONFIG.retryAttempts, true)
+        .then((data) => {
+          reviewedCapture = data;
+          respondSafely(sendResponse, { success: true, data });
+        })
         .catch((error) =>
-          sendResponse({ success: false, error: error.message }),
+          respondSafely(sendResponse, {
+            success: false,
+            error: normalizeErrorMessage(error),
+          }),
         );
       return true;
 
@@ -928,9 +955,9 @@ function handleMessage(
         break;
       }
       authToken = typedMessage.token;
-      chrome.storage.local.set({
-        [STORAGE_KEYS.authToken]: typedMessage.token,
-      });
+      chrome.storage.local
+        .set({ [STORAGE_KEYS.authToken]: typedMessage.token })
+        .catch(() => undefined);
       sendResponse({ success: true });
       break;
     }
@@ -940,6 +967,23 @@ function handleMessage(
   }
 
   return false;
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return "The extension could not complete this operation.";
+}
+
+function respondSafely(
+  sendResponse: (response: ExtensionResponse) => void,
+  response: ExtensionResponse,
+): void {
+  try {
+    sendResponse(response);
+  } catch {
+    // The popup or tab can close while extraction is still completing.
+  }
 }
 
 // =============================================================================

--- a/apps/chrome-extension/tests/phase1-capture-safety.test.ts
+++ b/apps/chrome-extension/tests/phase1-capture-safety.test.ts
@@ -69,3 +69,18 @@ test("classifies popup and service-worker channel teardown", () => {
   assert.match(backgroundSource, /function respondSafely/);
   assert.match(contentSource, /function respondSafely/);
 });
+
+test("snapshots a confirmed capture until its upload settles", () => {
+  assert.match(popupSource, /const captureToSend = pendingCapture/);
+  assert.match(popupSource, /data: captureToSend/);
+  assert.match(popupSource, /extractBtn\.disabled = true/);
+  assert.match(popupSource, /logoutBtn\.disabled = true/);
+  assert.match(popupSource, /pendingCapture === captureToSend/);
+});
+
+test("classifies upstream HTTP 429 as retry-required", () => {
+  assert.match(backgroundSource, /class HttpRequestError extends Error/);
+  assert.match(backgroundSource, /isRateLimitError\(error\)/);
+  assert.match(backgroundSource, /error\.status === 429/);
+  assert.match(backgroundSource, /retryRequired: true/);
+});

--- a/apps/chrome-extension/tests/phase1-capture-safety.test.ts
+++ b/apps/chrome-extension/tests/phase1-capture-safety.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path: string) =>
+  readFileSync(new URL(path, import.meta.url), "utf8");
+
+const backgroundSource = read("../src/background.ts");
+const contentSource = read("../src/content.ts");
+const popupSource = read("../popup/popup.js");
+const popupHtml = read("../popup/popup.html");
+const optionsSource = read("../options/options.js");
+const optionsHtml = read("../options/options.html");
+const manifest = JSON.parse(read("../manifest.json"));
+
+test("requires loaded-message review and confirmation in both upload surfaces", () => {
+  assert.match(popupHtml, /Loaded-message review/);
+  assert.match(popupHtml, /Only messages currently loaded by WhatsApp/);
+  assert.match(popupHtml, /id="confirmCapture"/);
+  assert.match(popupSource, /confirmCapture\.addEventListener\("click"/);
+  assert.match(contentSource, /const confirmed = window\.confirm/);
+  assert.match(
+    contentSource,
+    /Older messages that WhatsApp has not loaded are excluded/,
+  );
+});
+
+test("keeps popup extraction page-UI-silent and resets terminal progress", () => {
+  assert.match(
+    contentSource,
+    /extractCurrentChatWithRetry\(EXTRACTION_CONFIG\.retryAttempts, true\)/,
+  );
+  assert.match(contentSource, /if \(!silent && i % 10 === 0\)/);
+  assert.match(
+    contentSource,
+    /finally \{\s+state\.isExtracting = false;\s+updateProgress\(0\);/,
+  );
+});
+
+test("does not persist or automatically transmit new or legacy raw captures", () => {
+  assert.doesNotMatch(backgroundSource, /function queuePendingUpload/);
+  assert.doesNotMatch(backgroundSource, /function retryPendingUploads/);
+  assert.doesNotMatch(backgroundSource, /RETRY_PENDING_UPLOADS/);
+  assert.doesNotMatch(backgroundSource, /chrome\.alarms/);
+  assert.doesNotMatch(backgroundSource, /addEventListener\("online"/);
+  assert.match(backgroundSource, /code: "retry-required"/);
+  assert.ok(!manifest.permissions.includes("alarms"));
+});
+
+test("offers export or confirmed deletion for unowned legacy entries", () => {
+  assert.match(optionsHtml, /Export Local Queue/);
+  assert.match(optionsHtml, /Delete Local Queue/);
+  assert.match(
+    optionsHtml,
+    /never\s+upload those entries\s+under the current account/,
+  );
+  assert.match(optionsSource, /URL\.createObjectURL\(blob\)/);
+  assert.match(optionsSource, /confirm\(/);
+  assert.match(
+    optionsSource,
+    /chrome\.storage\.local\.remove\(STORAGE_KEYS\.pendingUploads\)/,
+  );
+  assert.doesNotMatch(optionsSource, /RETRY_PENDING_UPLOADS/);
+});
+
+test("classifies popup and service-worker channel teardown", () => {
+  assert.match(popupSource, /message port closed/);
+  assert.match(popupSource, /context invalidated/);
+  assert.match(backgroundSource, /function respondSafely/);
+  assert.match(contentSource, /function respondSafely/);
+});

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.11");
+  assert.equal(manifest.version, "1.0.12");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {
@@ -35,8 +35,10 @@ test("opens the conversation dashboard from both popup entry points", () => {
   );
   assert.match(
     popupSource,
-    /openDashboard\.addEventListener\("click", \(\) => \{\s+chrome\.tabs\.create\(\{ url: `\$\{DASHBOARD_URL\}\/dashboard` \}\)/,
+    /openDashboard\.addEventListener\("click", \(\) => \{\s+openTab\(`\$\{DASHBOARD_URL\}\/dashboard`\)/,
   );
+  assert.match(popupSource, /function openTab\(url\)/);
+  assert.match(popupSource, /chrome\.tabs\s+\.create\(\{ url \}\)\s+\.catch/);
 });
 
 test("targets the active WhatsApp tab before searching background tabs", () => {

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
@@ -1,0 +1,44 @@
+# ConvoLens extension capture Phase 1 handoff — 2026-07-28
+
+## Outcome
+
+Phase 1 changes the current WhatsApp capture surfaces from immediate upload to explicit loaded-message review and confirmation.
+
+- The popup reads the currently mounted WhatsApp messages without driving the in-page progress UI, shows the loaded count and exclusion boundary, and uploads only after **Confirm upload**.
+- The in-page action is now **Review loaded messages** and uses an explicit confirmation containing the loaded count and older-message exclusion before upload.
+- Guided **Capture as I scroll** and automatic **Load older messages for me** remain unavailable and labelled `Soon`.
+- Every in-page terminal path resets progress.
+- Popup, options, content, and background message paths normalize non-`Error` failures and contain expected popup, tab, frame, and service-worker teardown.
+- Rate-limit, timeout, and network failures return `retry-required`; new raw captures are not written to `pendingUploads`.
+- Login, extension update, alarm, and browser-online automatic legacy retries are removed, along with the `alarms` permission.
+- Unowned legacy local captures are never transmitted under the current account. Settings shows only safe count/time metadata and offers explicit local export or confirmed deletion. Export does not delete; confirmed deletion removes the legacy storage key.
+
+## Repository state
+
+- Base: `origin/main` at `890be5b50dd93f83ab19eed0e0ce9a4f6633f2d8` (merged PR #148).
+- Branch: `agent/extension-capture-phase1`.
+- Extension version: `1.0.12` in both manifest and package metadata.
+- Runtime/deployment impact: extension-only. No API, database, web deployment, Azure change, or production acceptance is included.
+- The primary checkout remains untouched at its earlier `main` commit with its existing untracked `docs/HANDOFF-2026-07-24-EXTENSION-RUNTIME.md`.
+
+## Validation
+
+- Chrome extension Node tests: 21 passed, 0 failed.
+- TypeScript: passed.
+- Repository CI-equivalent `pnpm run build`: 8 of 8 packages passed.
+- Prettier: passed for changed TypeScript, JavaScript, JSON, tests, and handoff files; the legacy options HTML retains its existing repository formatting to avoid unrelated churn.
+- Production extension build and package: passed.
+- Packaged manifest: version `1.0.12`; permissions are `storage`, `activeTab`, `scripting`, and `notifications`; `alarms` is absent.
+- Packaged ZIP SHA-256: `3ACA581F2065A65182E0C3D6391B7F3C8343A7D7B9CCD2383A57A7AD8EFD7A5A`.
+- The 16-mounted-of-200 fixture and both same-sender, same-text, same-minute occurrences remain covered.
+
+## Boundaries still open
+
+- Do not deploy or install an upload-capable intermediate build without retaining the confirmation gate.
+- Authentic WhatsApp connected-send, exact persisted loaded count, deterministic duplicate behavior, restart persistence, owner isolation, and authenticated deletion remain operator-held.
+- Generic browser console signals remain unattributed until the redacted operator profile matrix identifies their source extension/page.
+- Before starting the planned PR C slice, reconcile its sender/date work against merged PRs #141–#145 and implement only remaining hash-compatibility and media-rendering gaps.
+
+## Continuation
+
+Recheck the exact PR head, CI, reviews, mergeability, `origin/main`, Baton task `c3020f7e-6be8-4b83-9dca-6d6afe9df4e2`, and the primary checkout before merging or continuing. Keep the primary checkout's untracked handoff untouched. Do not call packaging, CI, synthetic fixtures, or browser UI smoke authentic production acceptance.

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
@@ -24,13 +24,13 @@ Phase 1 changes the current WhatsApp capture surfaces from immediate upload to e
 
 ## Validation
 
-- Chrome extension Node tests: 21 passed, 0 failed.
+- Chrome extension Node tests: 23 passed, 0 failed, including confirmed-capture snapshot and upstream HTTP 429 retry classification.
 - TypeScript: passed.
 - Repository CI-equivalent `pnpm run build`: 8 of 8 packages passed.
 - Prettier: passed for changed TypeScript, JavaScript, JSON, tests, and handoff files; the legacy options HTML retains its existing repository formatting to avoid unrelated churn.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.12`; permissions are `storage`, `activeTab`, `scripting`, and `notifications`; `alarms` is absent.
-- Packaged ZIP SHA-256: `3ACA581F2065A65182E0C3D6391B7F3C8343A7D7B9CCD2383A57A7AD8EFD7A5A`.
+- Packaged ZIP SHA-256: `F9EC12D13BB00D112C8BBB48B00B5C6C1EDD9FED099EAEA8EAD348A7A8F8890C`.
 - The 16-mounted-of-200 fixture and both same-sender, same-text, same-minute occurrences remain covered.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE1.md
@@ -17,6 +17,7 @@ Phase 1 changes the current WhatsApp capture surfaces from immediate upload to e
 
 - Base: `origin/main` at `890be5b50dd93f83ab19eed0e0ce9a4f6633f2d8` (merged PR #148).
 - Branch: `agent/extension-capture-phase1`.
+- Pull request: [#149](https://github.com/neuralliquid/convolens/pull/149).
 - Extension version: `1.0.12` in both manifest and package metadata.
 - Runtime/deployment impact: extension-only. No API, database, web deployment, Azure change, or production acceptance is included.
 - The primary checkout remains untouched at its earlier `main` commit with its existing untracked `docs/HANDOFF-2026-07-24-EXTENSION-RUNTIME.md`.


### PR DESCRIPTION
Implements Extension Capture Phase 1 from the merged Phase 0 handoff. Adds explicit loaded-message review and confirmation in popup and in-page surfaces; truthful loaded-only scope and Soon labels; page-UI-silent popup extraction and terminal progress reset; retry-required failures without new raw pendingUploads writes; removal of automatic legacy retries; export-or-confirmed-delete migration for unowned legacy entries; channel teardown handling; extension v1.0.12; and a durable Phase 1 handoff. Validation: 21 extension tests, TypeScript, production package, embedded manifest inspection, and the 8-package CI-equivalent build passed. No deployment or authentic WhatsApp acceptance is claimed.