### PR TITLE
Phase 4: add compact movable capture launcher

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/options/options.js
+++ b/apps/chrome-extension/options/options.js
@@ -84,6 +84,14 @@ async function sendRuntimeMessage(message) {
   }
 }
 
+async function notifyLauncherStateRefresh() {
+  try {
+    await sendRuntimeMessage({ action: "REFRESH_LAUNCHER_STATE" });
+  } catch (error) {
+    console.warn("Launcher state refresh notification failed:", error);
+  }
+}
+
 function runAction(action) {
   Promise.resolve()
     .then(action)
@@ -371,6 +379,7 @@ async function handleDeletePending() {
 
   try {
     await chrome.storage.local.remove(STORAGE_KEYS.pendingUploads);
+    await notifyLauncherStateRefresh();
     showStatus("Legacy local queue deleted", "success");
     await loadStats();
   } catch (error) {
@@ -400,6 +409,7 @@ async function handleClearData() {
     await loadAuthStatus();
     await loadStats();
     await loadHistory();
+    await notifyLauncherStateRefresh();
   } catch (error) {
     showStatus("Error: " + error.message, "error");
   }

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -147,6 +147,10 @@ async function handleMessage(
     case "GET_LEGACY_QUEUE_SUMMARY":
       return await getLegacyQueueSummary();
 
+    case "REFRESH_LAUNCHER_STATE":
+      await notifyLauncherStateRefresh();
+      return { success: true };
+
     case "CONFIRM_CAPTURE_OPERATION":
       return await confirmCaptureOperation(message, _sender);
 
@@ -963,7 +967,13 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
     !stored[STORAGE_KEYS.authToken] ||
     (expiresAt > 0 && expiresAt <= Date.now() + 30_000)
   ) {
-    await syncMystiraSession();
+    const syncResponse = await syncMystiraSession();
+    if (!syncResponse.success) {
+      return {
+        success: true,
+        data: { isAuthenticated: false },
+      };
+    }
     stored = await chrome.storage.local.get([
       STORAGE_KEYS.authToken,
       STORAGE_KEYS.user,
@@ -1068,6 +1078,19 @@ async function notifyContentScripts(token: string | null): Promise<void> {
       tab.id
         ? chrome.tabs
             .sendMessage(tab.id, { action: "SET_AUTH_TOKEN", token })
+            .catch(() => undefined)
+        : Promise.resolve(),
+    ),
+  );
+}
+
+async function notifyLauncherStateRefresh(): Promise<void> {
+  const tabs = await chrome.tabs.query({ url: "https://web.whatsapp.com/*" });
+  await Promise.all(
+    tabs.map((tab) =>
+      tab.id
+        ? chrome.tabs
+            .sendMessage(tab.id, { action: "REFRESH_LAUNCHER_STATE" })
             .catch(() => undefined)
         : Promise.resolve(),
     ),

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -69,6 +69,7 @@ let captureLifecycleEpoch = 0;
 let captureAuthTransitionCount = 0;
 let authenticationWriteTail: Promise<void> = Promise.resolve();
 let authenticationIntentGeneration = 0;
+let committedAuthenticationIntentGeneration = 0;
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   const operation = captureOperations.get(tabId);
@@ -1191,6 +1192,8 @@ async function replaceAuthenticatedUser(
     releaseWrite = resolve;
   });
   await previousWrite;
+  const committedAuthenticationIntent =
+    expectedAuthenticationIntent ?? authenticationIntentGeneration;
   if (
     typeof expectedAuthenticationIntent === "number" &&
     expectedAuthenticationIntent !== authenticationIntentGeneration
@@ -1228,6 +1231,10 @@ async function replaceAuthenticatedUser(
     }
 
     await notifyContentScripts(token);
+    committedAuthenticationIntentGeneration = Math.max(
+      committedAuthenticationIntentGeneration,
+      committedAuthenticationIntent,
+    );
     return true;
   } finally {
     captureAuthTransitionCount -= 1;
@@ -1272,9 +1279,17 @@ async function clearCaptureStateAndAuthentication(
     });
     await previousWrite;
     try {
-      if (clearAuthenticationIntent !== authenticationIntentGeneration) return;
+      if (
+        committedAuthenticationIntentGeneration > clearAuthenticationIntent
+      ) {
+        return;
+      }
       await invalidateLoadedCaptureOperations();
       await clearAuthenticationState();
+      committedAuthenticationIntentGeneration = Math.max(
+        committedAuthenticationIntentGeneration,
+        clearAuthenticationIntent,
+      );
     } finally {
       releaseWrite();
     }

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -1249,12 +1249,6 @@ async function clearCaptureStateAndAuthentication(
   waitForUploads: boolean,
 ): Promise<void> {
   authenticationIntentGeneration += 1;
-  let releaseWrite: () => void = () => undefined;
-  const previousWrite = authenticationWriteTail;
-  authenticationWriteTail = new Promise<void>((resolve) => {
-    releaseWrite = resolve;
-  });
-  await previousWrite;
   captureAuthTransitionCount += 1;
   try {
     await loadCaptureOperations();
@@ -1266,11 +1260,20 @@ async function clearCaptureStateAndAuthentication(
       await Promise.allSettled([...captureUploadPromises.values()]);
     }
 
-    await invalidateLoadedCaptureOperations();
-    await clearAuthenticationState();
+    let releaseWrite: () => void = () => undefined;
+    const previousWrite = authenticationWriteTail;
+    authenticationWriteTail = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    await previousWrite;
+    try {
+      await invalidateLoadedCaptureOperations();
+      await clearAuthenticationState();
+    } finally {
+      releaseWrite();
+    }
   } finally {
     captureAuthTransitionCount -= 1;
-    releaseWrite();
   }
 }
 

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -244,7 +244,10 @@ async function loadCaptureOperations(): Promise<void> {
       if (!Number.isInteger(tabId) || !value || typeof value !== "object") {
         continue;
       }
-      const operation = value as CaptureOperationSnapshot;
+      const operation = {
+        ...(value as CaptureOperationSnapshot),
+        authGeneration: captureLifecycleEpoch,
+      };
       const restored = isActiveCaptureState(operation.state)
         ? completeCaptureOperation(
             operation,
@@ -352,7 +355,12 @@ async function startCaptureOperation(
     return { success: true, data: existing };
   }
 
-  let operation = createCaptureOperation(tabId, message.initiator);
+  let operation = createCaptureOperation(
+    tabId,
+    message.initiator,
+    new Date(),
+    operationEpoch,
+  );
   captureOperationEpochs.set(operation.operationId, operationEpoch);
   captureOperationOwnerIds.set(operation.operationId, authenticatedOwnerId);
   await publishCaptureOperation(operation);
@@ -971,7 +979,10 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
     if (!syncResponse.success) {
       return {
         success: true,
-        data: { isAuthenticated: false },
+        data: {
+          isAuthenticated: false,
+          authGeneration: captureLifecycleEpoch,
+        },
       };
     }
     stored = await chrome.storage.local.get([
@@ -984,6 +995,7 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
     success: true,
     data: {
       isAuthenticated: !!stored[STORAGE_KEYS.authToken],
+      authGeneration: captureLifecycleEpoch,
       user: stored[STORAGE_KEYS.user],
     },
   };
@@ -1077,7 +1089,11 @@ async function notifyContentScripts(token: string | null): Promise<void> {
     tabs.map((tab) =>
       tab.id
         ? chrome.tabs
-            .sendMessage(tab.id, { action: "SET_AUTH_TOKEN", token })
+            .sendMessage(tab.id, {
+              action: "SET_AUTH_TOKEN",
+              token,
+              authGeneration: captureLifecycleEpoch,
+            })
             .catch(() => undefined)
         : Promise.resolve(),
     ),

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -144,6 +144,9 @@ async function handleMessage(
       return { success: true, data: captureOperations.get(tabId) };
     }
 
+    case "GET_LEGACY_QUEUE_SUMMARY":
+      return await getLegacyQueueSummary();
+
     case "CONFIRM_CAPTURE_OPERATION":
       return await confirmCaptureOperation(message, _sender);
 
@@ -789,10 +792,7 @@ async function sendChatData(
       STORAGE_KEYS.user,
     ]);
     const finalOwnerId = finalCredentialState[STORAGE_KEYS.user]?.id;
-    if (
-      typeof finalOwnerId !== "string" ||
-      finalOwnerId !== expectedOwnerId
-    ) {
+    if (typeof finalOwnerId !== "string" || finalOwnerId !== expectedOwnerId) {
       await clearCaptureStateForAccountChange();
       return {
         success: false,
@@ -1260,6 +1260,26 @@ async function getApiConfig() {
 async function clearPendingUploads(): Promise<ExtensionResponse> {
   await chrome.storage.local.remove(STORAGE_KEYS.pendingUploads);
   return { success: true };
+}
+
+async function getLegacyQueueSummary(): Promise<
+  ExtensionResponse<{ count: number }>
+> {
+  const stored = await chrome.storage.local.get([
+    STORAGE_KEYS.pendingUploads,
+    STORAGE_KEYS.user,
+  ]);
+  const pending = stored[STORAGE_KEYS.pendingUploads];
+  const authenticatedOwnerId = stored[STORAGE_KEYS.user]?.id;
+  return {
+    success: true,
+    data: {
+      count:
+        typeof authenticatedOwnerId === "string" && Array.isArray(pending)
+          ? pending.length
+          : 0,
+    },
+  };
 }
 
 // =============================================================================

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -174,7 +174,7 @@ async function handleMessage(
       return await getAuthStatus();
 
     case "SYNC_MYSTIRA_AUTH":
-      return await syncMystiraSession();
+      return await syncMystiraSession(++authenticationIntentGeneration);
 
     case "LOGIN": {
       const typedMessage = message as LoginMessage;
@@ -985,7 +985,9 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
     !stored[STORAGE_KEYS.authToken] ||
     (expiresAt > 0 && expiresAt <= Date.now() + 30_000)
   ) {
-    const syncResponse = await syncMystiraSession();
+    const syncResponse = await syncMystiraSession(
+      ++authenticationIntentGeneration,
+    );
     if (!syncResponse.success) {
       return {
         success: true,
@@ -1011,8 +1013,11 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
   };
 }
 
-async function syncMystiraSession(): Promise<ExtensionResponse> {
-  const authenticationIntent = authenticationIntentGeneration;
+async function syncMystiraSession(
+  expectedAuthenticationIntent?: number,
+): Promise<ExtensionResponse> {
+  const authenticationIntent =
+    expectedAuthenticationIntent ?? authenticationIntentGeneration;
   try {
     const config = getConfig();
     const sessionResponse = await fetch(
@@ -1248,7 +1253,7 @@ async function clearAuthenticationState(): Promise<void> {
 async function clearCaptureStateAndAuthentication(
   waitForUploads: boolean,
 ): Promise<void> {
-  authenticationIntentGeneration += 1;
+  const clearAuthenticationIntent = ++authenticationIntentGeneration;
   captureAuthTransitionCount += 1;
   try {
     await loadCaptureOperations();
@@ -1267,6 +1272,7 @@ async function clearCaptureStateAndAuthentication(
     });
     await previousWrite;
     try {
+      if (clearAuthenticationIntent !== authenticationIntentGeneration) return;
       await invalidateLoadedCaptureOperations();
       await clearAuthenticationState();
     } finally {

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -234,12 +234,19 @@ async function loadCaptureOperations(): Promise<void> {
   captureOperationsLoadPromise = (async () => {
     const stored = await chrome.storage.session.get([
       STORAGE_KEYS.captureOperations,
+      STORAGE_KEYS.captureLifecycleEpoch,
     ]);
+    const persistedEpoch = stored[STORAGE_KEYS.captureLifecycleEpoch];
+    captureLifecycleEpoch =
+      Number.isInteger(persistedEpoch) && persistedEpoch >= 0
+        ? persistedEpoch
+        : 0;
     const persisted = stored[STORAGE_KEYS.captureOperations];
-    if (!persisted || typeof persisted !== "object") return;
 
     const interrupted: CaptureOperationSnapshot[] = [];
-    for (const [tabIdValue, value] of Object.entries(persisted)) {
+    for (const [tabIdValue, value] of Object.entries(
+      persisted && typeof persisted === "object" ? persisted : {},
+    )) {
       const tabId = Number(tabIdValue);
       if (!Number.isInteger(tabId) || !value || typeof value !== "object") {
         continue;
@@ -279,6 +286,7 @@ async function loadCaptureOperations(): Promise<void> {
 async function persistCaptureOperations(): Promise<void> {
   await chrome.storage.session.set({
     [STORAGE_KEYS.captureOperations]: Object.fromEntries(captureOperations),
+    [STORAGE_KEYS.captureLifecycleEpoch]: captureLifecycleEpoch,
   });
 }
 
@@ -306,6 +314,7 @@ async function startCaptureOperation(
   message: StartCaptureOperationMessage,
   sender: chrome.runtime.MessageSender,
 ): Promise<ExtensionResponse<CaptureOperationSnapshot>> {
+  await loadCaptureOperations();
   const operationEpoch = captureLifecycleEpoch;
   if (captureAuthTransitionCount > 0) {
     return {
@@ -320,7 +329,6 @@ async function startCaptureOperation(
       error: "Open WhatsApp Web and select a chat first.",
     };
   }
-  await loadCaptureOperations();
   if (operationEpoch !== captureLifecycleEpoch) {
     return {
       success: false,
@@ -965,6 +973,7 @@ function isRateLimitError(error: unknown): boolean {
 // =============================================================================
 
 async function getAuthStatus(): Promise<ExtensionResponse> {
+  await loadCaptureOperations();
   let stored = await chrome.storage.local.get([
     STORAGE_KEYS.authToken,
     STORAGE_KEYS.authTokenExpiresAt,
@@ -1148,6 +1157,7 @@ async function replaceAuthenticatedUser(
   user: { id?: string },
   expiresAt?: number,
 ): Promise<void> {
+  await loadCaptureOperations();
   let releaseWrite: () => void = () => undefined;
   const previousWrite = authenticationWriteTail;
   authenticationWriteTail = new Promise<void>((resolve) => {

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -70,6 +70,7 @@ let captureAuthTransitionCount = 0;
 let authenticationWriteTail: Promise<void> = Promise.resolve();
 let authenticationIntentGeneration = 0;
 let committedAuthenticationIntentGeneration = 0;
+const activeAuthenticationClearIntents = new Set<number>();
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   const operation = captureOperations.get(tabId);
@@ -1197,7 +1198,10 @@ async function replaceAuthenticatedUser(
     expectedAuthenticationIntent ?? authenticationIntentGeneration;
   if (
     typeof expectedAuthenticationIntent === "number" &&
-    expectedAuthenticationIntent !== authenticationIntentGeneration
+    (committedAuthenticationIntentGeneration > expectedAuthenticationIntent ||
+      [...activeAuthenticationClearIntents].some(
+        (clearIntent) => clearIntent > expectedAuthenticationIntent,
+      ))
   ) {
     releaseWrite();
     return false;
@@ -1262,6 +1266,7 @@ async function clearCaptureStateAndAuthentication(
   waitForUploads: boolean,
 ): Promise<void> {
   const clearAuthenticationIntent = ++authenticationIntentGeneration;
+  activeAuthenticationClearIntents.add(clearAuthenticationIntent);
   captureAuthTransitionCount += 1;
   try {
     await loadCaptureOperations();
@@ -1296,6 +1301,7 @@ async function clearCaptureStateAndAuthentication(
     }
   } finally {
     captureAuthTransitionCount -= 1;
+    activeAuthenticationClearIntents.delete(clearAuthenticationIntent);
   }
 }
 

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -513,6 +513,7 @@ async function confirmCaptureOperation(
 async function uploadCaptureOperation(
   initialOperation: CaptureOperationSnapshot,
 ): Promise<ExtensionResponse<CaptureOperationSnapshot>> {
+  const uploadAuthenticationIntent = committedAuthenticationIntentGeneration;
   const expectedOwnerId = captureOperationOwnerIds.get(
     initialOperation.operationId,
   );
@@ -557,6 +558,7 @@ async function uploadCaptureOperation(
     const uploadResult = await sendChatData(
       payloadResponse.data,
       expectedOwnerId,
+      uploadAuthenticationIntent,
     );
     if (!isCurrentCaptureOperation(operation, operationEpoch)) {
       return await abandonCaptureOperation(
@@ -758,6 +760,7 @@ function normalizeChannelLifecycleReason(error: unknown): string {
 async function sendChatData(
   chatData: any,
   expectedOwnerId: string,
+  uploadAuthenticationIntent: number,
 ): Promise<ExtensionResponse> {
   try {
     let stored = await chrome.storage.local.get([
@@ -770,7 +773,7 @@ async function sendChatData(
       !stored[STORAGE_KEYS.authToken] ||
       (expiresAt > 0 && expiresAt <= Date.now() + 30_000)
     ) {
-      const syncResult = await syncMystiraSession();
+      const syncResult = await syncMystiraSession(uploadAuthenticationIntent);
       if (!syncResult.success) {
         return syncResult;
       }
@@ -1015,10 +1018,8 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
 }
 
 async function syncMystiraSession(
-  expectedAuthenticationIntent?: number,
+  authenticationIntent: number,
 ): Promise<ExtensionResponse> {
-  const authenticationIntent =
-    expectedAuthenticationIntent ?? authenticationIntentGeneration;
   try {
     const config = getConfig();
     const sessionResponse = await fetch(

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -68,6 +68,7 @@ let captureOperationsLoadPromise: Promise<void> | null = null;
 let captureLifecycleEpoch = 0;
 let captureAuthTransitionCount = 0;
 let authenticationWriteTail: Promise<void> = Promise.resolve();
+let authenticationIntentGeneration = 0;
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   const operation = captureOperations.get(tabId);
@@ -1011,6 +1012,7 @@ async function getAuthStatus(): Promise<ExtensionResponse> {
 }
 
 async function syncMystiraSession(): Promise<ExtensionResponse> {
+  const authenticationIntent = authenticationIntentGeneration;
   try {
     const config = getConfig();
     const sessionResponse = await fetch(
@@ -1069,11 +1071,18 @@ async function syncMystiraSession(): Promise<ExtensionResponse> {
       };
     }
 
-    await replaceAuthenticatedUser(
+    const replaced = await replaceAuthenticatedUser(
       exchanged.token,
       exchanged.user,
       Date.now() + exchanged.expiresIn * 1000,
+      authenticationIntent,
     );
+    if (!replaced) {
+      return {
+        success: false,
+        error: "Authentication changed while the session was refreshing.",
+      };
+    }
 
     return {
       success: true,
@@ -1126,6 +1135,7 @@ async function handleLogin(
   email: string,
   password: string,
 ): Promise<ExtensionResponse> {
+  const authenticationIntent = ++authenticationIntentGeneration;
   try {
     const config = await getApiConfig();
 
@@ -1144,7 +1154,18 @@ async function handleLogin(
 
     const { token, user } = await response.json();
 
-    await replaceAuthenticatedUser(token, user);
+    const replaced = await replaceAuthenticatedUser(
+      token,
+      user,
+      undefined,
+      authenticationIntent,
+    );
+    if (!replaced) {
+      return {
+        success: false,
+        error: "Authentication changed before sign-in completed.",
+      };
+    }
 
     return { success: true, data: { user } };
   } catch (error) {
@@ -1156,7 +1177,8 @@ async function replaceAuthenticatedUser(
   token: string,
   user: { id?: string },
   expiresAt?: number,
-): Promise<void> {
+  expectedAuthenticationIntent?: number,
+): Promise<boolean> {
   await loadCaptureOperations();
   let releaseWrite: () => void = () => undefined;
   const previousWrite = authenticationWriteTail;
@@ -1164,6 +1186,13 @@ async function replaceAuthenticatedUser(
     releaseWrite = resolve;
   });
   await previousWrite;
+  if (
+    typeof expectedAuthenticationIntent === "number" &&
+    expectedAuthenticationIntent !== authenticationIntentGeneration
+  ) {
+    releaseWrite();
+    return false;
+  }
   captureAuthTransitionCount += 1;
 
   try {
@@ -1194,6 +1223,7 @@ async function replaceAuthenticatedUser(
     }
 
     await notifyContentScripts(token);
+    return true;
   } finally {
     captureAuthTransitionCount -= 1;
     releaseWrite();
@@ -1218,6 +1248,13 @@ async function clearAuthenticationState(): Promise<void> {
 async function clearCaptureStateAndAuthentication(
   waitForUploads: boolean,
 ): Promise<void> {
+  authenticationIntentGeneration += 1;
+  let releaseWrite: () => void = () => undefined;
+  const previousWrite = authenticationWriteTail;
+  authenticationWriteTail = new Promise<void>((resolve) => {
+    releaseWrite = resolve;
+  });
+  await previousWrite;
   captureAuthTransitionCount += 1;
   try {
     await loadCaptureOperations();
@@ -1233,6 +1270,7 @@ async function clearCaptureStateAndAuthentication(
     await clearAuthenticationState();
   } finally {
     captureAuthTransitionCount -= 1;
+    releaseWrite();
   }
 }
 

--- a/apps/chrome-extension/src/capture-operation.ts
+++ b/apps/chrome-extension/src/capture-operation.ts
@@ -14,6 +14,7 @@ export type CaptureOperationInitiator = "popup" | "page";
 
 export interface CaptureOperationSnapshot {
   operationId: string;
+  authGeneration: number;
   tabId: number;
   initiator: CaptureOperationInitiator;
   mode: "loaded";
@@ -63,9 +64,11 @@ export function createCaptureOperation(
   tabId: number,
   initiator: CaptureOperationInitiator,
   now: Date = new Date(),
+  authGeneration: number = 0,
 ): CaptureOperationSnapshot {
   return {
     operationId: crypto.randomUUID(),
+    authGeneration,
     tabId,
     initiator,
     mode: "loaded",

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -92,6 +92,7 @@ export const STORAGE_KEYS = {
   extractionHistory: "extractionHistory",
   pendingUploads: "pendingUploads",
   captureOperations: "captureOperations",
+  launcherPosition: "launcherPosition",
 };
 
 // =============================================================================
@@ -261,6 +262,10 @@ export interface ClearPendingUploadsMessage {
   action: "CLEAR_PENDING_UPLOADS";
 }
 
+export interface GetLegacyQueueSummaryMessage {
+  action: "GET_LEGACY_QUEUE_SUMMARY";
+}
+
 // Union type of all message types
 export type ExtensionMessage =
   | GetCurrentChatMessage
@@ -283,7 +288,8 @@ export type ExtensionMessage =
   | LogoutMessage
   | GetSettingsMessage
   | UpdateSettingsMessage
-  | ClearPendingUploadsMessage;
+  | ClearPendingUploadsMessage
+  | GetLegacyQueueSummaryMessage;
 
 // Helper type to extract action names
 export type MessageAction = ExtensionMessage["action"];

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -151,6 +151,7 @@ export interface CheckStatusMessage {
 export interface SetAuthTokenMessage {
   action: "SET_AUTH_TOKEN";
   token: string | null;
+  authGeneration: number;
 }
 
 export interface SendChatDataMessage {
@@ -317,6 +318,7 @@ export type ExtensionResponse<T = unknown> = SuccessResponse<T> | ErrorResponse;
 // Specific response data types
 export interface AuthStatusData {
   isAuthenticated: boolean;
+  authGeneration: number;
   user?: {
     id: string;
     email: string;

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -266,6 +266,10 @@ export interface GetLegacyQueueSummaryMessage {
   action: "GET_LEGACY_QUEUE_SUMMARY";
 }
 
+export interface RefreshLauncherStateMessage {
+  action: "REFRESH_LAUNCHER_STATE";
+}
+
 // Union type of all message types
 export type ExtensionMessage =
   | GetCurrentChatMessage
@@ -289,7 +293,8 @@ export type ExtensionMessage =
   | GetSettingsMessage
   | UpdateSettingsMessage
   | ClearPendingUploadsMessage
-  | GetLegacyQueueSummaryMessage;
+  | GetLegacyQueueSummaryMessage
+  | RefreshLauncherStateMessage;
 
 // Helper type to extract action names
 export type MessageAction = ExtensionMessage["action"];

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -92,6 +92,7 @@ export const STORAGE_KEYS = {
   extractionHistory: "extractionHistory",
   pendingUploads: "pendingUploads",
   captureOperations: "captureOperations",
+  captureLifecycleEpoch: "captureLifecycleEpoch",
   launcherPosition: "launcherPosition",
 };
 

--- a/apps/chrome-extension/src/content.css
+++ b/apps/chrome-extension/src/content.css
@@ -1,180 +1,344 @@
-/**
- * ConvoLens Chrome Extension Styles (Production)
- *
- * Design System Adherence:
- * - Uses WhatsApp brand colors from Phase 0.5
- * - Primary: #25D366
- * - Secondary: #128C7E
- * - Follows glassmorphism design pattern
- * - Supports dark mode
- */
-
-/* =============================================================================
-   Container
-   ============================================================================= */
+/** ConvoLens compact capture launcher. */
 
 #convolens-fab {
+  --ws-green: #16a36a;
+  --ws-green-dark: #0b6b57;
+  --ws-surface: #ffffff;
+  --ws-surface-muted: #f3f6f5;
+  --ws-border: #d7dfdc;
+  --ws-text: #17211e;
+  --ws-text-muted: #52605b;
   position: fixed;
-  bottom: calc(76px + env(safe-area-inset-bottom, 0px));
-  right: 24px;
   z-index: 10000;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 8px;
+  display: block;
+  width: 44px;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: var(--ws-text);
+  line-height: 1.35;
+  color-scheme: light dark;
 }
 
-/* =============================================================================
-   Floating Action Button
-   ============================================================================= */
-
-.ws-fab-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  background: linear-gradient(135deg, #16a36a 0%, #0b6b57 100%);
-  color: white;
-  border: none;
-  border-radius: 24px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 600;
-  box-shadow: 0 4px 14px rgba(11, 107, 87, 0.32);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+#convolens-fab.ws-edge-left {
+  left: 12px;
 }
 
-.ws-fab-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(37, 211, 102, 0.5);
+#convolens-fab.ws-edge-right {
+  right: 12px;
 }
 
-.ws-fab-btn:active {
-  transform: translateY(0);
+.ws-launcher-toggle {
+  position: relative;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 14px;
+  background: linear-gradient(145deg, var(--ws-green), var(--ws-green-dark));
+  box-shadow: 0 6px 20px rgba(11, 107, 87, 0.36);
+  color: #ffffff;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
 }
 
-.ws-fab-btn:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-  transform: none;
+.ws-launcher-toggle:active {
+  cursor: grabbing;
 }
 
-.ws-fab-btn svg {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
+.ws-launcher-toggle:hover {
+  filter: brightness(1.05);
 }
 
-.ws-fab-text {
-  white-space: nowrap;
-}
-
-/* =============================================================================
-   Status Indicator
-   ============================================================================= */
-
-.ws-status {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  background: rgba(255, 255, 255, 0.98);
-  border-radius: 12px;
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(12px);
-  transition: all 0.3s ease;
-  max-width: 280px;
-}
-
-.ws-status.ws-hidden {
-  opacity: 0;
-  transform: translateY(10px);
+.ws-launcher-toggle svg {
+  width: 21px;
+  height: 21px;
   pointer-events: none;
 }
 
-/* Status icon */
+.ws-launcher-badge {
+  position: absolute;
+  top: -5px;
+  min-width: 18px;
+  height: 18px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  border: 2px solid var(--ws-surface);
+  border-radius: 9px;
+  background: #b42318;
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.ws-edge-left .ws-launcher-badge {
+  right: -5px;
+}
+
+.ws-edge-right .ws-launcher-badge {
+  left: -5px;
+}
+
+.ws-launcher-badge[data-visible] {
+  display: flex;
+}
+
+#convolens-fab[data-state="received"] .ws-launcher-badge,
+#convolens-fab[data-state="duplicate"] .ws-launcher-badge {
+  background: #087a55;
+}
+
+#convolens-fab[data-state="ready-for-review"] .ws-launcher-badge,
+#convolens-fab[data-state="inspecting"] .ws-launcher-badge,
+#convolens-fab[data-state="collecting"] .ws-launcher-badge,
+#convolens-fab[data-state="uploading"] .ws-launcher-badge {
+  background: #175cd3;
+}
+
+.ws-launcher-panel {
+  position: absolute;
+  top: 0;
+  box-sizing: border-box;
+  width: min(320px, calc(100vw - 80px));
+  max-height: min(520px, calc(100vh - 120px));
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--ws-border);
+  border-radius: 16px;
+  background: var(--ws-surface);
+  box-shadow: 0 16px 48px rgba(15, 23, 20, 0.22);
+  color: var(--ws-text);
+  scrollbar-width: thin;
+}
+
+.ws-edge-left .ws-launcher-panel {
+  left: calc(100% + 10px);
+  transform-origin: left center;
+}
+
+.ws-edge-right .ws-launcher-panel {
+  right: calc(100% + 10px);
+  transform-origin: right center;
+}
+
+#convolens-fab[data-preset="middle"] .ws-launcher-panel {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+#convolens-fab[data-preset="lower"] .ws-launcher-panel {
+  top: auto;
+  bottom: 0;
+}
+
+.ws-launcher-panel[hidden],
+.ws-legacy-attention[hidden] {
+  display: none !important;
+}
+
+.ws-launcher-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.ws-launcher-header div {
+  display: grid;
+  gap: 2px;
+}
+
+.ws-launcher-header strong {
+  font-size: 15px;
+}
+
+.ws-launcher-header span,
+.ws-scope-copy,
+.ws-position-controls > span,
+.ws-legacy-attention span {
+  color: var(--ws-text-muted);
+  font-size: 12px;
+}
+
+.ws-icon-btn {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--ws-text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ws-icon-btn:hover {
+  background: var(--ws-surface-muted);
+}
+
+.ws-status {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-height: 34px;
+  box-sizing: border-box;
+  padding: 9px 10px;
+  border-radius: 10px;
+  background: var(--ws-surface-muted);
+  color: var(--ws-text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .ws-status-icon {
   width: 8px;
   height: 8px;
+  flex: 0 0 8px;
+  margin-top: 4px;
   border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.ws-status-info .ws-status-icon {
-  background: #3b82f6;
-}
-
-.ws-status-success .ws-status-icon {
-  background: #25d366;
-}
-
-.ws-status-error .ws-status-icon {
-  background: #dc2626;
-}
-
-.ws-status-loading .ws-status-icon {
-  background: transparent;
-}
-
-/* Status text colors */
-.ws-status-info {
-  color: #333;
+  background: #175cd3;
 }
 
 .ws-status-success {
-  color: #065f46;
-  background: rgba(209, 250, 229, 0.95);
+  background: #eaf8f1;
+  color: #05603a;
+}
+
+.ws-status-success .ws-status-icon {
+  background: #087a55;
 }
 
 .ws-status-error {
-  color: #991b1b;
-  background: rgba(254, 226, 226, 0.95);
+  background: #fff0ee;
+  color: #912018;
+}
+
+.ws-status-error .ws-status-icon {
+  background: #d92d20;
 }
 
 .ws-status-loading {
-  color: #1e40af;
-  background: rgba(219, 234, 254, 0.95);
+  background: #eef4ff;
+  color: #1849a9;
 }
 
-/* =============================================================================
-   Progress Bar
-   ============================================================================= */
-
 .ws-progress {
-  width: 200px;
+  width: 100%;
   height: 4px;
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 2px;
+  margin-top: 8px;
   overflow: hidden;
-  transition: opacity 0.3s ease;
+  border-radius: 2px;
+  background: #d9e3df;
 }
 
 .ws-progress.ws-hidden {
-  opacity: 0;
+  visibility: hidden;
 }
 
 .ws-progress-bar {
+  width: 0;
   height: 100%;
-  background: linear-gradient(90deg, #25d366 0%, #34d058 100%);
-  border-radius: 2px;
-  transition: width 0.3s ease;
-  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--ws-green), #34d058);
+  transition: width 180ms ease;
 }
 
-/* =============================================================================
-   Spinner Animation
-   ============================================================================= */
+.ws-capture-btn {
+  width: 100%;
+  min-height: 40px;
+  margin-top: 10px;
+  padding: 9px 12px;
+  border: 0;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--ws-green), var(--ws-green-dark));
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ws-capture-btn:disabled {
+  opacity: 0.64;
+  cursor: progress;
+}
+
+.ws-scope-copy {
+  margin: 9px 2px 0;
+}
+
+.ws-legacy-attention {
+  display: grid;
+  gap: 5px;
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid #f5c27b;
+  border-radius: 10px;
+  background: #fff7e8;
+  color: #7a2e0e;
+}
+
+.ws-legacy-attention strong {
+  font-size: 12px;
+}
+
+.ws-position-controls {
+  display: grid;
+  gap: 7px;
+  margin-top: 13px;
+  padding-top: 11px;
+  border-top: 1px solid var(--ws-border);
+}
+
+.ws-position-controls div {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+}
+
+.ws-position-controls div button,
+.ws-link-btn {
+  min-height: 30px;
+  padding: 5px 8px;
+  border: 1px solid var(--ws-border);
+  border-radius: 8px;
+  background: var(--ws-surface);
+  color: var(--ws-text);
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.ws-position-controls div button[aria-pressed="true"] {
+  border-color: var(--ws-green);
+  background: #eaf8f1;
+  color: #05603a;
+}
+
+.ws-link-btn {
+  width: fit-content;
+  border: 0;
+  padding-inline: 0;
+  background: transparent;
+  color: #0b6b57;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
 
 .ws-spinner {
-  width: 14px !important;
-  height: 14px !important;
-  border: 2px solid rgba(30, 64, 175, 0.2);
-  border-top-color: #1e40af;
-  border-radius: 50%;
+  width: 12px !important;
+  height: 12px !important;
+  margin-top: 0;
+  border: 2px solid rgba(23, 92, 211, 0.2);
+  border-top-color: #175cd3;
+  background: transparent !important;
   animation: ws-spin 0.8s linear infinite;
 }
 
@@ -184,95 +348,68 @@
   }
 }
 
-/* =============================================================================
-   Loading State
-   ============================================================================= */
-
-.ws-fab-btn.ws-loading {
-  animation: ws-pulse 1.5s ease-in-out infinite;
-  pointer-events: none;
+.ws-launcher-toggle:focus-visible,
+.ws-launcher-panel button:focus-visible {
+  outline: 3px solid #53b1fd;
+  outline-offset: 2px;
 }
-
-@keyframes ws-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
-  }
-}
-
-/* =============================================================================
-   Dark Mode Support
-   ============================================================================= */
 
 @media (prefers-color-scheme: dark) {
-  .ws-status {
-    background: rgba(38, 38, 38, 0.98);
-    color: #e5e5e5;
+  #convolens-fab {
+    --ws-surface: #202724;
+    --ws-surface-muted: #29322f;
+    --ws-border: #46524e;
+    --ws-text: #f0f5f3;
+    --ws-text-muted: #bac5c1;
   }
 
-  .ws-status-info {
-    color: #d1d5db;
-  }
-
-  .ws-status-success {
-    background: rgba(6, 78, 59, 0.95);
-    color: #a7f3d0;
+  .ws-status-success,
+  .ws-position-controls div button[aria-pressed="true"] {
+    background: #123d2d;
+    color: #a6f4c5;
   }
 
   .ws-status-error {
-    background: rgba(127, 29, 29, 0.95);
-    color: #fca5a5;
+    background: #4a1d1a;
+    color: #fecdca;
   }
 
   .ws-status-loading {
-    background: rgba(30, 58, 138, 0.95);
-    color: #93c5fd;
+    background: #162b52;
+    color: #b2ccff;
   }
 
-  .ws-progress {
-    background: rgba(255, 255, 255, 0.1);
-  }
-}
-
-/* =============================================================================
-   Mobile/Responsive Adjustments
-   ============================================================================= */
-
-@media (max-width: 768px) {
-  #convolens-fab {
-    bottom: calc(72px + env(safe-area-inset-bottom, 0px));
-    right: 16px;
-  }
-
-  .ws-fab-btn {
-    padding: 10px 16px;
-    font-size: 13px;
-  }
-
-  .ws-fab-text {
-    display: none;
-  }
-
-  .ws-status {
-    max-width: 220px;
-    font-size: 12px;
-  }
-
-  .ws-progress {
-    width: 150px;
+  .ws-legacy-attention {
+    border-color: #93621f;
+    background: #3d2d16;
+    color: #fedf89;
   }
 }
 
-/* =============================================================================
-   Accessibility
-   ============================================================================= */
+@media (max-width: 420px) {
+  #convolens-fab.ws-edge-left {
+    left: 8px;
+  }
+
+  #convolens-fab.ws-edge-right {
+    right: 8px;
+  }
+
+  .ws-launcher-panel {
+    width: calc(100vw - 68px);
+    padding: 12px;
+  }
+
+  .ws-edge-left .ws-launcher-panel {
+    left: calc(100% + 8px);
+  }
+
+  .ws-edge-right .ws-launcher-panel {
+    right: calc(100% + 8px);
+  }
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .ws-fab-btn,
-  .ws-status,
   .ws-progress-bar {
     transition: none;
   }
@@ -280,29 +417,19 @@
   .ws-spinner {
     animation: none;
   }
-
-  .ws-fab-btn.ws-loading {
-    animation: none;
-  }
 }
-
-/* Focus states for keyboard navigation */
-.ws-fab-btn:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(37, 211, 102, 0.5);
-}
-
-/* =============================================================================
-   High Contrast Mode
-   ============================================================================= */
 
 @media (forced-colors: active) {
-  .ws-fab-btn {
+  .ws-launcher-toggle,
+  .ws-launcher-panel,
+  .ws-capture-btn,
+  .ws-position-controls div button,
+  .ws-legacy-attention {
     border: 2px solid currentColor;
+    forced-color-adjust: auto;
   }
 
-  .ws-status {
-    border: 1px solid currentColor;
+  .ws-launcher-badge {
+    border: 1px solid Canvas;
   }
 }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -146,6 +146,7 @@ let launcherPosition: LauncherPosition = DEFAULT_LAUNCHER_POSITION;
 let launcherOperation: CaptureOperationSnapshot | null = null;
 let legacyQueueCount = 0;
 let launcherSuppressClick = false;
+let launcherAuthRefreshGeneration = 0;
 
 // =============================================================================
 // Initialization
@@ -342,24 +343,7 @@ async function injectUI(): Promise<void> {
     });
   });
 
-  try {
-    const [operationResponse, legacyResponse] = (await Promise.all([
-      chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
-      chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
-    ])) as [
-      ExtensionResponse<CaptureOperationSnapshot>,
-      ExtensionResponse<{ count: number }>,
-    ];
-    if (operationResponse.success && operationResponse.data) {
-      renderCaptureOperation(operationResponse.data);
-    }
-    updateLegacyQueueState(
-      legacyResponse.success ? legacyResponse.data?.count || 0 : 0,
-    );
-  } catch {
-    updateLegacyQueueState(0);
-    // Operation state will arrive through CAPTURE_OPERATION_UPDATED when available.
-  }
+  await refreshLauncherAuthenticationState(authToken).catch(() => undefined);
 }
 
 function setupLauncherInteraction(): void {
@@ -547,23 +531,30 @@ function resetLauncherAccountState(authenticated: boolean): void {
 async function refreshLauncherAuthenticationState(
   token: string | null,
 ): Promise<void> {
+  const refreshGeneration = ++launcherAuthRefreshGeneration;
   resetLauncherAccountState(token !== null);
   if (token === null) return;
 
-  const [operationResponse, legacyResponse] = (await Promise.all([
-    chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
-    chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
-  ])) as [
-    ExtensionResponse<CaptureOperationSnapshot>,
-    ExtensionResponse<{ count: number }>,
-  ];
-  if (authToken !== token) return;
-  if (operationResponse.success && operationResponse.data) {
-    renderCaptureOperation(operationResponse.data);
+  try {
+    const [operationResponse, legacyResponse] = (await Promise.all([
+      chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
+      chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
+    ])) as [
+      ExtensionResponse<CaptureOperationSnapshot>,
+      ExtensionResponse<{ count: number }>,
+    ];
+    if (refreshGeneration !== launcherAuthRefreshGeneration) return;
+    if (operationResponse.success && operationResponse.data) {
+      renderCaptureOperation(operationResponse.data);
+    }
+    updateLegacyQueueState(
+      legacyResponse.success ? legacyResponse.data?.count || 0 : 0,
+    );
+  } catch (error) {
+    if (refreshGeneration !== launcherAuthRefreshGeneration) return;
+    resetLauncherAccountState(token !== null);
+    throw error;
   }
-  updateLegacyQueueState(
-    legacyResponse.success ? legacyResponse.data?.count || 0 : 0,
-  );
 }
 
 function updateStatus(
@@ -1607,7 +1598,6 @@ function handleMessage(
       refreshLauncherAuthenticationState(typedMessage.token)
         .then(() => respondSafely(sendResponse, { success: true }))
         .catch((error) => {
-          resetLauncherAccountState(typedMessage.token !== null);
           respondSafely(sendResponse, {
             success: false,
             error: normalizeErrorMessage(error),

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -527,6 +527,7 @@ function normalizeAuthToken(value: unknown): string | null {
 }
 
 async function refreshLauncherFromValidatedAuthentication(): Promise<void> {
+  launcherAuthRefreshGeneration += 1;
   authToken = null;
   resetLauncherAccountState(false);
   const authResponse = (await chrome.runtime.sendMessage({

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -448,12 +448,7 @@ function setLauncherExpanded(expanded: boolean, restoreFocus = false): void {
   if (!panel || !toggle) return;
   panel.hidden = !expanded;
   toggle.setAttribute("aria-expanded", String(expanded));
-  toggle.setAttribute(
-    "aria-label",
-    expanded
-      ? "Close ConvoLens capture panel. Drag to move."
-      : "Open ConvoLens capture panel. Drag to move.",
-  );
+  updateLauncherToggleLabel();
   if (expanded) {
     panel.querySelector<HTMLButtonElement>("button:not([disabled])")?.focus();
   }
@@ -836,6 +831,51 @@ function updateLauncherBadge(operation: CaptureOperationSnapshot | null): void {
   }
   badge.textContent = value;
   badge.toggleAttribute("data-visible", value.length > 0);
+  updateLauncherToggleLabel();
+}
+
+function updateLauncherToggleLabel(): void {
+  const toggle = document.getElementById(
+    "ws-launcher-toggle",
+  ) as HTMLButtonElement | null;
+  if (!toggle) return;
+  const action =
+    toggle.getAttribute("aria-expanded") === "true" ? "Close" : "Open";
+  toggle.setAttribute(
+    "aria-label",
+    `${action} ConvoLens capture panel. ${getLauncherAccessibleStatus()} Drag to move.`,
+  );
+}
+
+function getLauncherAccessibleStatus(): string {
+  if (launcherOperation?.state === "ready-for-review") {
+    return `${launcherOperation.extractedCount} loaded message${launcherOperation.extractedCount === 1 ? "" : "s"} ready for review.`;
+  }
+  if (
+    launcherOperation &&
+    ["inspecting", "collecting"].includes(launcherOperation.state)
+  ) {
+    return "Reading loaded messages.";
+  }
+  if (launcherOperation?.state === "uploading") {
+    return "Sending reviewed messages.";
+  }
+  if (
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state)
+  ) {
+    return "Capture received by ConvoLens.";
+  }
+  if (
+    launcherOperation &&
+    ["retry-required", "failed", "cancelled"].includes(launcherOperation.state)
+  ) {
+    return "Capture needs attention.";
+  }
+  if (legacyQueueCount > 0) {
+    return `${legacyQueueCount} legacy local capture${legacyQueueCount === 1 ? "" : "s"} need review.`;
+  }
+  return "Ready.";
 }
 
 function getCurrentChatIdentity(): string {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -41,6 +41,15 @@ import {
   findMessageRecord,
   findMessageText,
 } from "./dom-selectors";
+import {
+  DEFAULT_LAUNCHER_POSITION,
+  getLauncherTop,
+  normalizeLauncherPosition,
+  resolveLauncherEdge,
+  resolveLauncherPreset,
+  type LauncherPosition,
+  type LauncherPreset,
+} from "./launcher-position";
 
 // =============================================================================
 // Types
@@ -120,7 +129,6 @@ const state: ExtractionState = {
 
 let authToken: string | null = null;
 let currentChatId: string | null = null;
-let statusUI: HTMLElement | null = null;
 let chatObserver: MutationObserver | null = null;
 let isInitialized = false;
 interface ActiveCaptureOperation {
@@ -134,6 +142,10 @@ let activeCaptureOperation: ActiveCaptureOperation | null = null;
 let pageConfirmationOperationId: string | null = null;
 let lastCountedTerminalOperationId: string | null = null;
 const chatIdentityTokens = new Map<string, string>();
+let launcherPosition: LauncherPosition = DEFAULT_LAUNCHER_POSITION;
+let launcherOperation: CaptureOperationSnapshot | null = null;
+let legacyQueueCount = 0;
+let launcherSuppressClick = false;
 
 // =============================================================================
 // Initialization
@@ -173,7 +185,8 @@ async function init(): Promise<void> {
   }
 
   // Inject UI elements
-  injectUI();
+  await injectUI();
+  window.addEventListener("resize", handleViewportResize);
 
   // Observe chat navigation
   observeChatChanges();
@@ -199,6 +212,7 @@ function cleanup(): void {
     chatObserver = null;
   }
   chrome.runtime.onMessage.removeListener(handleMessage);
+  window.removeEventListener("resize", handleViewportResize);
   isInitialized = false;
   console.log("[ConvoLens] Cleanup completed");
 }
@@ -240,22 +254,60 @@ async function waitForWhatsAppReady(timeout: number = 30000): Promise<void> {
 // UI Injection
 // =============================================================================
 
-function injectUI(): void {
+async function injectUI(): Promise<void> {
   // Remove existing UI if present
   document.getElementById("convolens-fab")?.remove();
 
-  // Create floating action button container
+  let stored: Record<string, any> = {};
+  try {
+    stored = await chrome.storage.local.get([STORAGE_KEYS.launcherPosition]);
+  } catch {
+    // Default placement and an empty migration count remain safe fallbacks.
+  }
+  launcherPosition = normalizeLauncherPosition(
+    stored[STORAGE_KEYS.launcherPosition],
+  );
+
+  // Create the compact launcher and its inward-opening workflow panel.
   const fab = document.createElement("div");
   fab.id = "convolens-fab";
+  fab.className = "ws-launcher";
   fab.innerHTML = `
-    <div id="ws-status" class="ws-status ws-hidden" role="status" aria-live="polite">
-      <div class="ws-status-icon"></div>
-      <span id="ws-status-text">Ready</span>
-    </div>
-    <div id="ws-progress" class="ws-progress ws-hidden">
-      <div class="ws-progress-bar"></div>
-    </div>
-    <button id="ws-extract-btn" class="ws-fab-btn" title="Review the messages currently loaded in this chat">
+    <section id="ws-launcher-panel" class="ws-launcher-panel" aria-label="ConvoLens capture" hidden>
+      <header class="ws-launcher-header">
+        <div>
+          <strong>ConvoLens capture</strong>
+          <span>WhatsApp messages currently loaded</span>
+        </div>
+        <button id="ws-launcher-close" class="ws-icon-btn" type="button" aria-label="Close ConvoLens capture panel">×</button>
+      </header>
+      <div id="ws-status" class="ws-status ws-status-info" role="status" aria-live="polite">
+        <div class="ws-status-icon"></div>
+        <span id="ws-status-text">Ready to review loaded messages.</span>
+      </div>
+      <div id="ws-progress" class="ws-progress ws-hidden" aria-hidden="true">
+        <div class="ws-progress-bar"></div>
+      </div>
+      <button id="ws-extract-btn" class="ws-capture-btn" type="button">
+        Review loaded messages
+      </button>
+      <p class="ws-scope-copy">Older messages that WhatsApp has not loaded are excluded. Nothing is sent before review and confirmation.</p>
+      <div id="ws-legacy-attention" class="ws-legacy-attention" hidden>
+        <strong>Legacy local captures need review</strong>
+        <span id="ws-legacy-count"></span>
+        <button id="ws-open-settings" class="ws-link-btn" type="button">Open migration settings</button>
+      </div>
+      <div class="ws-position-controls" aria-label="Launcher position">
+        <span>Position</span>
+        <div role="group" aria-label="Vertical launcher position">
+          <button type="button" data-launcher-preset="upper">Top</button>
+          <button type="button" data-launcher-preset="middle">Middle</button>
+          <button type="button" data-launcher-preset="lower">Bottom</button>
+        </div>
+        <button id="ws-launcher-side" class="ws-link-btn" type="button"></button>
+      </div>
+    </section>
+    <button id="ws-launcher-toggle" class="ws-launcher-toggle" type="button" aria-expanded="false" aria-controls="ws-launcher-panel" aria-label="Open ConvoLens capture panel. Drag to move.">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
         <polyline points="14 2 14 8 20 8"></polyline>
@@ -263,17 +315,205 @@ function injectUI(): void {
         <line x1="16" y1="17" x2="8" y2="17"></line>
         <polyline points="10 9 9 9 8 9"></polyline>
       </svg>
-      <span class="ws-fab-text">Review loaded messages</span>
+      <span id="ws-launcher-badge" class="ws-launcher-badge" aria-hidden="true"></span>
     </button>
   `;
 
   document.body.appendChild(fab);
-  statusUI = fab;
+  applyLauncherPosition();
+  setupLauncherInteraction();
 
-  // Add event listeners
   document
     .getElementById("ws-extract-btn")
     ?.addEventListener("click", handleExtractClick);
+  document
+    .getElementById("ws-launcher-close")
+    ?.addEventListener("click", () => {
+      setLauncherExpanded(false, true);
+    });
+  document.getElementById("ws-open-settings")?.addEventListener("click", () => {
+    chrome.runtime.openOptionsPage(() => {
+      if (chrome.runtime.lastError) {
+        updateStatus(
+          "Open extension settings to review legacy captures.",
+          "error",
+        );
+      }
+    });
+  });
+
+  try {
+    const [operationResponse, legacyResponse] = (await Promise.all([
+      chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
+      chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
+    ])) as [
+      ExtensionResponse<CaptureOperationSnapshot>,
+      ExtensionResponse<{ count: number }>,
+    ];
+    if (operationResponse.success && operationResponse.data) {
+      renderCaptureOperation(operationResponse.data);
+    }
+    updateLegacyQueueState(
+      legacyResponse.success ? legacyResponse.data?.count || 0 : 0,
+    );
+  } catch {
+    updateLegacyQueueState(0);
+    // Operation state will arrive through CAPTURE_OPERATION_UPDATED when available.
+  }
+}
+
+function setupLauncherInteraction(): void {
+  const fab = document.getElementById("convolens-fab");
+  const toggle = document.getElementById(
+    "ws-launcher-toggle",
+  ) as HTMLButtonElement | null;
+  if (!fab || !toggle) return;
+
+  toggle.addEventListener("click", () => {
+    if (launcherSuppressClick) {
+      launcherSuppressClick = false;
+      return;
+    }
+    setLauncherExpanded(toggle.getAttribute("aria-expanded") !== "true");
+  });
+  toggle.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") setLauncherExpanded(false);
+  });
+
+  let drag:
+    | { pointerId: number; startX: number; startY: number; startTop: number }
+    | undefined;
+  toggle.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    drag = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startTop: fab.getBoundingClientRect().top,
+    };
+    toggle.setPointerCapture(event.pointerId);
+  });
+  toggle.addEventListener("pointermove", (event) => {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const moved = Math.hypot(
+      event.clientX - drag.startX,
+      event.clientY - drag.startY,
+    );
+    if (moved < 5 && !launcherSuppressClick) return;
+    launcherSuppressClick = true;
+    setLauncherExpanded(false);
+    const top = Math.max(
+      12,
+      Math.min(
+        window.innerHeight - 56,
+        drag.startTop + event.clientY - drag.startY,
+      ),
+    );
+    fab.style.top = `${top}px`;
+    fab.classList.toggle("ws-edge-left", event.clientX < window.innerWidth / 2);
+    fab.classList.toggle(
+      "ws-edge-right",
+      event.clientX >= window.innerWidth / 2,
+    );
+  });
+  const finishDrag = (event: PointerEvent) => {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    toggle.releasePointerCapture(event.pointerId);
+    if (launcherSuppressClick) {
+      const rect = fab.getBoundingClientRect();
+      void setLauncherPosition({
+        edge: resolveLauncherEdge(event.clientX, window.innerWidth),
+        preset: resolveLauncherPreset(
+          rect.top + rect.height / 2,
+          window.innerHeight,
+        ),
+      });
+    }
+    drag = undefined;
+  };
+  toggle.addEventListener("pointerup", finishDrag);
+  toggle.addEventListener("pointercancel", finishDrag);
+
+  fab
+    .querySelectorAll<HTMLButtonElement>("[data-launcher-preset]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        void setLauncherPosition({
+          ...launcherPosition,
+          preset: button.dataset.launcherPreset as LauncherPreset,
+        });
+      });
+    });
+  document.getElementById("ws-launcher-side")?.addEventListener("click", () => {
+    void setLauncherPosition({
+      ...launcherPosition,
+      edge: launcherPosition.edge === "right" ? "left" : "right",
+    });
+  });
+  fab.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") setLauncherExpanded(false, true);
+  });
+}
+
+function setLauncherExpanded(expanded: boolean, restoreFocus = false): void {
+  const panel = document.getElementById("ws-launcher-panel") as HTMLElement;
+  const toggle = document.getElementById(
+    "ws-launcher-toggle",
+  ) as HTMLButtonElement;
+  if (!panel || !toggle) return;
+  panel.hidden = !expanded;
+  toggle.setAttribute("aria-expanded", String(expanded));
+  toggle.setAttribute(
+    "aria-label",
+    expanded
+      ? "Close ConvoLens capture panel. Drag to move."
+      : "Open ConvoLens capture panel. Drag to move.",
+  );
+  if (restoreFocus) toggle.focus();
+}
+
+async function setLauncherPosition(position: LauncherPosition): Promise<void> {
+  launcherPosition = normalizeLauncherPosition(position);
+  applyLauncherPosition();
+  await chrome.storage.local
+    .set({ [STORAGE_KEYS.launcherPosition]: launcherPosition })
+    .catch(() => undefined);
+}
+
+function applyLauncherPosition(): void {
+  const fab = document.getElementById("convolens-fab");
+  if (!fab) return;
+  fab.classList.toggle("ws-edge-left", launcherPosition.edge === "left");
+  fab.classList.toggle("ws-edge-right", launcherPosition.edge === "right");
+  fab.dataset.preset = launcherPosition.preset;
+  fab.style.top = `${getLauncherTop(launcherPosition.preset, window.innerHeight)}px`;
+  fab
+    .querySelectorAll<HTMLButtonElement>("[data-launcher-preset]")
+    .forEach((button) => {
+      button.setAttribute(
+        "aria-pressed",
+        String(button.dataset.launcherPreset === launcherPosition.preset),
+      );
+    });
+  const side = document.getElementById("ws-launcher-side");
+  if (side) {
+    side.textContent = `Move to ${launcherPosition.edge === "right" ? "left" : "right"} edge`;
+  }
+}
+
+function handleViewportResize(): void {
+  applyLauncherPosition();
+}
+
+function updateLegacyQueueState(count: number): void {
+  legacyQueueCount = count;
+  const notice = document.getElementById("ws-legacy-attention");
+  const label = document.getElementById("ws-legacy-count");
+  if (notice) notice.hidden = count === 0;
+  if (label) {
+    label.textContent = `${count} unowned local capture${count === 1 ? "" : "s"}. Export or confirmed deletion only.`;
+  }
+  updateLauncherBadge(launcherOperation);
 }
 
 function updateStatus(
@@ -300,13 +540,6 @@ function updateStatus(
       statusIcon.classList.add("ws-spinner");
     }
   }
-
-  // Auto-hide after delay (except for loading)
-  if (type !== "loading") {
-    setTimeout(() => {
-      statusEl.classList.add("ws-hidden");
-    }, 3000);
-  }
 }
 
 function updateProgress(percent: number): void {
@@ -319,9 +552,11 @@ function updateProgress(percent: number): void {
 
   if (percent > 0 && percent < 100) {
     progressEl.classList.remove("ws-hidden");
+    progressEl.setAttribute("aria-hidden", "false");
     progressBar.style.width = `${percent}%`;
   } else {
     progressEl.classList.add("ws-hidden");
+    progressEl.setAttribute("aria-hidden", "true");
     progressBar.style.width = "0%";
   }
 }
@@ -384,9 +619,7 @@ async function handleExtractClick(): Promise<void> {
       return;
     }
     renderCaptureOperation(response.data);
-    if (
-      ["ready-for-review", "retry-required"].includes(response.data.state)
-    ) {
+    if (["ready-for-review", "retry-required"].includes(response.data.state)) {
       if (response.data.state === "retry-required") {
         pageConfirmationOperationId = null;
       }
@@ -430,6 +663,8 @@ async function reviewPageCapture(
 }
 
 function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
+  launcherOperation = operation;
+  updateLauncherBadge(operation);
   if (activeCaptureOperation?.operationId === operation.operationId) {
     activeCaptureOperation.state = operation.state;
   }
@@ -440,6 +675,7 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
     button.disabled = ["inspecting", "collecting", "uploading"].includes(
       operation.state,
     );
+    button.textContent = getLauncherActionLabel(operation);
   }
 
   switch (operation.state) {
@@ -492,6 +728,51 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
       updateStatus(operation.reason || "Capture cancelled.", "error");
       break;
   }
+}
+
+function getLauncherActionLabel(operation: CaptureOperationSnapshot): string {
+  switch (operation.state) {
+    case "inspecting":
+    case "collecting":
+      return "Reading loaded messages…";
+    case "ready-for-review":
+      return `Review ${operation.extractedCount} loaded message${operation.extractedCount === 1 ? "" : "s"}`;
+    case "uploading":
+      return "Sending reviewed messages…";
+    case "retry-required":
+      return "Review and retry";
+    default:
+      return "Review loaded messages";
+  }
+}
+
+function updateLauncherBadge(operation: CaptureOperationSnapshot | null): void {
+  const fab = document.getElementById("convolens-fab");
+  const badge = document.getElementById("ws-launcher-badge");
+  if (!fab || !badge) return;
+  const state =
+    operation?.state || (legacyQueueCount > 0 ? "attention" : "ready");
+  fab.dataset.state = state;
+  let value = "";
+  if (operation?.state === "ready-for-review") {
+    value = String(operation.extractedCount);
+  } else if (
+    operation &&
+    ["inspecting", "collecting", "uploading"].includes(operation.state)
+  ) {
+    value = "…";
+  } else if (operation && ["received", "duplicate"].includes(operation.state)) {
+    value = "✓";
+  } else if (
+    operation &&
+    ["retry-required", "failed", "cancelled"].includes(operation.state)
+  ) {
+    value = "!";
+  } else if (legacyQueueCount > 0) {
+    value = "!";
+  }
+  badge.textContent = value;
+  badge.toggleAttribute("data-visible", value.length > 0);
 }
 
 function getCurrentChatIdentity(): string {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -23,6 +23,7 @@ import {
   type ExtensionResponse,
   type SetAuthTokenMessage,
   type CheckStatusData,
+  type AuthStatusData,
 } from "./config";
 import type {
   CaptureCollectionSummary,
@@ -177,20 +178,9 @@ async function init(): Promise<void> {
   // Wait for WhatsApp to fully load
   await waitForWhatsAppReady();
 
-  // Load saved auth token
-  try {
-    const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
-    const storedToken = stored[STORAGE_KEYS.authToken];
-    authToken =
-      typeof storedToken === "string" && storedToken.trim().length > 0
-        ? storedToken
-        : null;
-  } catch (error) {
-    console.warn("[ConvoLens] Failed to load auth token:", error);
-  }
-
   // Inject UI elements
   await injectUI();
+  await refreshLauncherFromValidatedAuthentication().catch(() => undefined);
   window.addEventListener("resize", handleViewportResize);
 
   // Observe chat navigation
@@ -288,13 +278,13 @@ async function injectUI(): Promise<void> {
       </header>
       <div id="ws-status" class="ws-status ws-status-info" role="status" aria-live="polite">
         <div class="ws-status-icon"></div>
-        <span id="ws-status-text">Ready to review loaded messages.</span>
+        <span id="ws-status-text">Sign in to ConvoLens before reviewing loaded messages.</span>
       </div>
       <div id="ws-progress" class="ws-progress ws-hidden" aria-hidden="true">
         <div class="ws-progress-bar"></div>
       </div>
-      <button id="ws-extract-btn" class="ws-capture-btn" type="button">
-        Review loaded messages
+      <button id="ws-extract-btn" class="ws-capture-btn" type="button" disabled>
+        Sign in to capture
       </button>
       <p class="ws-scope-copy">Older messages that WhatsApp has not loaded are excluded. Nothing is sent before review and confirmation.</p>
       <div id="ws-legacy-attention" class="ws-legacy-attention" hidden>
@@ -346,8 +336,6 @@ async function injectUI(): Promise<void> {
       }
     });
   });
-
-  await refreshLauncherAuthenticationState(authToken).catch(() => undefined);
 }
 
 function setupLauncherInteraction(): void {
@@ -409,6 +397,12 @@ function setupLauncherInteraction(): void {
     if (toggle.hasPointerCapture(event.pointerId)) {
       toggle.releasePointerCapture(event.pointerId);
     }
+    if (cancelled) {
+      drag = undefined;
+      launcherSuppressClick = false;
+      applyLauncherPosition();
+      return;
+    }
     if (launcherSuppressClick) {
       const rect = fab.getBoundingClientRect();
       void setLauncherPosition({
@@ -420,7 +414,6 @@ function setupLauncherInteraction(): void {
       });
     }
     drag = undefined;
-    if (cancelled) launcherSuppressClick = false;
   };
   toggle.addEventListener("pointerup", (event) => finishDrag(event));
   toggle.addEventListener("pointercancel", (event) => finishDrag(event, true));
@@ -530,6 +523,23 @@ function resetLauncherAccountState(authenticated: boolean): void {
       ? "Review loaded messages"
       : "Sign in to capture";
   }
+}
+
+function normalizeAuthToken(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+async function refreshLauncherFromValidatedAuthentication(): Promise<void> {
+  authToken = null;
+  resetLauncherAccountState(false);
+  const authResponse = (await chrome.runtime.sendMessage({
+    action: "GET_AUTH_STATUS",
+  })) as ExtensionResponse<AuthStatusData>;
+  if (!authResponse.success || !authResponse.data?.isAuthenticated) return;
+
+  const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
+  authToken = normalizeAuthToken(stored[STORAGE_KEYS.authToken]);
+  await refreshLauncherAuthenticationState(authToken);
 }
 
 async function refreshLauncherAuthenticationState(
@@ -1595,11 +1605,11 @@ function handleMessage(
         });
         break;
       }
-      authToken = typedMessage.token;
+      authToken = normalizeAuthToken(typedMessage.token);
       chrome.storage.local
-        .set({ [STORAGE_KEYS.authToken]: typedMessage.token })
+        .set({ [STORAGE_KEYS.authToken]: authToken })
         .catch(() => undefined);
-      refreshLauncherAuthenticationState(typedMessage.token)
+      refreshLauncherAuthenticationState(authToken)
         .then(() => respondSafely(sendResponse, { success: true }))
         .catch((error) => {
           respondSafely(sendResponse, {
@@ -1609,6 +1619,17 @@ function handleMessage(
         });
       return true;
     }
+
+    case "REFRESH_LAUNCHER_STATE":
+      refreshLauncherFromValidatedAuthentication()
+        .then(() => respondSafely(sendResponse, { success: true }))
+        .catch((error) =>
+          respondSafely(sendResponse, {
+            success: false,
+            error: normalizeErrorMessage(error),
+          }),
+        );
+      return true;
 
     default:
       sendResponse({ success: false, error: "Unknown action" });

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -568,6 +568,7 @@ async function refreshLauncherAuthenticationState(
     );
   } catch (error) {
     if (refreshGeneration !== launcherAuthRefreshGeneration) return;
+    if (operationRenderGeneration !== launcherOperationRenderGeneration) return;
     resetLauncherAccountState(token !== null);
     throw error;
   }
@@ -808,8 +809,13 @@ function updateLauncherBadge(operation: CaptureOperationSnapshot | null): void {
   const fab = document.getElementById("convolens-fab");
   const badge = document.getElementById("ws-launcher-badge");
   if (!fab || !badge) return;
-  const state =
-    operation?.state || (legacyQueueCount > 0 ? "attention" : "ready");
+  const terminalAttention =
+    operation !== null &&
+    ["received", "duplicate"].includes(operation.state) &&
+    (operation.reconciliationRequired || legacyQueueCount > 0);
+  const state = terminalAttention
+    ? "attention"
+    : operation?.state || (legacyQueueCount > 0 ? "attention" : "ready");
   fab.dataset.state = state;
   let value = "";
   if (operation?.state === "ready-for-review") {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -819,13 +819,19 @@ function updateLauncherBadge(operation: CaptureOperationSnapshot | null): void {
     ["inspecting", "collecting", "uploading"].includes(operation.state)
   ) {
     value = "…";
-  } else if (operation && ["received", "duplicate"].includes(operation.state)) {
-    value = "✓";
   } else if (
     operation &&
     ["retry-required", "failed", "cancelled"].includes(operation.state)
   ) {
     value = "!";
+  } else if (
+    operation &&
+    ["received", "duplicate"].includes(operation.state) &&
+    (operation.reconciliationRequired || legacyQueueCount > 0)
+  ) {
+    value = "!";
+  } else if (operation && ["received", "duplicate"].includes(operation.state)) {
+    value = "✓";
   } else if (legacyQueueCount > 0) {
     value = "!";
   }
@@ -862,15 +868,29 @@ function getLauncherAccessibleStatus(): string {
   }
   if (
     launcherOperation &&
-    ["received", "duplicate"].includes(launcherOperation.state)
-  ) {
-    return "Capture received by ConvoLens.";
-  }
-  if (
-    launcherOperation &&
     ["retry-required", "failed", "cancelled"].includes(launcherOperation.state)
   ) {
     return "Capture needs attention.";
+  }
+  if (
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state) &&
+    launcherOperation.reconciliationRequired
+  ) {
+    return "Capture received. Reconciliation review required.";
+  }
+  if (
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state) &&
+    legacyQueueCount > 0
+  ) {
+    return `Capture received. ${legacyQueueCount} legacy local capture${legacyQueueCount === 1 ? "" : "s"} need review.`;
+  }
+  if (
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state)
+  ) {
+    return "Capture received by ConvoLens.";
   }
   if (legacyQueueCount > 0) {
     return `${legacyQueueCount} legacy local capture${legacyQueueCount === 1 ? "" : "s"} need review.`;

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -148,6 +148,7 @@ let launcherOperation: CaptureOperationSnapshot | null = null;
 let legacyQueueCount = 0;
 let launcherSuppressClick = false;
 let launcherAuthRefreshGeneration = 0;
+let launcherOperationRenderGeneration = 0;
 
 // =============================================================================
 // Initialization
@@ -504,6 +505,7 @@ function updateLegacyQueueState(count: number): void {
 }
 
 function resetLauncherAccountState(authenticated: boolean): void {
+  launcherOperationRenderGeneration += 1;
   launcherOperation = null;
   pageConfirmationOperationId = null;
   updateLegacyQueueState(0);
@@ -548,6 +550,7 @@ async function refreshLauncherAuthenticationState(
   const refreshGeneration = ++launcherAuthRefreshGeneration;
   resetLauncherAccountState(token !== null);
   if (token === null) return;
+  const operationRenderGeneration = launcherOperationRenderGeneration;
 
   try {
     const [operationResponse, legacyResponse] = (await Promise.all([
@@ -558,7 +561,11 @@ async function refreshLauncherAuthenticationState(
       ExtensionResponse<{ count: number }>,
     ];
     if (refreshGeneration !== launcherAuthRefreshGeneration) return;
-    if (operationResponse.success && operationResponse.data) {
+    if (
+      operationRenderGeneration === launcherOperationRenderGeneration &&
+      operationResponse.success &&
+      operationResponse.data
+    ) {
       renderCaptureOperation(operationResponse.data);
     }
     updateLegacyQueueState(
@@ -718,6 +725,7 @@ async function reviewPageCapture(
 }
 
 function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
+  launcherOperationRenderGeneration += 1;
   launcherOperation = operation;
   updateLauncherBadge(operation);
   if (activeCaptureOperation?.operationId === operation.operationId) {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -180,7 +180,11 @@ async function init(): Promise<void> {
   // Load saved auth token
   try {
     const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
-    authToken = stored[STORAGE_KEYS.authToken];
+    const storedToken = stored[STORAGE_KEYS.authToken];
+    authToken =
+      typeof storedToken === "string" && storedToken.trim().length > 0
+        ? storedToken
+        : null;
   } catch (error) {
     console.warn("[ConvoLens] Failed to load auth token:", error);
   }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -416,9 +416,11 @@ function setupLauncherInteraction(): void {
       event.clientX >= window.innerWidth / 2,
     );
   });
-  const finishDrag = (event: PointerEvent) => {
+  const finishDrag = (event: PointerEvent, cancelled = false) => {
     if (!drag || drag.pointerId !== event.pointerId) return;
-    toggle.releasePointerCapture(event.pointerId);
+    if (toggle.hasPointerCapture(event.pointerId)) {
+      toggle.releasePointerCapture(event.pointerId);
+    }
     if (launcherSuppressClick) {
       const rect = fab.getBoundingClientRect();
       void setLauncherPosition({
@@ -430,9 +432,10 @@ function setupLauncherInteraction(): void {
       });
     }
     drag = undefined;
+    if (cancelled) launcherSuppressClick = false;
   };
-  toggle.addEventListener("pointerup", finishDrag);
-  toggle.addEventListener("pointercancel", finishDrag);
+  toggle.addEventListener("pointerup", (event) => finishDrag(event));
+  toggle.addEventListener("pointercancel", (event) => finishDrag(event, true));
 
   fab
     .querySelectorAll<HTMLButtonElement>("[data-launcher-preset]")
@@ -469,6 +472,9 @@ function setLauncherExpanded(expanded: boolean, restoreFocus = false): void {
       ? "Close ConvoLens capture panel. Drag to move."
       : "Open ConvoLens capture panel. Drag to move.",
   );
+  if (expanded) {
+    panel.querySelector<HTMLButtonElement>("button:not([disabled])")?.focus();
+  }
   if (restoreFocus) toggle.focus();
 }
 
@@ -514,6 +520,50 @@ function updateLegacyQueueState(count: number): void {
     label.textContent = `${count} unowned local capture${count === 1 ? "" : "s"}. Export or confirmed deletion only.`;
   }
   updateLauncherBadge(launcherOperation);
+}
+
+function resetLauncherAccountState(authenticated: boolean): void {
+  launcherOperation = null;
+  pageConfirmationOperationId = null;
+  updateLegacyQueueState(0);
+  updateProgress(0);
+  updateStatus(
+    authenticated
+      ? "Ready to review loaded messages."
+      : "Sign in to ConvoLens before reviewing loaded messages.",
+    "info",
+  );
+  const button = document.getElementById(
+    "ws-extract-btn",
+  ) as HTMLButtonElement | null;
+  if (button) {
+    button.disabled = !authenticated;
+    button.textContent = authenticated
+      ? "Review loaded messages"
+      : "Sign in to capture";
+  }
+}
+
+async function refreshLauncherAuthenticationState(
+  token: string | null,
+): Promise<void> {
+  resetLauncherAccountState(token !== null);
+  if (token === null) return;
+
+  const [operationResponse, legacyResponse] = (await Promise.all([
+    chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
+    chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
+  ])) as [
+    ExtensionResponse<CaptureOperationSnapshot>,
+    ExtensionResponse<{ count: number }>,
+  ];
+  if (authToken !== token) return;
+  if (operationResponse.success && operationResponse.data) {
+    renderCaptureOperation(operationResponse.data);
+  }
+  updateLegacyQueueState(
+    legacyResponse.success ? legacyResponse.data?.count || 0 : 0,
+  );
 }
 
 function updateStatus(
@@ -1554,8 +1604,16 @@ function handleMessage(
       chrome.storage.local
         .set({ [STORAGE_KEYS.authToken]: typedMessage.token })
         .catch(() => undefined);
-      sendResponse({ success: true });
-      break;
+      refreshLauncherAuthenticationState(typedMessage.token)
+        .then(() => respondSafely(sendResponse, { success: true }))
+        .catch((error) => {
+          resetLauncherAccountState(typedMessage.token !== null);
+          respondSafely(sendResponse, {
+            success: false,
+            error: normalizeErrorMessage(error),
+          });
+        });
+      return true;
     }
 
     default:

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -528,18 +528,20 @@ function normalizeAuthToken(value: unknown): string | null {
 }
 
 async function refreshLauncherFromValidatedAuthentication(): Promise<void> {
-  launcherAuthRefreshGeneration += 1;
+  const refreshGeneration = ++launcherAuthRefreshGeneration;
   authToken = null;
   resetLauncherAccountState(false);
   const authResponse = (await chrome.runtime.sendMessage({
     action: "GET_AUTH_STATUS",
   })) as ExtensionResponse<AuthStatusData>;
+  if (refreshGeneration !== launcherAuthRefreshGeneration) return;
   if (authResponse.success) {
     launcherCaptureAuthGeneration = authResponse.data?.authGeneration || 0;
   }
   if (!authResponse.success || !authResponse.data?.isAuthenticated) return;
 
   const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
+  if (refreshGeneration !== launcherAuthRefreshGeneration) return;
   authToken = normalizeAuthToken(stored[STORAGE_KEYS.authToken]);
   await refreshLauncherAuthenticationState(authToken);
 }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -149,6 +149,7 @@ let legacyQueueCount = 0;
 let launcherSuppressClick = false;
 let launcherAuthRefreshGeneration = 0;
 let launcherOperationRenderGeneration = 0;
+let launcherCaptureAuthGeneration = 0;
 
 // =============================================================================
 // Initialization
@@ -533,6 +534,9 @@ async function refreshLauncherFromValidatedAuthentication(): Promise<void> {
   const authResponse = (await chrome.runtime.sendMessage({
     action: "GET_AUTH_STATUS",
   })) as ExtensionResponse<AuthStatusData>;
+  if (authResponse.success) {
+    launcherCaptureAuthGeneration = authResponse.data?.authGeneration || 0;
+  }
   if (!authResponse.success || !authResponse.data?.isAuthenticated) return;
 
   const stored = await chrome.storage.local.get([STORAGE_KEYS.authToken]);
@@ -629,9 +633,11 @@ async function handleExtractClick(): Promise<void> {
     const existingResponse = (await chrome.runtime.sendMessage({
       action: "GET_CAPTURE_OPERATION",
     })) as ExtensionResponse<CaptureOperationSnapshot>;
-    const existingOperation = existingResponse.success
-      ? existingResponse.data
-      : undefined;
+    const existingOperation =
+      existingResponse.success &&
+      existingResponse.data?.authGeneration === launcherCaptureAuthGeneration
+        ? existingResponse.data
+        : undefined;
     if (
       existingOperation &&
       ["ready-for-review", "retry-required"].includes(existingOperation.state)
@@ -677,7 +683,7 @@ async function handleExtractClick(): Promise<void> {
       );
       return;
     }
-    renderCaptureOperation(response.data);
+    if (!renderCaptureOperation(response.data)) return;
     if (["ready-for-review", "retry-required"].includes(response.data.state)) {
       if (response.data.state === "retry-required") {
         pageConfirmationOperationId = null;
@@ -692,6 +698,7 @@ async function handleExtractClick(): Promise<void> {
 async function reviewPageCapture(
   operation: CaptureOperationSnapshot,
 ): Promise<void> {
+  if (operation.authGeneration !== launcherCaptureAuthGeneration) return;
   if (pageConfirmationOperationId === operation.operationId) return;
   pageConfirmationOperationId = operation.operationId;
   const confirmed = window.confirm(
@@ -707,7 +714,9 @@ async function reviewPageCapture(
       reason: confirmed ? undefined : "Upload cancelled. Nothing was sent.",
     })) as ExtensionResponse<CaptureOperationSnapshot>;
     if (response.success && response.data) {
-      renderCaptureOperation(response.data);
+      if (!renderCaptureOperation(response.data)) {
+        pageConfirmationOperationId = null;
+      }
       return;
     }
     pageConfirmationOperationId = null;
@@ -721,7 +730,8 @@ async function reviewPageCapture(
   }
 }
 
-function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
+function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
+  if (operation.authGeneration !== launcherCaptureAuthGeneration) return false;
   launcherOperationRenderGeneration += 1;
   launcherOperation = operation;
   updateLauncherBadge(operation);
@@ -788,6 +798,7 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): void {
       updateStatus(operation.reason || "Capture cancelled.", "error");
       break;
   }
+  return true;
 }
 
 function getLauncherActionLabel(operation: CaptureOperationSnapshot): string {
@@ -1681,6 +1692,7 @@ function handleMessage(
         break;
       }
       authToken = normalizeAuthToken(typedMessage.token);
+      launcherCaptureAuthGeneration = typedMessage.authGeneration;
       chrome.storage.local
         .set({ [STORAGE_KEYS.authToken]: authToken })
         .catch(() => undefined);

--- a/apps/chrome-extension/src/launcher-position.ts
+++ b/apps/chrome-extension/src/launcher-position.ts
@@ -1,0 +1,66 @@
+export type LauncherEdge = "left" | "right";
+export type LauncherPreset = "upper" | "middle" | "lower";
+
+export interface LauncherPosition {
+  edge: LauncherEdge;
+  preset: LauncherPreset;
+}
+
+export const DEFAULT_LAUNCHER_POSITION: LauncherPosition = {
+  edge: "right",
+  preset: "middle",
+};
+
+export function normalizeLauncherPosition(value: unknown): LauncherPosition {
+  if (!value || typeof value !== "object") return DEFAULT_LAUNCHER_POSITION;
+  const candidate = value as Partial<LauncherPosition>;
+  return {
+    edge: candidate.edge === "left" ? "left" : "right",
+    preset:
+      candidate.preset === "upper" || candidate.preset === "lower"
+        ? candidate.preset
+        : "middle",
+  };
+}
+
+export function getLauncherTop(
+  preset: LauncherPreset,
+  viewportHeight: number,
+  launcherSize: number = 44,
+): number {
+  const viewportMargin = 12;
+  const preferredTopInset = 72;
+  const composerClearance = 104;
+  const absoluteMaximum = Math.max(
+    viewportMargin,
+    viewportHeight - launcherSize - viewportMargin,
+  );
+  const minimum = Math.min(preferredTopInset, absoluteMaximum);
+  const maximum = Math.max(
+    minimum,
+    Math.min(
+      absoluteMaximum,
+      viewportHeight - launcherSize - composerClearance,
+    ),
+  );
+
+  if (preset === "upper") return minimum;
+  if (preset === "lower") return maximum;
+  return Math.round(minimum + (maximum - minimum) / 2);
+}
+
+export function resolveLauncherEdge(
+  pointerX: number,
+  viewportWidth: number,
+): LauncherEdge {
+  return pointerX < viewportWidth / 2 ? "left" : "right";
+}
+
+export function resolveLauncherPreset(
+  launcherCenterY: number,
+  viewportHeight: number,
+): LauncherPreset {
+  if (launcherCenterY < viewportHeight / 3) return "upper";
+  if (launcherCenterY > (viewportHeight * 2) / 3) return "lower";
+  return "middle";
+}

--- a/apps/chrome-extension/tests/phase3-operation-state.test.ts
+++ b/apps/chrome-extension/tests/phase3-operation-state.test.ts
@@ -68,6 +68,14 @@ test("persists only operation snapshots and keeps raw capture in tab memory", ()
   );
   assert.match(persistenceFunction, /chrome\.storage\.session\.set/);
   assert.match(persistenceFunction, /Object\.fromEntries\(captureOperations\)/);
+  assert.match(
+    persistenceFunction,
+    /STORAGE_KEYS\.captureLifecycleEpoch.*captureLifecycleEpoch/s,
+  );
+  assert.match(
+    backgroundSource,
+    /const persistedEpoch = stored\[STORAGE_KEYS\.captureLifecycleEpoch\][\s\S]*captureLifecycleEpoch =/,
+  );
   assert.match(contentSource, /payload: ExtractedChat \| null/);
   assert.match(contentSource, /activeCaptureOperation/);
   assert.match(contentSource, /getOpaqueChatKey/);

--- a/apps/chrome-extension/tests/phase3-operation-state.test.ts
+++ b/apps/chrome-extension/tests/phase3-operation-state.test.ts
@@ -205,7 +205,7 @@ test("invalidates retained reviews when authentication writes change owner", () 
   );
   assert.match(
     backgroundSource,
-    /await replaceAuthenticatedUser\(token, user\)/,
+    /replaceAuthenticatedUser\(\s*token,\s*user/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase3-operation-state.test.ts
+++ b/apps/chrome-extension/tests/phase3-operation-state.test.ts
@@ -29,6 +29,7 @@ test("models active and terminal capture operation states", () => {
     new Date("2026-07-28T12:00:00.000Z"),
   );
   assert.equal(started.tabId, 42);
+  assert.equal(started.authGeneration, 0);
   assert.equal(started.state, "inspecting");
   assert.equal(isActiveCaptureState(started.state), true);
 

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -97,7 +97,12 @@ test("gets only a safe legacy count from the background", () => {
     contentSource.indexOf("async function injectUI"),
     contentSource.indexOf("function setupLauncherInteraction"),
   );
-  assert.match(injection, /GET_LEGACY_QUEUE_SUMMARY/);
+  const authenticationRefresh = contentSource.slice(
+    contentSource.indexOf("async function refreshLauncherAuthenticationState"),
+    contentSource.indexOf("function updateStatus"),
+  );
+  assert.match(injection, /refreshLauncherAuthenticationState\(authToken\)/);
+  assert.match(authenticationRefresh, /GET_LEGACY_QUEUE_SUMMARY/);
   assert.doesNotMatch(injection, /STORAGE_KEYS\.pendingUploads/);
   assert.doesNotMatch(contentSource, /chrome\.storage\.onChanged/);
   assert.match(backgroundSource, /async function getLegacyQueueSummary/);
@@ -118,7 +123,18 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
     contentSource,
     /GET_CAPTURE_OPERATION[\s\S]*GET_LEGACY_QUEUE_SUMMARY/,
   );
-  assert.match(contentSource, /if \(authToken !== token\) return/);
+  assert.match(
+    contentSource,
+    /const refreshGeneration = \+\+launcherAuthRefreshGeneration/,
+  );
+  assert.match(
+    contentSource,
+    /catch \(error\) \{\s*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;\s*resetLauncherAccountState\(token !== null\)/,
+  );
+  assert.match(
+    contentSource,
+    /await refreshLauncherAuthenticationState\(authToken\)\.catch\(\(\) => undefined\)/,
+  );
   assert.match(
     contentSource,
     /case "SET_AUTH_TOKEN"[\s\S]*refreshLauncherAuthenticationState\(typedMessage\.token\)/,

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -180,6 +180,10 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
     contentSource,
     /launcherCaptureAuthGeneration = typedMessage\.authGeneration/,
   );
+  assert.match(
+    backgroundSource,
+    /async function getAuthStatus[\s\S]*await loadCaptureOperations\(\)[\s\S]*authGeneration: captureLifecycleEpoch/,
+  );
 });
 
 test("moves focus into the panel and clears cancelled-drag suppression", () => {

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -104,3 +104,33 @@ test("gets only a safe legacy count from the background", () => {
   assert.match(backgroundSource, /typeof authenticatedOwnerId === "string"/);
   assert.match(backgroundSource, /Array\.isArray\(pending\)/);
 });
+
+test("refreshes account-scoped launcher state on authentication messages", () => {
+  assert.match(
+    contentSource,
+    /async function refreshLauncherAuthenticationState/,
+  );
+  assert.match(
+    contentSource,
+    /resetLauncherAccountState\(token !== null\)[\s\S]*if \(token === null\) return/,
+  );
+  assert.match(
+    contentSource,
+    /GET_CAPTURE_OPERATION[\s\S]*GET_LEGACY_QUEUE_SUMMARY/,
+  );
+  assert.match(contentSource, /if \(authToken !== token\) return/);
+  assert.match(
+    contentSource,
+    /case "SET_AUTH_TOKEN"[\s\S]*refreshLauncherAuthenticationState\(typedMessage\.token\)/,
+  );
+  assert.match(contentSource, /launcherOperation = null/);
+});
+
+test("moves focus into the panel and clears cancelled-drag suppression", () => {
+  assert.match(
+    contentSource,
+    /if \(expanded\) \{\s*panel\.querySelector<HTMLButtonElement>\("button:not\(\[disabled\]\)"\)\?\.focus\(\)/,
+  );
+  assert.match(contentSource, /pointercancel[\s\S]*finishDrag\(event, true\)/);
+  assert.match(contentSource, /if \(cancelled\) launcherSuppressClick = false/);
+});

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -145,6 +145,14 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     contentSource,
+    /const operationRenderGeneration = launcherOperationRenderGeneration[\s\S]*operationRenderGeneration === launcherOperationRenderGeneration[\s\S]*renderCaptureOperation\(operationResponse\.data\)/,
+  );
+  assert.match(
+    contentSource,
+    /function renderCaptureOperation[\s\S]*launcherOperationRenderGeneration \+= 1/,
+  );
+  assert.match(
+    contentSource,
     /catch \(error\) \{\s*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;\s*resetLauncherAccountState\(token !== null\)/,
   );
   assert.match(

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -190,11 +190,15 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     backgroundSource,
-    /syncMystiraSession[\s\S]*const authenticationIntent = authenticationIntentGeneration[\s\S]*replaceAuthenticatedUser\([\s\S]*authenticationIntent[\s\S]*if \(!replaced\)/,
+    /syncMystiraSession[\s\S]*expectedAuthenticationIntent \?\? authenticationIntentGeneration[\s\S]*replaceAuthenticatedUser\([\s\S]*authenticationIntent[\s\S]*if \(!replaced\)/,
   );
   assert.match(
     backgroundSource,
-    /clearCaptureStateAndAuthentication[\s\S]*authenticationIntentGeneration \+= 1[\s\S]*Promise\.allSettled\(\[\.\.\.captureUploadPromises\.values\(\)\]\)[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
+    /clearCaptureStateAndAuthentication[\s\S]*const clearAuthenticationIntent = \+\+authenticationIntentGeneration[\s\S]*Promise\.allSettled\(\[\.\.\.captureUploadPromises\.values\(\)\]\)[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationIntent !== authenticationIntentGeneration[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
+  );
+  assert.match(
+    backgroundSource,
+    /case "SYNC_MYSTIRA_AUTH":[\s\S]*syncMystiraSession\(\+\+authenticationIntentGeneration\)/,
   );
   assert.match(
     backgroundSource,
@@ -243,7 +247,7 @@ test("revalidates authentication and safe legacy state after options changes", (
   );
   assert.match(
     backgroundSource,
-    /const syncResponse = await syncMystiraSession\(\)[\s\S]*if \(!syncResponse\.success\)[\s\S]*isAuthenticated: false/,
+    /const syncResponse = await syncMystiraSession\([\s\S]*authenticationIntentGeneration[\s\S]*if \(!syncResponse\.success\)[\s\S]*isAuthenticated: false/,
   );
   assert.match(
     optionsSource,

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -113,6 +113,10 @@ test("gets only a safe legacy count from the background", () => {
 test("refreshes account-scoped launcher state on authentication messages", () => {
   assert.match(
     contentSource,
+    /typeof storedToken === "string" && storedToken\.trim\(\)\.length > 0[\s\S]*\? storedToken[\s\S]*: null/,
+  );
+  assert.match(
+    contentSource,
     /async function refreshLauncherAuthenticationState/,
   );
   assert.match(

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -125,6 +125,10 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     contentSource,
+    /async function refreshLauncherFromValidatedAuthentication[\s\S]*launcherAuthRefreshGeneration \+= 1[\s\S]*resetLauncherAccountState\(false\)/,
+  );
+  assert.match(
+    contentSource,
     /await refreshLauncherFromValidatedAuthentication\(\)\.catch\(\(\) => undefined\)/,
   );
   assert.match(

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -174,6 +174,19 @@ test("moves focus into the panel and clears cancelled-drag suppression", () => {
   );
 });
 
+test("exposes collapsed badge state through the launcher accessible name", () => {
+  assert.match(
+    contentSource,
+    /function updateLauncherBadge[\s\S]*updateLauncherToggleLabel\(\)/,
+  );
+  assert.match(
+    contentSource,
+    /getLauncherAccessibleStatus\(\)[\s\S]*loaded message[\s\S]*ready for review/,
+  );
+  assert.match(contentSource, /Capture needs attention/);
+  assert.match(contentSource, /legacy local capture/);
+});
+
 test("revalidates authentication and safe legacy state after options changes", () => {
   assert.match(
     backgroundSource,

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -188,6 +188,18 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
     backgroundSource,
     /async function getAuthStatus[\s\S]*await loadCaptureOperations\(\)[\s\S]*authGeneration: captureLifecycleEpoch/,
   );
+  assert.match(
+    backgroundSource,
+    /syncMystiraSession[\s\S]*const authenticationIntent = authenticationIntentGeneration[\s\S]*replaceAuthenticatedUser\([\s\S]*authenticationIntent[\s\S]*if \(!replaced\)/,
+  );
+  assert.match(
+    backgroundSource,
+    /clearCaptureStateAndAuthentication[\s\S]*authenticationIntentGeneration \+= 1[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
+  );
+  assert.match(
+    backgroundSource,
+    /expectedAuthenticationIntent !== authenticationIntentGeneration[\s\S]*return false/,
+  );
 });
 
 test("moves focus into the panel and clears cancelled-drag suppression", () => {

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -190,7 +190,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     backgroundSource,
-    /syncMystiraSession[\s\S]*expectedAuthenticationIntent \?\? authenticationIntentGeneration[\s\S]*replaceAuthenticatedUser\([\s\S]*authenticationIntent[\s\S]*if \(!replaced\)/,
+    /syncMystiraSession\(\s*authenticationIntent: number[\s\S]*replaceAuthenticatedUser\([\s\S]*authenticationIntent[\s\S]*if \(!replaced\)/,
   );
   assert.match(
     backgroundSource,
@@ -207,6 +207,14 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   assert.match(
     backgroundSource,
     /notifyContentScripts\(token\)[\s\S]*committedAuthenticationIntentGeneration = Math\.max/,
+  );
+  assert.match(
+    backgroundSource,
+    /uploadCaptureOperation[\s\S]*const uploadAuthenticationIntent = committedAuthenticationIntentGeneration[\s\S]*sendChatData\([\s\S]*uploadAuthenticationIntent/,
+  );
+  assert.match(
+    backgroundSource,
+    /sendChatData\([\s\S]*uploadAuthenticationIntent: number[\s\S]*syncMystiraSession\(uploadAuthenticationIntent\)/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -125,7 +125,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     contentSource,
-    /async function refreshLauncherFromValidatedAuthentication[\s\S]*launcherAuthRefreshGeneration \+= 1[\s\S]*resetLauncherAccountState\(false\)/,
+    /async function refreshLauncherFromValidatedAuthentication[\s\S]*const refreshGeneration = \+\+launcherAuthRefreshGeneration[\s\S]*resetLauncherAccountState\(false\)/,
   );
   assert.match(
     contentSource,
@@ -146,6 +146,10 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   assert.match(
     contentSource,
     /const refreshGeneration = \+\+launcherAuthRefreshGeneration/,
+  );
+  assert.match(
+    contentSource,
+    /refreshLauncherFromValidatedAuthentication[\s\S]*const refreshGeneration = \+\+launcherAuthRefreshGeneration[\s\S]*GET_AUTH_STATUS[\s\S]*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;[\s\S]*chrome\.storage\.local\.get[\s\S]*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;[\s\S]*refreshLauncherAuthenticationState/,
   );
   assert.match(
     contentSource,

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -194,7 +194,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     backgroundSource,
-    /clearCaptureStateAndAuthentication[\s\S]*const clearAuthenticationIntent = \+\+authenticationIntentGeneration[\s\S]*Promise\.allSettled\(\[\.\.\.captureUploadPromises\.values\(\)\]\)[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationIntent !== authenticationIntentGeneration[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
+    /clearCaptureStateAndAuthentication[\s\S]*const clearAuthenticationIntent = \+\+authenticationIntentGeneration[\s\S]*Promise\.allSettled\(\[\.\.\.captureUploadPromises\.values\(\)\]\)[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*committedAuthenticationIntentGeneration > clearAuthenticationIntent[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
   );
   assert.match(
     backgroundSource,
@@ -203,6 +203,10 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   assert.match(
     backgroundSource,
     /expectedAuthenticationIntent !== authenticationIntentGeneration[\s\S]*return false/,
+  );
+  assert.match(
+    backgroundSource,
+    /notifyContentScripts\(token\)[\s\S]*committedAuthenticationIntentGeneration = Math\.max/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -185,6 +185,11 @@ test("exposes collapsed badge state through the launcher accessible name", () =>
   );
   assert.match(contentSource, /Capture needs attention/);
   assert.match(contentSource, /legacy local capture/);
+  assert.match(
+    contentSource,
+    /\["received", "duplicate"\][\s\S]*operation\.reconciliationRequired \|\| legacyQueueCount > 0[\s\S]*value = "!"/,
+  );
+  assert.match(contentSource, /Reconciliation review required/);
 });
 
 test("revalidates authentication and safe legacy state after options changes", () => {

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -20,6 +20,10 @@ const backgroundSource = await readFile(
   new URL("../src/background.ts", import.meta.url),
   "utf8",
 );
+const optionsSource = await readFile(
+  new URL("../options/options.js", import.meta.url),
+  "utf8",
+);
 
 test("normalizes persisted launcher placement without trusting arbitrary data", () => {
   assert.deepEqual(normalizeLauncherPosition(null), {
@@ -101,7 +105,7 @@ test("gets only a safe legacy count from the background", () => {
     contentSource.indexOf("async function refreshLauncherAuthenticationState"),
     contentSource.indexOf("function updateStatus"),
   );
-  assert.match(injection, /refreshLauncherAuthenticationState\(authToken\)/);
+  assert.doesNotMatch(injection, /STORAGE_KEYS\.authToken/);
   assert.match(authenticationRefresh, /GET_LEGACY_QUEUE_SUMMARY/);
   assert.doesNotMatch(injection, /STORAGE_KEYS\.pendingUploads/);
   assert.doesNotMatch(contentSource, /chrome\.storage\.onChanged/);
@@ -113,7 +117,15 @@ test("gets only a safe legacy count from the background", () => {
 test("refreshes account-scoped launcher state on authentication messages", () => {
   assert.match(
     contentSource,
-    /typeof storedToken === "string" && storedToken\.trim\(\)\.length > 0[\s\S]*\? storedToken[\s\S]*: null/,
+    /function normalizeAuthToken[\s\S]*typeof value === "string" && value\.trim\(\)\.length > 0/,
+  );
+  assert.match(
+    contentSource,
+    /async function refreshLauncherFromValidatedAuthentication[\s\S]*GET_AUTH_STATUS[\s\S]*isAuthenticated[\s\S]*normalizeAuthToken/,
+  );
+  assert.match(
+    contentSource,
+    /await refreshLauncherFromValidatedAuthentication\(\)\.catch\(\(\) => undefined\)/,
   );
   assert.match(
     contentSource,
@@ -137,11 +149,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     contentSource,
-    /await refreshLauncherAuthenticationState\(authToken\)\.catch\(\(\) => undefined\)/,
-  );
-  assert.match(
-    contentSource,
-    /case "SET_AUTH_TOKEN"[\s\S]*refreshLauncherAuthenticationState\(typedMessage\.token\)/,
+    /case "SET_AUTH_TOKEN"[\s\S]*authToken = normalizeAuthToken\(typedMessage\.token\)[\s\S]*refreshLauncherAuthenticationState\(authToken\)/,
   );
   assert.match(contentSource, /launcherOperation = null/);
 });
@@ -152,5 +160,28 @@ test("moves focus into the panel and clears cancelled-drag suppression", () => {
     /if \(expanded\) \{\s*panel\.querySelector<HTMLButtonElement>\("button:not\(\[disabled\]\)"\)\?\.focus\(\)/,
   );
   assert.match(contentSource, /pointercancel[\s\S]*finishDrag\(event, true\)/);
-  assert.match(contentSource, /if \(cancelled\) launcherSuppressClick = false/);
+  assert.match(
+    contentSource,
+    /if \(cancelled\) \{\s*drag = undefined;\s*launcherSuppressClick = false;\s*applyLauncherPosition\(\);\s*return;/,
+  );
+});
+
+test("revalidates authentication and safe legacy state after options changes", () => {
+  assert.match(
+    backgroundSource,
+    /case "REFRESH_LAUNCHER_STATE"[\s\S]*notifyLauncherStateRefresh/,
+  );
+  assert.match(
+    backgroundSource,
+    /const syncResponse = await syncMystiraSession\(\)[\s\S]*if \(!syncResponse\.success\)[\s\S]*isAuthenticated: false/,
+  );
+  assert.match(
+    optionsSource,
+    /remove\(STORAGE_KEYS\.pendingUploads\)[\s\S]*notifyLauncherStateRefresh\(\)/,
+  );
+  assert.match(
+    optionsSource,
+    /chrome\.storage\.local\.clear\(\)[\s\S]*notifyLauncherStateRefresh\(\)/,
+  );
+  assert.doesNotMatch(contentSource, /chrome\.storage\.onChanged/);
 });

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -153,7 +153,11 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     contentSource,
-    /catch \(error\) \{\s*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;\s*resetLauncherAccountState\(token !== null\)/,
+    /catch \(error\) \{\s*if \(refreshGeneration !== launcherAuthRefreshGeneration\) return;/,
+  );
+  assert.match(
+    contentSource,
+    /catch \(error\)[\s\S]*operationRenderGeneration !== launcherOperationRenderGeneration[\s\S]*resetLauncherAccountState/,
   );
   assert.match(
     contentSource,
@@ -190,6 +194,10 @@ test("exposes collapsed badge state through the launcher accessible name", () =>
     /\["received", "duplicate"\][\s\S]*operation\.reconciliationRequired \|\| legacyQueueCount > 0[\s\S]*value = "!"/,
   );
   assert.match(contentSource, /Reconciliation review required/);
+  assert.match(
+    contentSource,
+    /const terminalAttention =[\s\S]*operation\.reconciliationRequired \|\| legacyQueueCount > 0[\s\S]*\? "attention"/,
+  );
 });
 
 test("revalidates authentication and safe legacy state after options changes", () => {

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -194,7 +194,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     backgroundSource,
-    /clearCaptureStateAndAuthentication[\s\S]*authenticationIntentGeneration \+= 1[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
+    /clearCaptureStateAndAuthentication[\s\S]*authenticationIntentGeneration \+= 1[\s\S]*Promise\.allSettled\(\[\.\.\.captureUploadPromises\.values\(\)\]\)[\s\S]*const previousWrite = authenticationWriteTail[\s\S]*await previousWrite[\s\S]*clearAuthenticationState\(\)[\s\S]*releaseWrite\(\)/,
   );
   assert.match(
     backgroundSource,

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  getLauncherTop,
+  normalizeLauncherPosition,
+  resolveLauncherEdge,
+  resolveLauncherPreset,
+} from "../src/launcher-position";
+
+const contentSource = await readFile(
+  new URL("../src/content.ts", import.meta.url),
+  "utf8",
+);
+const styles = await readFile(
+  new URL("../src/content.css", import.meta.url),
+  "utf8",
+);
+const backgroundSource = await readFile(
+  new URL("../src/background.ts", import.meta.url),
+  "utf8",
+);
+
+test("normalizes persisted launcher placement without trusting arbitrary data", () => {
+  assert.deepEqual(normalizeLauncherPosition(null), {
+    edge: "right",
+    preset: "middle",
+  });
+  assert.deepEqual(
+    normalizeLauncherPosition({ edge: "left", preset: "lower" }),
+    { edge: "left", preset: "lower" },
+  );
+  assert.deepEqual(
+    normalizeLauncherPosition({ edge: "center", preset: "anywhere" }),
+    { edge: "right", preset: "middle" },
+  );
+});
+
+test("keeps all three presets inside the viewport and above the composer", () => {
+  const upper = getLauncherTop("upper", 900);
+  const middle = getLauncherTop("middle", 900);
+  const lower = getLauncherTop("lower", 900);
+  assert.ok(upper < middle);
+  assert.ok(middle < lower);
+  assert.ok(lower + 44 <= 900 - 104);
+  assert.ok(getLauncherTop("lower", 120) >= 12);
+  assert.ok(getLauncherTop("lower", 120) + 44 <= 120 - 12);
+});
+
+test("snaps pointer placement to an edge and vertical preset", () => {
+  assert.equal(resolveLauncherEdge(100, 1000), "left");
+  assert.equal(resolveLauncherEdge(900, 1000), "right");
+  assert.equal(resolveLauncherPreset(100, 900), "upper");
+  assert.equal(resolveLauncherPreset(450, 900), "middle");
+  assert.equal(resolveLauncherPreset(800, 900), "lower");
+});
+
+test("renders a compact inward-opening launcher with explicit position controls", () => {
+  assert.match(contentSource, /id="ws-launcher-toggle"/);
+  assert.match(contentSource, /id="ws-launcher-panel"/);
+  assert.match(contentSource, /data-launcher-preset="upper"/);
+  assert.match(contentSource, /data-launcher-preset="middle"/);
+  assert.match(contentSource, /data-launcher-preset="lower"/);
+  assert.match(contentSource, /setPointerCapture/);
+  assert.match(contentSource, /resolveLauncherEdge/);
+  assert.match(contentSource, /resolveLauncherPreset/);
+  assert.match(contentSource, /STORAGE_KEYS\.launcherPosition/);
+  assert.match(styles, /width: 44px/);
+  assert.match(
+    styles,
+    /\.ws-edge-left \.ws-launcher-panel \{[\s\S]*left: calc\(100% \+ 10px\)/,
+  );
+  assert.match(
+    styles,
+    /\.ws-edge-right \.ws-launcher-panel \{[\s\S]*right: calc\(100% \+ 10px\)/,
+  );
+  assert.match(styles, /position: absolute/);
+  assert.match(styles, /data-preset="lower"[\s\S]*bottom: 0/);
+});
+
+test("keeps operation, migration, and accessibility state inside the panel", () => {
+  assert.match(contentSource, /id="ws-launcher-badge"/);
+  assert.match(contentSource, /ready-for-review/);
+  assert.match(contentSource, /retry-required/);
+  assert.match(contentSource, /Legacy local captures need review/);
+  assert.match(contentSource, /Export or confirmed deletion only/);
+  assert.match(contentSource, /aria-live="polite"/);
+  assert.match(contentSource, /aria-expanded="false"/);
+  assert.match(contentSource, /event\.key === "Escape"/);
+  assert.match(styles, /prefers-reduced-motion: reduce/);
+  assert.match(styles, /forced-colors: active/);
+  assert.match(styles, /max-width: 420px/);
+});
+
+test("gets only a safe legacy count from the background", () => {
+  const injection = contentSource.slice(
+    contentSource.indexOf("async function injectUI"),
+    contentSource.indexOf("function setupLauncherInteraction"),
+  );
+  assert.match(injection, /GET_LEGACY_QUEUE_SUMMARY/);
+  assert.doesNotMatch(injection, /STORAGE_KEYS\.pendingUploads/);
+  assert.doesNotMatch(contentSource, /chrome\.storage\.onChanged/);
+  assert.match(backgroundSource, /async function getLegacyQueueSummary/);
+  assert.match(backgroundSource, /typeof authenticatedOwnerId === "string"/);
+  assert.match(backgroundSource, /Array\.isArray\(pending\)/);
+});

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -202,7 +202,7 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   );
   assert.match(
     backgroundSource,
-    /expectedAuthenticationIntent !== authenticationIntentGeneration[\s\S]*return false/,
+    /committedAuthenticationIntentGeneration > expectedAuthenticationIntent[\s\S]*activeAuthenticationClearIntents[\s\S]*clearIntent > expectedAuthenticationIntent[\s\S]*return false/,
   );
   assert.match(
     backgroundSource,
@@ -215,6 +215,10 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
   assert.match(
     backgroundSource,
     /sendChatData\([\s\S]*uploadAuthenticationIntent: number[\s\S]*syncMystiraSession\(uploadAuthenticationIntent\)/,
+  );
+  assert.match(
+    backgroundSource,
+    /activeAuthenticationClearIntents\.add\(clearAuthenticationIntent\)[\s\S]*activeAuthenticationClearIntents\.delete\(clearAuthenticationIntent\)/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -168,6 +168,18 @@ test("refreshes account-scoped launcher state on authentication messages", () =>
     /case "SET_AUTH_TOKEN"[\s\S]*authToken = normalizeAuthToken\(typedMessage\.token\)[\s\S]*refreshLauncherAuthenticationState\(authToken\)/,
   );
   assert.match(contentSource, /launcherOperation = null/);
+  assert.match(
+    backgroundSource,
+    /SET_AUTH_TOKEN[\s\S]*authGeneration: captureLifecycleEpoch/,
+  );
+  assert.match(
+    contentSource,
+    /operation\.authGeneration !== launcherCaptureAuthGeneration[\s\S]*return false/,
+  );
+  assert.match(
+    contentSource,
+    /launcherCaptureAuthGeneration = typedMessage\.authGeneration/,
+  );
 });
 
 test("moves focus into the panel and clears cancelled-drag suppression", () => {

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.14");
+  assert.equal(manifest.version, "1.0.15");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -15,6 +15,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Safe summary refreshes capture a monotonic launcher-render generation and cannot overwrite a newer live capture-operation update.
 - Failed safe-summary refreshes use the same render-generation guard and cannot clear a newer live operation.
 - Starting expiry-aware authentication validation advances the auth refresh generation immediately, invalidating older in-flight summary results even when validation ends signed out.
+- Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -40,7 +41,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `79EF3D7A311339F13729F9A3B9133AEED433BCBF6CCCC7B82D235BF99E9E0CDF`.
+- Packaged ZIP SHA-256: `DB4800BC5178BFC955FC43E8DCD06B3BA8A665A764876FD91E595AD86C2766B8`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -10,7 +10,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The expanded panel is absolutely anchored inward from either edge, aligned to the selected vertical preset, width- and height-bounded to the viewport, and scrollable when needed.
 - The panel renders ready, inspecting/collecting, review count, uploading, received/duplicate, retry-required, failed/cancelled, and legacy-migration attention states without changing the Phase 3 operation owner.
 - The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
-- Cold start and authentication changes immediately establish the correct signed-in or signed-out launcher state. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
+- Cold start normalizes an absent or invalid stored credential to signed out, and authentication changes immediately establish the correct launcher state. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
@@ -32,7 +32,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `9B286A37ACC2B776692ABD3E3491DAD169ACBA5A2FED729679FD14B62AE6D591`.
+- Packaged ZIP SHA-256: `9A2CE603B0A6D7859E8B238B3EE78F44687B7B7FA5D2B572093FB0924602CE89`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -10,7 +10,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The expanded panel is absolutely anchored inward from either edge, aligned to the selected vertical preset, width- and height-bounded to the viewport, and scrollable when needed.
 - The panel renders ready, inspecting/collecting, review count, uploading, received/duplicate, retry-required, failed/cancelled, and legacy-migration attention states without changing the Phase 3 operation owner.
 - The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
-- Authentication changes immediately clear account-scoped launcher operation and legacy-count rendering; an authenticated session then refetches both safe summaries from the background.
+- Cold start and authentication changes immediately establish the correct signed-in or signed-out launcher state. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
@@ -32,7 +32,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `B3866A29BE70DC15D3DD2805D9B6D6B4469B50B92CD3AB9856C1AC290074E4D3`.
+- Packaged ZIP SHA-256: `9B286A37ACC2B776692ABD3E3491DAD169ACBA5A2FED729679FD14B62AE6D591`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -18,7 +18,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Validated outer authentication refreshes retain and recheck their generation after both async boundaries, so an older auth-status result cannot overwrite a newer token notification.
 - Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
 - The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
-- Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately and shares the serialized authentication-write boundary, so a late refresh cannot restore a cleared account.
+- Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately, waits for already-authorized uploads without holding the authentication-write lock, then serializes the final clear so a late refresh cannot restore a cleared account or deadlock an upload.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -44,7 +44,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `E6CDA07F3A5FB0C559E2EC2FD5B23B531FF2EC91EBD81D331D49DA4544B55417`.
+- Packaged ZIP SHA-256: `9A945FFBEBF1A64E0D5CB54264FE75FA10373EA2AA7B2442E45977CCCF26E3C4`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -13,11 +13,13 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Cold start uses the background's expiry-aware authentication check and defaults the launcher to signed out. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
 - Confirmed legacy deletion and clear-all actions send a payload-free refresh signal through the background, keeping the launcher current without exposing raw legacy entries to the WhatsApp content script.
 - Safe summary refreshes capture a monotonic launcher-render generation and cannot overwrite a newer live capture-operation update.
+- Failed safe-summary refreshes use the same render-generation guard and cannot clear a newer live operation.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The launcher toggle's accessible name mirrors collapsed review count, progress, success, attention, and legacy-review state instead of relying on the hidden panel or visual badge.
 - Reconciliation-required or legacy-review attention takes precedence over a generic terminal-success check in both the visual badge and accessible status.
+- Terminal attention also sets the launcher's semantic/CSS state to `attention`, keeping its colour consistent with the warning symbol and accessible text.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
 - Extension runtime and package metadata are synchronized at `1.0.15`.
 
@@ -37,7 +39,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `C7A954056819915E41429709C9CC526A280D43F6537CCDF0617F64DD176DB478`.
+- Packaged ZIP SHA-256: `F18508E1E73A9338BE99447FBCE3701273D53ADF5D86D50C3BF58C82CE070782`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -12,6 +12,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
 - Cold start uses the background's expiry-aware authentication check and defaults the launcher to signed out. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
 - Confirmed legacy deletion and clear-all actions send a payload-free refresh signal through the background, keeping the launcher current without exposing raw legacy entries to the WhatsApp content script.
+- Safe summary refreshes capture a monotonic launcher-render generation and cannot overwrite a newer live capture-operation update.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -34,7 +35,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `07AE6E3AF007E3EAC888F0B9088B6F1B20BD84EE7CAEF05ABBA2744355667C81`.
+- Packaged ZIP SHA-256: `406B7BFDAD120113570D4E8A864E499D570B2DBA7B1F28FFAA55BCC20E319653`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -10,7 +10,9 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The expanded panel is absolutely anchored inward from either edge, aligned to the selected vertical preset, width- and height-bounded to the viewport, and scrollable when needed.
 - The panel renders ready, inspecting/collecting, review count, uploading, received/duplicate, retry-required, failed/cancelled, and legacy-migration attention states without changing the Phase 3 operation owner.
 - The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
-- Cold start normalizes an absent or invalid stored credential to signed out, and authentication changes immediately establish the correct launcher state. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
+- Cold start uses the background's expiry-aware authentication check and defaults the launcher to signed out. Authenticated sessions refetch both safe summaries through a generation-guarded path so stale successes or failures cannot overwrite a newer account transition.
+- Confirmed legacy deletion and clear-all actions send a payload-free refresh signal through the background, keeping the launcher current without exposing raw legacy entries to the WhatsApp content script.
+- Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
@@ -26,13 +28,13 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 
 ## Validation
 
-- Chrome extension Node tests: 63 passed, 0 failed, including eight focused launcher placement, inward anchoring, state, authentication-refresh, accessibility, and privacy-boundary tests.
+- Chrome extension Node tests: 64 passed, 0 failed, including nine focused launcher placement, inward anchoring, state, expiry/authentication refresh, options synchronization, accessibility, and privacy-boundary tests.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `9A2CE603B0A6D7859E8B238B3EE78F44687B7B7FA5D2B572093FB0924602CE89`.
+- Packaged ZIP SHA-256: `07AE6E3AF007E3EAC888F0B9088B6F1B20BD84EE7CAEF05ABBA2744355667C81`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -21,6 +21,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately, waits for already-authorized uploads without holding the authentication-write lock, then serializes the final clear so a late refresh cannot restore a cleared account or deadlock an upload.
 - Logout rechecks its intent after acquiring the final-clear lock. A later explicit password sign-in or external Mystira session validation wins; an upload-internal refresh remains part of the older operation and cannot supersede logout.
 - That final check uses the latest successfully committed authentication intent rather than a merely started attempt, so a failed later validation cannot cause logout to report success while leaving old credentials behind.
+- Upload-internal session refresh receives the committed authentication intent captured when that upload began; it cannot inherit a newer failed sign-in attempt from global state or supersede a pending logout.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -46,7 +47,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `0C3327EADF3F03F78FDC00E409531C5F3B8C3FA9A816A2692036906F2BE109AF`.
+- Packaged ZIP SHA-256: `3FFA99EAA1BD0BC7906D979673358F9AAF136ADB8F6EDA445780E73BEAA88C20`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -14,6 +14,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Confirmed legacy deletion and clear-all actions send a payload-free refresh signal through the background, keeping the launcher current without exposing raw legacy entries to the WhatsApp content script.
 - Safe summary refreshes capture a monotonic launcher-render generation and cannot overwrite a newer live capture-operation update.
 - Failed safe-summary refreshes use the same render-generation guard and cannot clear a newer live operation.
+- Starting expiry-aware authentication validation advances the auth refresh generation immediately, invalidating older in-flight summary results even when validation ends signed out.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -39,7 +40,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `F18508E1E73A9338BE99447FBCE3701273D53ADF5D86D50C3BF58C82CE070782`.
+- Packaged ZIP SHA-256: `79EF3D7A311339F13729F9A3B9133AEED433BCBF6CCCC7B82D235BF99E9E0CDF`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -16,6 +16,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Failed safe-summary refreshes use the same render-generation guard and cannot clear a newer live operation.
 - Starting expiry-aware authentication validation advances the auth refresh generation immediately, invalidating older in-flight summary results even when validation ends signed out.
 - Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
+- The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -41,7 +42,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `DB4800BC5178BFC955FC43E8DCD06B3BA8A665A764876FD91E595AD86C2766B8`.
+- Packaged ZIP SHA-256: `46742F9423C343A251F4E7D5FD6B28BEEDDE6DECCC4402018526E55C88765D11`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -18,6 +18,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Validated outer authentication refreshes retain and recheck their generation after both async boundaries, so an older auth-status result cannot overwrite a newer token notification.
 - Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
 - The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
+- Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately and shares the serialized authentication-write boundary, so a late refresh cannot restore a cleared account.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -43,7 +44,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `17552A155FB839103D67CCB8198C17F190E8C4E8324AD8A31460B905A0C9000E`.
+- Packaged ZIP SHA-256: `E6CDA07F3A5FB0C559E2EC2FD5B23B531FF2EC91EBD81D331D49DA4544B55417`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -22,6 +22,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Logout rechecks its intent after acquiring the final-clear lock. A later explicit password sign-in or external Mystira session validation wins; an upload-internal refresh remains part of the older operation and cannot supersede logout.
 - That final check uses the latest successfully committed authentication intent rather than a merely started attempt, so a failed later validation cannot cause logout to report success while leaving old credentials behind.
 - Upload-internal session refresh receives the committed authentication intent captured when that upload began; it cannot inherit a newer failed sign-in attempt from global state or supersede a pending logout.
+- Authentication writes reject only a newer successfully committed credential or a newer active clear intent. Merely started or failed external validation cannot poison a later upload refresh.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -47,7 +48,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `3FFA99EAA1BD0BC7906D979673358F9AAF136ADB8F6EDA445780E73BEAA88C20`.
+- Packaged ZIP SHA-256: `BDB2EB7C776C222735043458C5F07CDCB429A8289C90992640CC4832CA14759D`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -19,6 +19,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
 - The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
 - Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately, waits for already-authorized uploads without holding the authentication-write lock, then serializes the final clear so a late refresh cannot restore a cleared account or deadlock an upload.
+- Logout rechecks its intent after acquiring the final-clear lock. A later explicit password sign-in or external Mystira session validation wins; an upload-internal refresh remains part of the older operation and cannot supersede logout.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -44,7 +45,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `9A945FFBEBF1A64E0D5CB54264FE75FA10373EA2AA7B2442E45977CCCF26E3C4`.
+- Packaged ZIP SHA-256: `C242DEE1C03973974B8C5CAACC76053366F3F21D7CE16949E6E7767806B31162`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -1,0 +1,45 @@
+# ConvoLens extension capture Phase 4 handoff — 2026-07-28
+
+## Outcome
+
+Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable launcher from the phased extension plan.
+
+- The collapsed launcher is 44px square and remains above the composer at its lower preset.
+- Pointer dragging snaps to the left or right edge and to upper, middle, or lower vertical presets. The same presets and edge move are available as explicit keyboard-accessible controls.
+- Only the normalized non-sensitive `{ edge, preset }` placement is persisted in `chrome.storage.local`. Reload and viewport resize reapply a constrained preset rather than trusting arbitrary stored coordinates.
+- The expanded panel is absolutely anchored inward from either edge, aligned to the selected vertical preset, width- and height-bounded to the viewport, and scrollable when needed.
+- The panel renders ready, inspecting/collecting, review count, uploading, received/duplicate, retry-required, failed/cancelled, and legacy-migration attention states without changing the Phase 3 operation owner.
+- The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
+- Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
+- The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
+- Extension runtime and package metadata are synchronized at `1.0.15`.
+
+## Repository state
+
+- Base: `origin/main` at `373e76dc3bf54ac9c116fce82550f1b6ea1c89f6` (merged PR #151).
+- Branch: `agent/extension-capture-phase4`.
+- Worktree: `C:/tmp/convolens-extension-phase4`.
+- Pull request: to be opened.
+- The primary checkout and its pre-existing untracked handoff remain untouched.
+
+## Validation
+
+- Chrome extension Node tests: 61 passed, 0 failed, including six focused launcher placement, inward anchoring, state, accessibility, and privacy-boundary tests.
+- Chrome extension TypeScript: passed.
+- Prettier and `git diff --check`: passed.
+- Repository Turbo build: 8 of 8 packages passed.
+- Production extension build and package: passed.
+- Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
+- Packaged ZIP SHA-256: `BC0C0EAF68BD771C1917EA294FEDA2E59ED74046A6D23EB1EBBB1CC3E4F75628`.
+- A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
+
+## Boundaries still open
+
+- No extension, API, web, database, or Azure deployment is included.
+- No authentic WhatsApp position persistence, drag, keyboard, overlay-collision, narrow-window, connected-send, popup-close, navigation, persistence, deduplication, restart, isolation, deletion, or console-attribution evidence is claimed.
+- The launcher surfaces only a safe legacy count and opens the existing export-or-confirmed-deletion settings flow. It does not upload, retry, inspect, or delete legacy entries.
+- Guided `Capture as I scroll` and automatic older-history loading remain unavailable. No durable offline raw-message queue is introduced.
+
+## Continuation
+
+After Phase 4 is reviewed and merged, begin Phase 5 from current `origin/main`: add the explicit preview and capture-mode selection UI while preserving the shared operation state, loaded-message confirmation gate, privacy boundary, and the two disabled `Soon` modes until their implementation phases ship.

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -19,7 +19,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Base: `origin/main` at `373e76dc3bf54ac9c116fce82550f1b6ea1c89f6` (merged PR #151).
 - Branch: `agent/extension-capture-phase4`.
 - Worktree: `C:/tmp/convolens-extension-phase4`.
-- Pull request: to be opened.
+- Pull request: [#152](https://github.com/neuralliquid/convolens/pull/152).
 - The primary checkout and its pre-existing untracked handoff remain untouched.
 
 ## Validation

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -15,6 +15,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Safe summary refreshes capture a monotonic launcher-render generation and cannot overwrite a newer live capture-operation update.
 - Failed safe-summary refreshes use the same render-generation guard and cannot clear a newer live operation.
 - Starting expiry-aware authentication validation advances the auth refresh generation immediately, invalidating older in-flight summary results even when validation ends signed out.
+- Validated outer authentication refreshes retain and recheck their generation after both async boundaries, so an older auth-status result cannot overwrite a newer token notification.
 - Capture snapshots carry the background authentication epoch; direct responses and operation-update messages render only for the content script's validated current epoch, preventing old-account state from resurfacing after logout or account switch.
 - The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
@@ -42,7 +43,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `46742F9423C343A251F4E7D5FD6B28BEEDDE6DECCC4402018526E55C88765D11`.
+- Packaged ZIP SHA-256: `17552A155FB839103D67CCB8198C17F190E8C4E8324AD8A31460B905A0C9000E`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -17,6 +17,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The launcher toggle's accessible name mirrors collapsed review count, progress, success, attention, and legacy-review state instead of relying on the hidden panel or visual badge.
+- Reconciliation-required or legacy-review attention takes precedence over a generic terminal-success check in both the visual badge and accessible status.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
 - Extension runtime and package metadata are synchronized at `1.0.15`.
 
@@ -36,7 +37,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `1A5F199A0EB75CC8776DA3810933E61651888B8AE3021F03B974DFF990799839`.
+- Packaged ZIP SHA-256: `C7A954056819915E41429709C9CC526A280D43F6537CCDF0617F64DD176DB478`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -20,6 +20,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The authentication epoch is persisted in `chrome.storage.session` and restored before auth status or capture startup, so an MV3 service-worker restart cannot reset the background to an epoch that retained content scripts reject.
 - Background session refresh and password sign-in results are bound to the authentication intent that started them. Logout invalidates older intents immediately, waits for already-authorized uploads without holding the authentication-write lock, then serializes the final clear so a late refresh cannot restore a cleared account or deadlock an upload.
 - Logout rechecks its intent after acquiring the final-clear lock. A later explicit password sign-in or external Mystira session validation wins; an upload-internal refresh remains part of the older operation and cannot supersede logout.
+- That final check uses the latest successfully committed authentication intent rather than a merely started attempt, so a failed later validation cannot cause logout to report success while leaving old credentials behind.
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
@@ -45,7 +46,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `C242DEE1C03973974B8C5CAACC76053366F3F21D7CE16949E6E7767806B31162`.
+- Packaged ZIP SHA-256: `0C3327EADF3F03F78FDC00E409531C5F3B8C3FA9A816A2692036906F2BE109AF`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -10,6 +10,8 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - The expanded panel is absolutely anchored inward from either edge, aligned to the selected vertical preset, width- and height-bounded to the viewport, and scrollable when needed.
 - The panel renders ready, inspecting/collecting, review count, uploading, received/duplicate, retry-required, failed/cancelled, and legacy-migration attention states without changing the Phase 3 operation owner.
 - The legacy attention state receives only an authenticated, background-derived count. The WhatsApp content script does not read or subscribe to raw legacy `pendingUploads` values.
+- Authentication changes immediately clear account-scoped launcher operation and legacy-count rendering; an authenticated session then refetches both safe summaries from the background.
+- Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
 - Extension runtime and package metadata are synchronized at `1.0.15`.
@@ -24,13 +26,13 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 
 ## Validation
 
-- Chrome extension Node tests: 61 passed, 0 failed, including six focused launcher placement, inward anchoring, state, accessibility, and privacy-boundary tests.
+- Chrome extension Node tests: 63 passed, 0 failed, including eight focused launcher placement, inward anchoring, state, authentication-refresh, accessibility, and privacy-boundary tests.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `BC0C0EAF68BD771C1917EA294FEDA2E59ED74046A6D23EB1EBBB1CC3E4F75628`.
+- Packaged ZIP SHA-256: `B3866A29BE70DC15D3DD2805D9B6D6B4469B50B92CD3AB9856C1AC290074E4D3`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE4.md
@@ -16,6 +16,7 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 - Cancelled pointer drags restore the last saved launcher placement instead of persisting interrupted coordinates.
 - Opening the panel moves focus into its first enabled control, while pointer cancellation clears drag click-suppression state.
 - Escape, focus-visible, reduced-motion, forced-colour, dark-mode, and narrow-window behavior are included.
+- The launcher toggle's accessible name mirrors collapsed review count, progress, success, attention, and legacy-review state instead of relying on the hidden panel or visual badge.
 - The shared Phase 3 operation state machine, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture boundary remain intact.
 - Extension runtime and package metadata are synchronized at `1.0.15`.
 
@@ -29,13 +30,13 @@ Phase 4 replaces the permanent full-width WhatsApp pill with the compact movable
 
 ## Validation
 
-- Chrome extension Node tests: 64 passed, 0 failed, including nine focused launcher placement, inward anchoring, state, expiry/authentication refresh, options synchronization, accessibility, and privacy-boundary tests.
+- Chrome extension Node tests: 65 passed, 0 failed, including ten focused launcher placement, inward anchoring, state, expiry/authentication refresh, options synchronization, accessibility, and privacy-boundary tests.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.15`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `406B7BFDAD120113570D4E8A864E499D570B2DBA7B1F28FFAA55BCC20E319653`.
+- Packaged ZIP SHA-256: `1A5F199A0EB75CC8776DA3810933E61651888B8AE3021F03B974DFF990799839`.
 - A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect, which was replaced by explicit absolute inward anchoring and covered by focused source tests. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so no final visual or authentic acceptance is claimed.
 
 ## Boundaries still open


### PR DESCRIPTION
## What changed

- replace the permanent full-width WhatsApp capture pill with a compact 44px launcher
- support pointer drag with left/right edge snapping and upper/middle/lower vertical presets
- provide equivalent keyboard-accessible preset and edge controls
- persist only normalized non-sensitive edge/preset placement and reconstrain it on reload or viewport resize
- open the expanded workflow panel inward from either edge with bounded, scrollable desktop and narrow-window layout
- render shared ready, collecting, review-count, uploading, received/duplicate, retry-required, failure/cancellation, and legacy-migration attention states
- expose only an authenticated background-derived legacy queue count to WhatsApp; never read or subscribe to raw legacy payloads in the content script
- validate cold-start credentials through the background's expiry-aware auth path, default signed out, and generation-guard refreshes so stale work cannot overwrite newer account state
- refresh safe launcher summaries after options-page legacy deletion or clear-all through a payload-free background signal
- prevent safe-summary refresh snapshots from overwriting newer live operation renders with a monotonic render generation
- apply the same render-generation guard to failed refreshes so transient summary errors cannot clear newer live state
- invalidate older in-flight summaries as soon as expiry-aware auth validation starts, including signed-out outcomes
- discard older outer auth-status results after either async boundary when a newer token notification has already advanced the launcher generation
- bind capture snapshots to the background auth epoch and ignore stale direct responses or update messages after logout/account switch
- persist and restore that epoch through `chrome.storage.session` before auth status or capture startup so MV3 service-worker restarts cannot desynchronize retained content scripts
- bind background session refresh and password sign-in results to their initiating auth intent; logout invalidates older work immediately, waits for already-authorized uploads without holding the auth-write lock, then serializes the final clear
- recheck logout intent under that final-clear lock so a later password sign-in or external Mystira validation wins while an upload-internal refresh cannot supersede logout
- compare against successfully committed authentication intent, not merely started validation, so failed later validation cannot suppress logout's clear
- bind upload-internal session refresh to the committed auth intent captured when upload starts so it cannot inherit newer failed sign-in intent or supersede logout
- reject authentication writes only for a newer committed credential or newer active clear, preventing failed external validation from poisoning later upload refresh
- restore the last saved placement when a pointer drag is cancelled instead of persisting interrupted coordinates
- move focus into the expanded panel and clear click suppression after cancelled drags
- retain Phase 3 shared operation ownership, explicit loaded-message review, Phase 2 reconciliation truth, and memory-only new raw capture behavior
- add reduced-motion, forced-colour, dark-mode, focus-visible, Escape, and narrow-window support
- mirror collapsed review/progress/result/legacy-attention state in the launcher toggle's accessible name
- prioritize reconciliation-required and legacy-review attention over generic terminal-success status
- set terminal warning badges to the semantic/CSS `attention` state as well as the warning symbol
- bump the packaged extension to 1.0.15 and add the Phase 4 handoff

## Validation

- Chrome extension: 65 tests passed; typecheck passed
- focused launcher tests cover normalization, viewport constraints, edge/preset snapping, inward anchoring, expiry/auth refresh, options synchronization, state/accessibility contracts, and safe legacy summary isolation
- Prettier and `git diff --check` passed
- Turbo workspace build: 8/8 packages passed
- production package passed; embedded manifest version 1.0.15
- packaged permissions: storage, activeTab, scripting, notifications
- ZIP SHA-256: `BDB2EB7C776C222735043458C5F07CDCB429A8289C90992640CC4832CA14759D`

## Visual-smoke boundary

A local mocked WhatsApp Playwright smoke exposed an initial outward/flex-shrunk panel defect. The implementation now uses explicit absolute inward anchoring and focused regression contracts. The Playwright session wrapper became unresponsive before a post-fix screenshot could be captured, so this PR does not claim a final visual or authentic WhatsApp acceptance result.

## Not claimed

No deployment or authentic WhatsApp position-persistence, drag, keyboard, overlay-collision, narrow-window, connected-send, popup-close, navigation, persistence, deduplication, restart, isolation, deletion, or console-attribution acceptance is claimed. Guided capture and automatic older-history loading remain unavailable.
