### PR TITLE
Extension capture Phase 5: explicit preview and modes

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -233,20 +233,83 @@
         line-height: 1.4;
       }
 
+      #captureChatName {
+        display: block;
+        overflow: hidden;
+        margin-top: 4px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .capture-summary-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 5px;
+        margin: 8px 0;
+      }
+
+      .capture-summary-grid div {
+        padding: 6px;
+        border-radius: 7px;
+        background: #ffffff;
+      }
+
+      .capture-summary-grid dt,
+      .capture-range {
+        color: #6b7280;
+        font-size: 10px;
+      }
+
+      .capture-summary-grid dd {
+        margin: 2px 0 0;
+        color: #14532d;
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      .capture-range {
+        margin: 0;
+        line-height: 1.4;
+      }
+
       .capture-modes {
         display: grid;
         gap: 5px;
         margin: 8px 0 10px;
+        padding: 0;
+        border: 0;
+      }
+
+      .capture-modes legend {
+        margin-bottom: 4px;
+        color: #6b7280;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
       }
 
       .capture-mode {
-        display: flex;
-        justify-content: space-between;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
         gap: 8px;
+        padding: 6px;
+        border: 1px solid #d1d5db;
+        border-radius: 7px;
       }
 
-      .capture-mode span:last-child {
+      .capture-mode.selected {
+        border-color: #25d366;
+      }
+
+      .capture-mode.disabled {
+        opacity: 0.68;
+      }
+
+      .capture-mode em {
         color: #6b7280;
+        font-size: 10px;
+        font-style: normal;
         font-weight: 600;
       }
 
@@ -389,22 +452,65 @@
             </button>
             <div class="capture-preview" id="capturePreview">
               <h4>Loaded-message review</h4>
-              <div id="captureSummary"></div>
+              <strong id="captureChatName"></strong>
+              <dl class="capture-summary-grid" id="captureSummary">
+                <div>
+                  <dt>Loaded messages</dt>
+                  <dd id="previewLoaded">0</dd>
+                </div>
+                <div>
+                  <dt>Participant labels</dt>
+                  <dd id="previewParticipants">0</dd>
+                </div>
+                <div>
+                  <dt>Media</dt>
+                  <dd id="previewMedia">0</dd>
+                </div>
+                <div>
+                  <dt>Skipped</dt>
+                  <dd id="previewSkipped">0</dd>
+                </div>
+                <div>
+                  <dt>Unreadable</dt>
+                  <dd id="previewUnreadable">0</dd>
+                </div>
+              </dl>
+              <p class="capture-range" id="captureRange"></p>
               <p class="capture-scope">
-                Only messages currently loaded by WhatsApp will be uploaded.
-                Unloaded older messages are excluded.
+                Only the loaded messages counted above will be uploaded.
+                Unloaded older messages are excluded. Nothing is sent until you
+                confirm.
               </p>
-              <div class="capture-modes" aria-label="Capture modes">
-                <div class="capture-mode">
-                  <span>Loaded messages</span><span>Selected</span>
-                </div>
-                <div class="capture-mode">
-                  <span>Capture as I scroll</span><span>Soon</span>
-                </div>
-                <div class="capture-mode">
-                  <span>Load older messages for me</span><span>Soon</span>
-                </div>
-              </div>
+              <fieldset class="capture-modes">
+                <legend>Capture mode</legend>
+                <label class="capture-mode selected">
+                  <input
+                    type="radio"
+                    name="captureMode"
+                    value="loaded"
+                    checked
+                  />
+                  <span>Loaded messages</span><em>Selected</em>
+                </label>
+                <label class="capture-mode disabled">
+                  <input
+                    type="radio"
+                    name="captureMode"
+                    value="scroll"
+                    disabled
+                  />
+                  <span>Capture as I scroll</span><em>Soon · Phase 6</em>
+                </label>
+                <label class="capture-mode disabled">
+                  <input
+                    type="radio"
+                    name="captureMode"
+                    value="automatic"
+                    disabled
+                  />
+                  <span>Load older messages for me</span><em>Soon · Phase 7</em>
+                </label>
+              </fieldset>
               <div class="preview-actions">
                 <button class="btn-primary" id="confirmCapture">
                   Confirm upload

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -22,7 +22,13 @@ const actionStatus = document.getElementById("actionStatus");
 const extensionVersion = document.getElementById("extensionVersion");
 const dashboardLink = document.getElementById("dashboardLink");
 const capturePreview = document.getElementById("capturePreview");
-const captureSummary = document.getElementById("captureSummary");
+const captureChatName = document.getElementById("captureChatName");
+const captureRange = document.getElementById("captureRange");
+const previewLoaded = document.getElementById("previewLoaded");
+const previewParticipants = document.getElementById("previewParticipants");
+const previewMedia = document.getElementById("previewMedia");
+const previewSkipped = document.getElementById("previewSkipped");
+const previewUnreadable = document.getElementById("previewUnreadable");
 const confirmCapture = document.getElementById("confirmCapture");
 const cancelCapture = document.getElementById("cancelCapture");
 
@@ -71,8 +77,62 @@ function openTab(url) {
 }
 
 function clearCapturePreview() {
-  captureSummary.textContent = "";
+  captureChatName.textContent = "";
+  captureRange.textContent = "";
+  for (const field of [
+    previewLoaded,
+    previewParticipants,
+    previewMedia,
+    previewSkipped,
+    previewUnreadable,
+  ]) {
+    field.textContent = "0";
+  }
   capturePreview.classList.remove("show");
+}
+
+function formatPreviewTimestamp(value) {
+  if (!value) return "Not detected";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "Not detected" : date.toLocaleString();
+}
+
+async function renderCapturePreview(operation) {
+  if (!activeWhatsAppTabId) return;
+  const operationId = operation.operationId;
+  capturePreview.classList.add("show");
+  confirmCapture.disabled = true;
+  captureChatName.textContent = "Reading preview…";
+  const response = await sendToWhatsApp(activeWhatsAppTabId, {
+    action: "GET_CAPTURE_PREVIEW",
+    operationId,
+  });
+  if (currentOperation?.operationId !== operationId) return;
+  if (!response.success || !response.data) {
+    confirmCapture.disabled = true;
+    setActionStatus(
+      response.error || "The reviewed preview is no longer available.",
+      "error",
+    );
+    return;
+  }
+  const preview = response.data;
+  if (preview.loadedMessageCount !== operation.extractedCount) {
+    confirmCapture.disabled = true;
+    setActionStatus(
+      "The preview no longer matches the reviewed payload. Recapture before uploading.",
+      "error",
+    );
+    return;
+  }
+  captureChatName.textContent = preview.chatName;
+  previewLoaded.textContent = String(preview.loadedMessageCount);
+  previewParticipants.textContent = String(preview.participantLabelCount);
+  previewMedia.textContent = String(preview.mediaCount);
+  previewSkipped.textContent = String(preview.skippedCount);
+  previewUnreadable.textContent = String(preview.unreadableCount);
+  captureRange.textContent = `Oldest: ${formatPreviewTimestamp(preview.oldestTimestamp)} · Newest: ${formatPreviewTimestamp(preview.newestTimestamp)}`;
+  confirmCapture.disabled = false;
 }
 
 function renderCaptureOperation(operation) {
@@ -87,8 +147,11 @@ function renderCaptureOperation(operation) {
   cancelCapture.disabled = operation.state === "uploading";
 
   if (["ready-for-review", "retry-required"].includes(operation.state)) {
-    captureSummary.textContent = `${count} loaded message${count === 1 ? "" : "s"} from the selected chat.`;
     capturePreview.classList.add("show");
+    void renderCapturePreview(operation).catch((error) => {
+      confirmCapture.disabled = true;
+      setActionStatus(normalizeExtensionError(error), "error");
+    });
   } else {
     clearCapturePreview();
   }
@@ -392,6 +455,33 @@ cancelCapture.addEventListener("click", () => {
       else if (!response.success) setActionStatus(response.error, "error");
     })
     .catch((error) => setActionStatus(normalizeExtensionError(error), "error"));
+});
+
+async function discardUnconfirmedCaptureForModeChange(selectedMode) {
+  if (
+    selectedMode === "loaded" ||
+    !currentOperation ||
+    !activeWhatsAppTabId ||
+    !["ready-for-review", "retry-required"].includes(currentOperation.state)
+  ) {
+    return;
+  }
+  await sendRuntimeMessage({
+    action: "CANCEL_CAPTURE_OPERATION",
+    tabId: activeWhatsAppTabId,
+    operationId: currentOperation.operationId,
+    reason: "Capture mode changed. The unconfirmed buffer was discarded.",
+  });
+  currentOperation = null;
+  clearCapturePreview();
+}
+
+document.querySelectorAll('input[name="captureMode"]').forEach((input) => {
+  input.addEventListener("change", () => {
+    void discardUnconfirmedCaptureForModeChange(input.value).catch((error) =>
+      setActionStatus(normalizeExtensionError(error), "error"),
+    );
+  });
 });
 
 chrome.runtime.onMessage.addListener((message) => {

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -205,6 +205,7 @@ async function handleMessage(
       return await clearPendingUploads();
 
     case "GET_CURRENT_CHAT":
+    case "GET_CAPTURE_PREVIEW":
     case "CHECK_STATUS":
     case "SET_AUTH_TOKEN":
     case "COLLECT_CAPTURE_OPERATION":
@@ -257,6 +258,16 @@ async function loadCaptureOperations(): Promise<void> {
       const operation = {
         ...(value as CaptureOperationSnapshot),
         authGeneration: captureLifecycleEpoch,
+        unreadableCount: Number.isInteger(
+          (value as CaptureOperationSnapshot).unreadableCount,
+        )
+          ? (value as CaptureOperationSnapshot).unreadableCount
+          : 0,
+        participantLabelCount: Number.isInteger(
+          (value as CaptureOperationSnapshot).participantLabelCount,
+        )
+          ? (value as CaptureOperationSnapshot).participantLabelCount
+          : 0,
       };
       const restored = isActiveCaptureState(operation.state)
         ? completeCaptureOperation(
@@ -422,6 +433,8 @@ async function startCaptureOperation(
       collectedCount: summary.extractedCount,
       extractedCount: summary.extractedCount,
       skippedCount: summary.skippedCount,
+      unreadableCount: summary.unreadableCount,
+      participantLabelCount: summary.participantLabelCount,
       mediaCount: summary.mediaCount,
       oldestTimestamp: summary.oldestTimestamp,
       newestTimestamp: summary.newestTimestamp,
@@ -1285,9 +1298,7 @@ async function clearCaptureStateAndAuthentication(
     });
     await previousWrite;
     try {
-      if (
-        committedAuthenticationIntentGeneration > clearAuthenticationIntent
-      ) {
+      if (committedAuthenticationIntentGeneration > clearAuthenticationIntent) {
         return;
       }
       await invalidateLoadedCaptureOperations();

--- a/apps/chrome-extension/src/capture-operation.ts
+++ b/apps/chrome-extension/src/capture-operation.ts
@@ -24,6 +24,8 @@ export interface CaptureOperationSnapshot {
   collectedCount: number;
   extractedCount: number;
   skippedCount: number;
+  unreadableCount: number;
+  participantLabelCount: number;
   mediaCount: number;
   oldestTimestamp?: string;
   newestTimestamp?: string;
@@ -40,6 +42,8 @@ export interface CaptureCollectionSummary {
   renderedCount: number;
   extractedCount: number;
   skippedCount: number;
+  unreadableCount: number;
+  participantLabelCount: number;
   mediaCount: number;
   oldestTimestamp?: string;
   newestTimestamp?: string;
@@ -77,6 +81,8 @@ export function createCaptureOperation(
     collectedCount: 0,
     extractedCount: 0,
     skippedCount: 0,
+    unreadableCount: 0,
+    participantLabelCount: 0,
     mediaCount: 0,
     startedAt: now.toISOString(),
   };

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -145,6 +145,11 @@ export interface GetCurrentChatMessage {
   action: "GET_CURRENT_CHAT";
 }
 
+export interface GetCapturePreviewMessage {
+  action: "GET_CAPTURE_PREVIEW";
+  operationId: string;
+}
+
 export interface CheckStatusMessage {
   action: "CHECK_STATUS";
 }
@@ -275,6 +280,7 @@ export interface RefreshLauncherStateMessage {
 // Union type of all message types
 export type ExtensionMessage =
   | GetCurrentChatMessage
+  | GetCapturePreviewMessage
   | CheckStatusMessage
   | SetAuthTokenMessage
   | SendChatDataMessage

--- a/apps/chrome-extension/src/content.css
+++ b/apps/chrome-extension/src/content.css
@@ -138,6 +138,7 @@
 }
 
 .ws-launcher-panel[hidden],
+.ws-capture-review[hidden],
 .ws-legacy-attention[hidden] {
   display: none !important;
 }
@@ -268,6 +269,134 @@
 .ws-capture-btn:disabled {
   opacity: 0.64;
   cursor: progress;
+}
+
+.ws-capture-modes {
+  display: grid;
+  gap: 6px;
+  margin: 10px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.ws-capture-modes legend {
+  margin-bottom: 5px;
+  color: var(--ws-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ws-capture-mode {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--ws-border);
+  border-radius: 9px;
+  background: var(--ws-surface);
+  font-size: 11px;
+}
+
+.ws-capture-mode-selected {
+  border-color: var(--ws-green);
+  background: var(--ws-surface-muted);
+}
+
+.ws-capture-mode input {
+  margin: 2px 0 0;
+}
+
+.ws-capture-mode span {
+  display: grid;
+  gap: 1px;
+}
+
+.ws-capture-mode small,
+.ws-capture-mode em {
+  color: var(--ws-text-muted);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.ws-capture-mode-disabled {
+  opacity: 0.7;
+}
+
+.ws-capture-review {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid var(--ws-border);
+  border-radius: 10px;
+  background: var(--ws-surface-muted);
+}
+
+.ws-capture-review h3,
+.ws-preview-grid,
+.ws-preview-grid div,
+.ws-preview-range {
+  margin: 0;
+}
+
+.ws-capture-review h3 {
+  font-size: 13px;
+}
+
+.ws-preview-chat-name {
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.ws-preview-grid div {
+  padding: 6px;
+  border-radius: 7px;
+  background: var(--ws-surface);
+}
+
+.ws-preview-grid dt,
+.ws-preview-range {
+  color: var(--ws-text-muted);
+  font-size: 10px;
+}
+
+.ws-preview-grid dd {
+  margin: 2px 0 0;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.ws-preview-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
+}
+
+.ws-preview-actions .ws-capture-btn {
+  margin-top: 0;
+}
+
+.ws-secondary-btn {
+  min-height: 40px;
+  padding: 9px 12px;
+  border: 1px solid var(--ws-border);
+  border-radius: 10px;
+  background: var(--ws-surface);
+  color: var(--ws-text);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
 }
 
 .ws-scope-copy {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -90,6 +90,7 @@ type TimestampMethod = "metadata" | "visible-time" | "fallback";
 interface ExtractionDiagnostics {
   messageContainerCount: number;
   extractedMessageCount: number;
+  unreadableMessageCount: number;
   metadataPathCounts: Record<MetadataPath, number>;
   senderMethodCounts: Record<ExtractedParticipant["extractionMethod"], number>;
   timestampMethodCounts: Record<TimestampMethod, number>;
@@ -108,6 +109,17 @@ interface ExtractedChat {
   payloadVersion: 2;
   participants: ExtractedParticipant[];
   diagnostics: ExtractionDiagnostics;
+}
+
+interface CapturePreviewSummary {
+  chatName: string;
+  loadedMessageCount: number;
+  oldestTimestamp?: string;
+  newestTimestamp?: string;
+  participantLabelCount: number;
+  mediaCount: number;
+  skippedCount: number;
+  unreadableCount: number;
 }
 
 interface ExtractionState {
@@ -285,10 +297,44 @@ async function injectUI(): Promise<void> {
       <div id="ws-progress" class="ws-progress ws-hidden" aria-hidden="true">
         <div class="ws-progress-bar"></div>
       </div>
+      <fieldset class="ws-capture-modes">
+        <legend>Capture mode</legend>
+        <label class="ws-capture-mode ws-capture-mode-selected">
+          <input type="radio" name="ws-capture-mode" value="loaded" checked>
+          <span><strong>Loaded messages</strong><small>Review what WhatsApp has loaded now</small></span>
+          <em>Selected</em>
+        </label>
+        <label class="ws-capture-mode ws-capture-mode-disabled">
+          <input type="radio" name="ws-capture-mode" value="scroll" disabled>
+          <span><strong>Capture as I scroll</strong><small>Guided collection while you scroll</small></span>
+          <em>Soon · Phase 6</em>
+        </label>
+        <label class="ws-capture-mode ws-capture-mode-disabled">
+          <input type="radio" name="ws-capture-mode" value="automatic" disabled>
+          <span><strong>Load older messages for me</strong><small>Automatic older-history loading</small></span>
+          <em>Soon · Phase 7</em>
+        </label>
+      </fieldset>
       <button id="ws-extract-btn" class="ws-capture-btn" type="button" disabled>
         Sign in to capture
       </button>
-      <p class="ws-scope-copy">Older messages that WhatsApp has not loaded are excluded. Nothing is sent before review and confirmation.</p>
+      <section id="ws-capture-review" class="ws-capture-review" aria-labelledby="ws-capture-review-title" hidden>
+        <h3 id="ws-capture-review-title">Review before upload</h3>
+        <strong id="ws-preview-chat-name" class="ws-preview-chat-name"></strong>
+        <dl class="ws-preview-grid">
+          <div><dt>Loaded messages</dt><dd id="ws-preview-loaded">0</dd></div>
+          <div><dt>Participant labels</dt><dd id="ws-preview-participants">0</dd></div>
+          <div><dt>Media</dt><dd id="ws-preview-media">0</dd></div>
+          <div><dt>Skipped</dt><dd id="ws-preview-skipped">0</dd></div>
+          <div><dt>Unreadable</dt><dd id="ws-preview-unreadable">0</dd></div>
+        </dl>
+        <p id="ws-preview-range" class="ws-preview-range"></p>
+        <p class="ws-scope-copy">Only the loaded messages counted above will be uploaded. Older messages WhatsApp has not loaded are excluded. Nothing is sent until you confirm.</p>
+        <div class="ws-preview-actions">
+          <button id="ws-confirm-capture" class="ws-capture-btn" type="button">Confirm upload</button>
+          <button id="ws-cancel-capture" class="ws-secondary-btn" type="button">Cancel</button>
+        </div>
+      </section>
       <div id="ws-legacy-attention" class="ws-legacy-attention" hidden>
         <strong>Legacy local captures need review</strong>
         <span id="ws-legacy-count"></span>
@@ -323,6 +369,21 @@ async function injectUI(): Promise<void> {
   document
     .getElementById("ws-extract-btn")
     ?.addEventListener("click", handleExtractClick);
+  document
+    .getElementById("ws-confirm-capture")
+    ?.addEventListener("click", () => {
+      if (launcherOperation) void reviewPageCapture(launcherOperation, true);
+    });
+  document
+    .getElementById("ws-cancel-capture")
+    ?.addEventListener("click", () => {
+      if (launcherOperation) void reviewPageCapture(launcherOperation, false);
+    });
+  fab
+    .querySelectorAll<HTMLInputElement>('input[name="ws-capture-mode"]')
+    .forEach((input) =>
+      input.addEventListener("change", handleCaptureModeChange),
+    );
   document
     .getElementById("ws-launcher-close")
     ?.addEventListener("click", () => {
@@ -504,6 +565,8 @@ function resetLauncherAccountState(authenticated: boolean): void {
   launcherOperationRenderGeneration += 1;
   launcherOperation = null;
   pageConfirmationOperationId = null;
+  const review = document.getElementById("ws-capture-review");
+  if (review) review.hidden = true;
   updateLegacyQueueState(0);
   updateProgress(0);
   updateStatus(
@@ -630,6 +693,94 @@ function updateProgress(percent: number): void {
 // Extraction Logic
 // =============================================================================
 
+function getCapturePreviewSummary(
+  operationId: string,
+): CapturePreviewSummary | null {
+  const operation = activeCaptureOperation;
+  const payload = operation?.payload;
+  if (!operation || operation.operationId !== operationId || !payload) {
+    return null;
+  }
+  const timestamps = payload.messages
+    .map((message) => message.timestamp)
+    .filter(Boolean)
+    .sort();
+  const unreadableCount = payload.diagnostics.unreadableMessageCount;
+  return {
+    chatName: payload.chatName,
+    loadedMessageCount: payload.messages.length,
+    oldestTimestamp: timestamps[0],
+    newestTimestamp: timestamps[timestamps.length - 1],
+    participantLabelCount: payload.participants.filter(
+      (participant) =>
+        participant.isSelf ||
+        Boolean(
+          participant.rawDisplayName ||
+            participant.rawUsername ||
+            participant.normalizedPhone ||
+            participant.platformUserId,
+        ),
+    ).length,
+    mediaCount: payload.messages.filter((message) => message.isMedia).length,
+    skippedCount: Math.max(
+      0,
+      payload.diagnostics.messageContainerCount -
+        payload.messages.length -
+        unreadableCount,
+    ),
+    unreadableCount,
+  };
+}
+
+function formatPreviewTimestamp(value?: string): string {
+  if (!value) return "Not detected";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "Not detected" : date.toLocaleString();
+}
+
+function renderPageCapturePreview(operation: CaptureOperationSnapshot): void {
+  const review = document.getElementById("ws-capture-review");
+  if (!review) return;
+  if (!["ready-for-review", "retry-required"].includes(operation.state)) {
+    review.hidden = true;
+    return;
+  }
+  const preview = getCapturePreviewSummary(operation.operationId);
+  if (!preview || preview.loadedMessageCount !== operation.extractedCount) {
+    review.hidden = true;
+    updateStatus(
+      "The preview no longer matches the reviewed payload. Recapture before uploading.",
+      "error",
+    );
+    return;
+  }
+  const values: Record<string, string> = {
+    "ws-preview-chat-name": preview.chatName,
+    "ws-preview-loaded": String(preview.loadedMessageCount),
+    "ws-preview-participants": String(preview.participantLabelCount),
+    "ws-preview-media": String(preview.mediaCount),
+    "ws-preview-skipped": String(preview.skippedCount),
+    "ws-preview-unreadable": String(preview.unreadableCount),
+    "ws-preview-range": `Oldest: ${formatPreviewTimestamp(preview.oldestTimestamp)} · Newest: ${formatPreviewTimestamp(preview.newestTimestamp)}`,
+  };
+  for (const [id, value] of Object.entries(values)) {
+    const element = document.getElementById(id);
+    if (element) element.textContent = value;
+  }
+  review.hidden = false;
+}
+
+function handleCaptureModeChange(event: Event): void {
+  const selectedMode = (event.target as HTMLInputElement).value;
+  if (
+    selectedMode !== "loaded" &&
+    launcherOperation &&
+    ["ready-for-review", "retry-required"].includes(launcherOperation.state)
+  ) {
+    void reviewPageCapture(launcherOperation, false);
+  }
+}
+
 async function handleExtractClick(): Promise<void> {
   try {
     const existingResponse = (await chrome.runtime.sendMessage({
@@ -648,7 +799,6 @@ async function handleExtractClick(): Promise<void> {
       if (existingOperation.state === "retry-required") {
         pageConfirmationOperationId = null;
       }
-      await reviewPageCapture(existingOperation);
       return;
     }
     if (
@@ -690,7 +840,6 @@ async function handleExtractClick(): Promise<void> {
       if (response.data.state === "retry-required") {
         pageConfirmationOperationId = null;
       }
-      await reviewPageCapture(response.data);
     }
   } catch (error) {
     updateStatus(normalizeErrorMessage(error), "error");
@@ -699,13 +848,21 @@ async function handleExtractClick(): Promise<void> {
 
 async function reviewPageCapture(
   operation: CaptureOperationSnapshot,
+  confirmed: boolean,
 ): Promise<void> {
   if (operation.authGeneration !== launcherCaptureAuthGeneration) return;
   if (pageConfirmationOperationId === operation.operationId) return;
+  if (confirmed) {
+    const preview = getCapturePreviewSummary(operation.operationId);
+    if (!preview || preview.loadedMessageCount !== operation.extractedCount) {
+      updateStatus(
+        "The preview no longer matches the reviewed payload. Recapture before uploading.",
+        "error",
+      );
+      return;
+    }
+  }
   pageConfirmationOperationId = operation.operationId;
-  const confirmed = window.confirm(
-    `Send ${operation.extractedCount} loaded message${operation.extractedCount === 1 ? "" : "s"} from the selected chat to ConvoLens?\n\nOlder messages that WhatsApp has not loaded are excluded. Capture as I scroll and automatic older-message loading are coming soon.`,
-  );
   const action = confirmed
     ? "CONFIRM_CAPTURE_OPERATION"
     : "CANCEL_CAPTURE_OPERATION";
@@ -716,6 +873,9 @@ async function reviewPageCapture(
       reason: confirmed ? undefined : "Upload cancelled. Nothing was sent.",
     })) as ExtensionResponse<CaptureOperationSnapshot>;
     if (response.success && response.data) {
+      if (response.data.state === "retry-required") {
+        pageConfirmationOperationId = null;
+      }
       if (!renderCaptureOperation(response.data)) {
         pageConfirmationOperationId = null;
       }
@@ -737,6 +897,7 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
   launcherOperationRenderGeneration += 1;
   launcherOperation = operation;
   updateLauncherBadge(operation);
+  renderPageCapturePreview(operation);
   if (activeCaptureOperation?.operationId === operation.operationId) {
     activeCaptureOperation.state = operation.state;
   }
@@ -1022,8 +1183,21 @@ async function collectCaptureOperation(
       extractedCount: payload.messages.length,
       skippedCount: Math.max(
         0,
-        payload.diagnostics.messageContainerCount - payload.messages.length,
+        payload.diagnostics.messageContainerCount -
+          payload.messages.length -
+          payload.diagnostics.unreadableMessageCount,
       ),
+      unreadableCount: payload.diagnostics.unreadableMessageCount,
+      participantLabelCount: payload.participants.filter(
+        (participant) =>
+          participant.isSelf ||
+          Boolean(
+            participant.rawDisplayName ||
+              participant.rawUsername ||
+              participant.normalizedPhone ||
+              participant.platformUserId,
+          ),
+      ).length,
       mediaCount: payload.messages.filter((message) => message.isMedia).length,
       oldestTimestamp: timestamps[0],
       newestTimestamp: timestamps[timestamps.length - 1],
@@ -1148,8 +1322,11 @@ async function extractCurrentChat(
       );
       if (message) {
         messages.push(message);
+      } else {
+        diagnostics.unreadableMessageCount += 1;
       }
     } catch (error) {
+      diagnostics.unreadableMessageCount += 1;
       console.warn("[ConvoLens] Failed to extract message:", error);
     }
 
@@ -1483,6 +1660,7 @@ function createExtractionDiagnostics(
   return {
     messageContainerCount,
     extractedMessageCount: 0,
+    unreadableMessageCount: 0,
     metadataPathCounts: { container: 0, ancestor: 0, descendant: 0, none: 0 },
     senderMethodCounts: {
       metadata: 0,
@@ -1617,6 +1795,19 @@ function handleMessage(
           }),
         );
       return true;
+
+    case "GET_CAPTURE_PREVIEW": {
+      const preview = getCapturePreviewSummary(message.operationId);
+      if (!preview) {
+        sendResponse({
+          success: false,
+          error: "The reviewed preview is no longer available in this tab.",
+        });
+      } else {
+        sendResponse({ success: true, data: preview });
+      }
+      break;
+    }
 
     case "GET_CAPTURE_OPERATION_PAYLOAD":
       if (

--- a/apps/chrome-extension/tests/phase1-capture-safety.test.ts
+++ b/apps/chrome-extension/tests/phase1-capture-safety.test.ts
@@ -15,13 +15,17 @@ const manifest = JSON.parse(read("../manifest.json"));
 
 test("requires loaded-message review and confirmation in both upload surfaces", () => {
   assert.match(popupHtml, /Loaded-message review/);
-  assert.match(popupHtml, /Only messages currently loaded by WhatsApp/);
+  assert.match(
+    popupHtml,
+    /Only the loaded messages counted above will be uploaded/,
+  );
   assert.match(popupHtml, /id="confirmCapture"/);
   assert.match(popupSource, /confirmCapture\.addEventListener\("click"/);
-  assert.match(contentSource, /const confirmed = window\.confirm/);
+  assert.match(contentSource, /id="ws-confirm-capture"/);
+  assert.doesNotMatch(contentSource, /window\.confirm/);
   assert.match(
     contentSource,
-    /Older messages that WhatsApp has not loaded are excluded/,
+    /Older messages(?: that)? WhatsApp has not loaded are excluded/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase3-operation-state.test.ts
+++ b/apps/chrome-extension/tests/phase3-operation-state.test.ts
@@ -128,7 +128,8 @@ test("allows an explicit page click to continue a popup-started review", () => {
     /\["ready-for-review", "retry-required"\]\.includes\(response\.data\.state\)/,
   );
   assert.doesNotMatch(clickHandler, /response\.data\.initiator/);
-  assert.match(clickHandler, /await reviewPageCapture\(response\.data\)/);
+  assert.match(clickHandler, /renderCaptureOperation\(existingOperation\)/);
+  assert.doesNotMatch(clickHandler, /reviewPageCapture\(/);
 });
 
 test("invalidates collection and upload continuations across auth changes", () => {
@@ -203,10 +204,7 @@ test("invalidates retained reviews when authentication writes change owner", () 
     backgroundSource,
     /await replaceAuthenticatedUser\(\s*exchanged\.token/,
   );
-  assert.match(
-    backgroundSource,
-    /replaceAuthenticatedUser\(\s*token,\s*user/,
-  );
+  assert.match(backgroundSource, /replaceAuthenticatedUser\(\s*token,\s*user/);
 });
 
 test("keeps in-flight upload truth across logout and tab closure", () => {

--- a/apps/chrome-extension/tests/phase5-preview.test.ts
+++ b/apps/chrome-extension/tests/phase5-preview.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path: string) =>
+  readFileSync(new URL(path, import.meta.url), "utf8");
+
+const captureSource = read("../src/capture-operation.ts");
+const contentSource = read("../src/content.ts");
+const popupHtml = read("../popup/popup.html");
+const popupSource = read("../popup/popup.js");
+
+test("renders an ephemeral exact-count preview in both capture surfaces", () => {
+  for (const label of [
+    "Loaded messages",
+    "Participant labels",
+    "Media",
+    "Skipped",
+    "Unreadable",
+  ]) {
+    assert.match(popupHtml, new RegExp(label));
+    assert.match(contentSource, new RegExp(label));
+  }
+  assert.match(contentSource, /chatName: payload\.chatName/);
+  assert.match(contentSource, /oldestTimestamp: timestamps\[0\]/);
+  assert.match(
+    contentSource,
+    /newestTimestamp: timestamps\[timestamps\.length - 1\]/,
+  );
+  assert.match(contentSource, /GET_CAPTURE_PREVIEW/);
+  assert.match(popupSource, /action: "GET_CAPTURE_PREVIEW"/);
+  assert.match(
+    popupSource,
+    /preview\.loadedMessageCount !== operation\.extractedCount[\s\S]*confirmCapture\.disabled = true/,
+  );
+  assert.match(
+    contentSource,
+    /preview\.loadedMessageCount !== operation\.extractedCount/,
+  );
+});
+
+test("keeps future capture modes disabled and phase-labelled", () => {
+  for (const surface of [popupHtml, contentSource]) {
+    assert.match(surface, /Capture as I scroll/);
+    assert.match(surface, /Soon · Phase 6/);
+    assert.match(surface, /Load older messages for me/);
+    assert.match(surface, /Soon · Phase 7/);
+    assert.match(surface, /value="scroll"[\s\S]{0,40}disabled/);
+    assert.match(surface, /value="automatic"[\s\S]{0,40}disabled/);
+  }
+  assert.match(popupHtml, /value="loaded"[\s\S]{0,40}checked/);
+  assert.match(contentSource, /value="loaded"[\s\S]{0,40}checked/);
+});
+
+test("uses explicit confirm and cancel without persisting the chat name", () => {
+  assert.match(popupSource, /confirmCapture\.addEventListener\("click"/);
+  assert.match(popupSource, /cancelCapture\.addEventListener\("click"/);
+  assert.match(contentSource, /reviewPageCapture\(launcherOperation, true\)/);
+  assert.match(contentSource, /reviewPageCapture\(launcherOperation, false\)/);
+  assert.doesNotMatch(contentSource, /window\.confirm/);
+  assert.doesNotMatch(captureSource, /chatName/);
+  assert.match(
+    popupSource,
+    /discardUnconfirmedCaptureForModeChange[\s\S]*CANCEL_CAPTURE_OPERATION/,
+  );
+  assert.match(
+    contentSource,
+    /handleCaptureModeChange[\s\S]*reviewPageCapture\(launcherOperation, false\)/,
+  );
+});
+
+test("separates unreadable records from skipped containers", () => {
+  assert.match(contentSource, /unreadableMessageCount \+= 1/);
+  assert.match(
+    contentSource,
+    /messageContainerCount -[\s\S]*messages\.length -[\s\S]*unreadableMessageCount/,
+  );
+  assert.match(captureSource, /unreadableCount: number/);
+  assert.match(captureSource, /participantLabelCount: number/);
+});

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.15");
+  assert.equal(manifest.version, "1.0.16");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE5.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE5.md
@@ -1,0 +1,45 @@
+# ConvoLens extension capture Phase 5 handoff — 2026-07-28
+
+## Outcome
+
+Phase 5 makes the exact loaded-message scope visible before either extension surface can upload it.
+
+- The popup and WhatsApp launcher review show the current chat name, loaded-message count, oldest and newest detected timestamps, participant-label count, media count, skipped count, and unreadable count.
+- The preview is derived from the exact retained in-tab payload and confirmation remains disabled unless its loaded-message count equals the background-owned operation count.
+- The chat name is returned only through an ephemeral content-script preview request. It is not added to the persisted operation snapshot; new raw captures remain memory-only.
+- Unreadable message records are counted separately from rendered containers skipped because of the configured extraction boundary.
+- `Loaded messages` is the selected capture mode. `Capture as I scroll` and `Load older messages for me` remain disabled and are labelled `Soon · Phase 6` and `Soon · Phase 7` respectively.
+- Both surfaces expose explicit confirm and cancel actions. Cancel discards the retained payload and sends nothing.
+- A capture-mode change handler cancels an existing unconfirmed buffer before a different mode can collect, preserving the future mode-switch contract even while those modes remain disabled.
+- The scope and exclusions remain visible through confirmation: only the counted loaded messages upload, older unloaded messages are excluded, and nothing sends until confirmation.
+- Persisted operation snapshots from an earlier extension version receive safe zero defaults for the two new aggregate fields during service-worker restoration.
+- Extension runtime and package metadata are synchronized at `1.0.16`.
+
+## Repository state
+
+- Base: `origin/main` at `1a5b45f33ab03fbcb56c74ff08580a48a6e22faa` (merged PR #152).
+- Branch: `agent/extension-capture-phase5`.
+- Worktree: `C:/tmp/convolens-extension-phase5`.
+- Pull request: pending.
+- The primary checkout and its pre-existing untracked handoff remain untouched.
+
+## Validation
+
+- Chrome extension Node tests: 69 passed, 0 failed, including four focused Phase 5 preview, mode, confirmation/cancellation, privacy, and count-separation tests.
+- Chrome extension TypeScript: passed.
+- Prettier and `git diff --check`: passed.
+- Repository Turbo build: 8 of 8 packages passed.
+- Production extension build and package: passed.
+- Packaged manifest: version `1.0.16`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
+- Packaged ZIP SHA-256: `8A5708E6A4CC2F03A152E8184585971E30D4763FA32B01A669BFF3C23D1AA318`.
+
+## Boundaries still open
+
+- No extension, API, web, database, or Azure deployment is included.
+- No authentic WhatsApp preview, connected-send, popup-close, navigation, persistence, deduplication, restart, isolation, deletion, or console-attribution evidence is claimed.
+- The preview reports evidence present in the retained capture; it does not claim participant enrichment, media download, or older unloaded history.
+- Guided and automatic collection remain unavailable. No durable offline raw-message queue is introduced.
+
+## Continuation
+
+After Phase 5 is reviewed and merged, begin Phase 6 from current `origin/main`: implement user-driven `Capture as I scroll` collection with occurrence-safe overlap alignment, explicit stop/cancel and stop reasons, bounded safety exits, and a 200-message virtualized fixture, while preserving the shared operation owner and memory-only raw-capture boundary.

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE5.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE5.md
@@ -20,7 +20,7 @@ Phase 5 makes the exact loaded-message scope visible before either extension sur
 - Base: `origin/main` at `1a5b45f33ab03fbcb56c74ff08580a48a6e22faa` (merged PR #152).
 - Branch: `agent/extension-capture-phase5`.
 - Worktree: `C:/tmp/convolens-extension-phase5`.
-- Pull request: pending.
+- Pull request: [#153](https://github.com/neuralliquid/convolens/pull/153).
 - The primary checkout and its pre-existing untracked handoff remain untouched.
 
 ## Validation


### PR DESCRIPTION
## Summary

- add an exact loaded-message preview to the popup and in-page launcher
- show chat, timestamp, participant-label, media, skipped, and unreadable evidence before upload
- keep raw preview details ephemeral while persisting only aggregate operation state
- expose explicit confirm/cancel and keep Phase 6/7 modes disabled and phase-labelled
- bump and package the extension as v1.0.16

## Validation

- `pnpm --filter @convolens/chrome-extension test` (69 passed)
- `pnpm --filter @convolens/chrome-extension typecheck`
- `pnpm --filter @convolens/chrome-extension package`
- `pnpm build` (8/8 packages)
- `git diff --check`
- packaged manifest version: `1.0.16`
- ZIP SHA-256: `8A5708E6A4CC2F03A152E8184585971E30D4763FA32B01A669BFF3C23D1AA318`

## Boundaries

- no deployment or authentic WhatsApp acceptance is claimed
- guided and automatic collection remain disabled
- connected-send, persistence, deduplication, restart, isolation, deletion, and console-attribution evidence remain operator-held

## Handoff

- `docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE5.md`
