### PR TITLE
Extension capture Phase 7: bounded automatic loading

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -325,6 +325,37 @@
         font-weight: 600;
       }
 
+      .automatic-options {
+        display: none;
+        gap: 8px;
+        padding: 9px;
+        border: 1px solid #bfdbfe;
+        border-radius: 8px;
+        background: #eff6ff;
+        color: #374151;
+        font-size: 11px;
+        line-height: 1.4;
+      }
+
+      .automatic-options.show {
+        display: grid;
+      }
+
+      .automatic-options select {
+        width: 100%;
+        padding: 7px;
+        border: 1px solid #93c5fd;
+        border-radius: 6px;
+        background: white;
+      }
+
+      .automatic-consent {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 7px;
+        align-items: start;
+      }
+
       .preview-actions {
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -469,28 +500,48 @@
                 <input type="radio" name="captureMode" value="scroll" />
                 <span>Capture as I scroll</span><em>Available</em>
               </label>
-              <label class="capture-mode disabled">
-                <input
-                  type="radio"
-                  name="captureMode"
-                  value="automatic"
-                  disabled
-                />
-                <span>Load older messages for me</span><em>Soon · Phase 7</em>
+              <label class="capture-mode">
+                <input type="radio" name="captureMode" value="automatic" />
+                <span>Load older messages for me</span><em>Available</em>
               </label>
             </fieldset>
+            <div class="automatic-options" id="automaticOptions">
+              <label for="automaticBoundary">Stop boundary</label>
+              <select id="automaticBoundary">
+                <option value="days-7">Messages from the last 7 days</option>
+                <option value="days-30">Messages from the last 30 days</option>
+                <option value="messages-100">100 messages</option>
+                <option value="messages-250">250 messages</option>
+                <option value="messages-500">500 messages (safety cap)</option>
+                <option value="verified-top">
+                  Verified top of conversation
+                </option>
+              </select>
+              <label class="automatic-consent">
+                <input type="checkbox" id="automaticConsent" />
+                <span
+                  >I understand WhatsApp will scroll while collection runs. I
+                  can pause, stop, or cancel at any time.</span
+                >
+              </label>
+            </div>
             <button class="btn-secondary" id="extractBtn">
               Review loaded messages
             </button>
             <div class="capture-preview" id="guidedProgress">
-              <h4>Guided capture is active</h4>
-              <p>Scroll upward in the selected chat, then stop and review.</p>
+              <h4 id="collectionProgressTitle">Guided capture is active</h4>
+              <p id="collectionProgressInstruction">
+                Scroll upward in the selected chat, then stop and review.
+              </p>
               <p>
                 <strong id="guidedCount">0</strong> unique messages · oldest
                 <span id="guidedOldest">Not detected</span>
               </p>
               <p class="capture-warning" id="guidedWarning"></p>
               <div class="preview-actions">
+                <button class="btn-secondary" id="pauseAutomaticCapture" hidden>
+                  Pause
+                </button>
                 <button class="btn-primary" id="stopGuidedCapture">
                   Stop and review
                 </button>

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -255,7 +255,8 @@ function renderCaptureOperation(operation) {
     collectionProgressInstruction.textContent = automatic
       ? "Keep this chat open. ConvoLens is loading older history within the selected boundary."
       : "Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.";
-    pauseAutomaticCapture.hidden = !automatic;
+    pauseAutomaticCapture.hidden =
+      !automatic || !operation.automaticControlsReady;
     pauseAutomaticCapture.textContent =
       operation.state === "paused" ? "Resume" : "Pause";
     guidedCount.textContent = String(count);

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -257,6 +257,7 @@ function renderCaptureOperation(operation) {
       : "Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.";
     pauseAutomaticCapture.hidden =
       !automatic || !operation.automaticControlsReady;
+    stopGuidedCapture.hidden = automatic && !operation.automaticControlsReady;
     pauseAutomaticCapture.textContent =
       operation.state === "paused" ? "Resume" : "Pause";
     guidedCount.textContent = String(count);

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -40,6 +40,16 @@ const guidedOldest = document.getElementById("guidedOldest");
 const guidedWarning = document.getElementById("guidedWarning");
 const stopGuidedCapture = document.getElementById("stopGuidedCapture");
 const cancelGuidedCapture = document.getElementById("cancelGuidedCapture");
+const pauseAutomaticCapture = document.getElementById("pauseAutomaticCapture");
+const automaticOptions = document.getElementById("automaticOptions");
+const automaticBoundary = document.getElementById("automaticBoundary");
+const automaticConsent = document.getElementById("automaticConsent");
+const collectionProgressTitle = document.getElementById(
+  "collectionProgressTitle",
+);
+const collectionProgressInstruction = document.getElementById(
+  "collectionProgressInstruction",
+);
 
 let currentOperation = null;
 let activeWhatsAppTabId = null;
@@ -121,6 +131,35 @@ function guidedStopReasonLabel(reason) {
   }
 }
 
+function automaticStopReasonLabel(reason) {
+  switch (reason) {
+    case "automatic-date-boundary":
+      return "The selected date boundary was reached.";
+    case "automatic-message-limit":
+      return "The selected message limit was reached.";
+    case "automatic-verified-top":
+      return "WhatsApp exposed a verified top-of-history marker.";
+    case "automatic-safety-cap":
+      return "The 500-message automatic safety cap was reached.";
+    case "automatic-no-progress":
+      return "WhatsApp made no further progress; the top was not verified.";
+    case "automatic-dom-failure":
+      return "Collection stopped after repeated WhatsApp DOM failures.";
+    default:
+      return "You stopped automatic collection.";
+  }
+}
+
+function selectedAutomaticBoundary() {
+  const value = automaticBoundary.value;
+  if (value === "days-7") return { kind: "days", days: 7 };
+  if (value === "days-30") return { kind: "days", days: 30 };
+  if (value.startsWith("messages-")) {
+    return { kind: "messages", messageLimit: Number(value.slice(9)) };
+  }
+  return { kind: "verified-top" };
+}
+
 async function renderCapturePreview(operation) {
   if (!activeWhatsAppTabId) return;
   const operationId = operation.operationId;
@@ -157,11 +196,13 @@ async function renderCapturePreview(operation) {
   previewUnreadable.textContent = String(preview.unreadableCount);
   captureRange.textContent = `Oldest: ${formatPreviewTimestamp(preview.oldestTimestamp)} · Newest: ${formatPreviewTimestamp(preview.newestTimestamp)}`;
   previewCountLabel.textContent =
-    operation.mode === "guided" ? "Captured messages" : "Loaded messages";
+    operation.mode === "loaded" ? "Loaded messages" : "Captured messages";
   captureScope.textContent =
     operation.mode === "guided"
       ? `Only the guided messages counted above will be uploaded. ${guidedStopReasonLabel(operation.stopReason)} Nothing is sent until you confirm.`
-      : "Only the loaded messages counted above will be uploaded. Unloaded older messages are excluded. Nothing is sent until you confirm.";
+      : operation.mode === "automatic"
+        ? `Only the automatically collected messages counted above will be uploaded. ${automaticStopReasonLabel(operation.stopReason)} Nothing is sent until you confirm.`
+        : "Only the loaded messages counted above will be uploaded. Unloaded older messages are excluded. Nothing is sent until you confirm.";
   previewWarning.textContent = operation.alignmentWarningCount
     ? `${operation.alignmentWarningCount} ambiguous overlap${operation.alignmentWarningCount === 1 ? " was" : "s were"} retained for review; no candidate occurrence was silently removed.`
     : "";
@@ -172,17 +213,18 @@ async function renderCapturePreview(operation) {
 function renderCaptureOperation(operation) {
   if (!operation) return;
   currentOperation = operation;
-  const modeValue = operation.mode === "guided" ? "scroll" : "loaded";
+  const modeValue = operation.mode === "guided" ? "scroll" : operation.mode;
   document.querySelectorAll('input[name="captureMode"]').forEach((input) => {
     input.checked = input.value === modeValue;
     input.closest(".capture-mode")?.classList.toggle("selected", input.checked);
     const status = input.closest(".capture-mode")?.querySelector("em");
-    if (status && input.value !== "automatic") {
+    if (status) {
       status.textContent = input.checked ? "Selected" : "Available";
     }
   });
+  automaticOptions.classList.toggle("show", modeValue === "automatic");
   const count = operation.extractedCount || 0;
-  const busy = ["inspecting", "collecting", "uploading"].includes(
+  const busy = ["inspecting", "collecting", "paused", "uploading"].includes(
     operation.state,
   );
   extractBtn.disabled = busy;
@@ -193,12 +235,29 @@ function renderCaptureOperation(operation) {
       ? operation.state === "collecting"
         ? `Guided: ${count} captured`
         : "Start guided capture"
-      : "Review loaded messages";
+      : operation.mode === "automatic"
+        ? ["collecting", "paused"].includes(operation.state)
+          ? `Automatic: ${count} captured`
+          : "Load older messages"
+        : "Review loaded messages";
 
-  const guidedActive =
-    operation.mode === "guided" && operation.state === "collecting";
-  guidedProgress.classList.toggle("show", guidedActive);
-  if (guidedActive) {
+  const collectionActive =
+    ["guided", "automatic"].includes(operation.mode) &&
+    ["collecting", "paused"].includes(operation.state);
+  guidedProgress.classList.toggle("show", collectionActive);
+  if (collectionActive) {
+    const automatic = operation.mode === "automatic";
+    collectionProgressTitle.textContent = automatic
+      ? operation.state === "paused"
+        ? "Automatic capture is paused"
+        : "Automatic capture is active"
+      : "Guided capture is active";
+    collectionProgressInstruction.textContent = automatic
+      ? "Keep this chat open. ConvoLens is loading older history within the selected boundary."
+      : "Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.";
+    pauseAutomaticCapture.hidden = !automatic;
+    pauseAutomaticCapture.textContent =
+      operation.state === "paused" ? "Resume" : "Pause";
     guidedCount.textContent = String(count);
     guidedOldest.textContent = formatPreviewTimestamp(
       operation.oldestTimestamp,
@@ -227,13 +286,21 @@ function renderCaptureOperation(operation) {
       setActionStatus(
         operation.mode === "guided"
           ? `Guided capture active: ${count} unique message${count === 1 ? "" : "s"}.`
-          : "Reading loaded messages…",
+          : operation.mode === "automatic"
+            ? `Automatic capture active: ${count} unique message${count === 1 ? "" : "s"}.`
+            : "Reading loaded messages…",
+        "info",
+      );
+      break;
+    case "paused":
+      setActionStatus(
+        `Automatic capture paused at ${count} unique message${count === 1 ? "" : "s"}.`,
         "info",
       );
       break;
     case "ready-for-review":
       setActionStatus(
-        "Review the loaded-message scope, then confirm or cancel.",
+        `Review the ${operation.mode === "loaded" ? "loaded-message" : "collected-message"} scope, then confirm or cancel.`,
         "info",
       );
       break;
@@ -436,9 +503,25 @@ extractBtn.addEventListener("click", async () => {
   const selectedMode = document.querySelector(
     'input[name="captureMode"]:checked',
   )?.value;
-  const mode = selectedMode === "scroll" ? "guided" : "loaded";
+  const mode =
+    selectedMode === "scroll"
+      ? "guided"
+      : selectedMode === "automatic"
+        ? "automatic"
+        : "loaded";
+  if (mode === "automatic" && !automaticConsent.checked) {
+    setActionStatus(
+      "Confirm that WhatsApp may scroll this chat before starting automatic capture.",
+      "error",
+    );
+    return;
+  }
   const defaultLabel =
-    mode === "guided" ? "Start guided capture" : "Review loaded messages";
+    mode === "guided"
+      ? "Start guided capture"
+      : mode === "automatic"
+        ? "Load older messages"
+        : "Review loaded messages";
   setActionStatus("");
 
   try {
@@ -458,6 +541,9 @@ extractBtn.addEventListener("click", async () => {
       tabId: tab.id,
       initiator: "popup",
       mode,
+      ...(mode === "automatic"
+        ? { automaticBoundary: selectedAutomaticBoundary() }
+        : {}),
     });
 
     if (response.success && response.data) {
@@ -477,7 +563,7 @@ extractBtn.addEventListener("click", async () => {
     }, 1500);
     extractBtn.disabled = Boolean(
       currentOperation &&
-        ["inspecting", "collecting", "uploading"].includes(
+        ["inspecting", "collecting", "paused", "uploading"].includes(
           currentOperation.state,
         ),
     );
@@ -489,11 +575,16 @@ stopGuidedCapture.addEventListener("click", async () => {
   stopGuidedCapture.disabled = true;
   cancelGuidedCapture.disabled = true;
   try {
+    const automatic = currentOperation.mode === "automatic";
     const response = await sendRuntimeMessage({
-      action: "STOP_GUIDED_CAPTURE_OPERATION",
+      action: automatic
+        ? "CONTROL_AUTOMATIC_CAPTURE_OPERATION"
+        : "STOP_GUIDED_CAPTURE_OPERATION",
       tabId: activeWhatsAppTabId,
       operationId: currentOperation.operationId,
-      stopReason: "guided-user-stopped",
+      ...(automatic
+        ? { command: "stop", stopReason: "automatic-user-stopped" }
+        : { stopReason: "guided-user-stopped" }),
     });
     if (response.success && response.data)
       renderCaptureOperation(response.data);
@@ -507,6 +598,30 @@ stopGuidedCapture.addEventListener("click", async () => {
   } finally {
     stopGuidedCapture.disabled = false;
     cancelGuidedCapture.disabled = false;
+  }
+});
+
+pauseAutomaticCapture.addEventListener("click", async () => {
+  if (!currentOperation || !activeWhatsAppTabId) return;
+  pauseAutomaticCapture.disabled = true;
+  try {
+    const response = await sendRuntimeMessage({
+      action: "CONTROL_AUTOMATIC_CAPTURE_OPERATION",
+      tabId: activeWhatsAppTabId,
+      operationId: currentOperation.operationId,
+      command: currentOperation.state === "paused" ? "resume" : "pause",
+    });
+    if (response.success && response.data)
+      renderCaptureOperation(response.data);
+    else
+      setActionStatus(
+        response.error || "Automatic capture could not be updated.",
+        "error",
+      );
+  } catch (error) {
+    setActionStatus(normalizeExtensionError(error), "error");
+  } finally {
+    pauseAutomaticCapture.disabled = false;
   }
 });
 
@@ -582,7 +697,12 @@ cancelCapture.addEventListener("click", () => {
 });
 
 async function discardUnconfirmedCaptureForModeChange(selectedMode) {
-  const selectedOperationMode = selectedMode === "scroll" ? "guided" : "loaded";
+  const selectedOperationMode =
+    selectedMode === "scroll"
+      ? "guided"
+      : selectedMode === "automatic"
+        ? "automatic"
+        : "loaded";
   if (
     !currentOperation ||
     !activeWhatsAppTabId ||
@@ -590,6 +710,7 @@ async function discardUnconfirmedCaptureForModeChange(selectedMode) {
     ![
       "inspecting",
       "collecting",
+      "paused",
       "ready-for-review",
       "retry-required",
     ].includes(currentOperation.state)
@@ -616,14 +737,17 @@ function applyPopupCaptureMode(selectedMode) {
       const label = modeInput.closest(".capture-mode");
       label?.classList.toggle("selected", selected);
       const status = label?.querySelector("em");
-      if (status && modeInput.value !== "automatic") {
+      if (status) {
         status.textContent = selected ? "Selected" : "Available";
       }
     });
+  automaticOptions.classList.toggle("show", selectedMode === "automatic");
   extractBtn.textContent =
     selectedMode === "scroll"
       ? "Start guided capture"
-      : "Review loaded messages";
+      : selectedMode === "automatic"
+        ? "Load older messages"
+        : "Review loaded messages";
 }
 
 document.querySelectorAll('input[name="captureMode"]').forEach((input) => {

--- a/apps/chrome-extension/src/automatic-capture.ts
+++ b/apps/chrome-extension/src/automatic-capture.ts
@@ -61,7 +61,17 @@ export function automaticDateBoundaryStartIndex(
       lastExcludedIndex = index;
     }
   }
-  return lastExcludedIndex < 0 ? null : lastExcludedIndex + 1;
+  if (lastExcludedIndex < 0) return null;
+  for (
+    let index = lastExcludedIndex + 1;
+    index < trustedTimestamps.length;
+    index += 1
+  ) {
+    const timestamp = trustedTimestamps[index];
+    const parsed = timestamp ? Date.parse(timestamp) : Number.NaN;
+    if (Number.isFinite(parsed) && parsed > cutoff) return index;
+  }
+  return trustedTimestamps.length;
 }
 
 export function automaticBoundaryStopReason(options: {

--- a/apps/chrome-extension/src/automatic-capture.ts
+++ b/apps/chrome-extension/src/automatic-capture.ts
@@ -35,6 +35,23 @@ export function automaticDateCutoff(
   return startedAt.getTime() - boundary.days * 24 * 60 * 60 * 1_000;
 }
 
+export function automaticDateBoundaryStartIndex(
+  trustedTimestamps: Array<string | undefined>,
+  boundary: AutomaticCaptureBoundary,
+  startedAt: Date,
+): number | null {
+  const cutoff = automaticDateCutoff(boundary, startedAt);
+  if (cutoff === null) return null;
+  let lastExcludedIndex = -1;
+  for (const [index, timestamp] of trustedTimestamps.entries()) {
+    const parsed = timestamp ? Date.parse(timestamp) : Number.NaN;
+    if (Number.isFinite(parsed) && parsed <= cutoff) {
+      lastExcludedIndex = index;
+    }
+  }
+  return lastExcludedIndex < 0 ? null : lastExcludedIndex + 1;
+}
+
 export function automaticBoundaryStopReason(options: {
   boundary: AutomaticCaptureBoundary;
   extractedCount: number;
@@ -42,14 +59,13 @@ export function automaticBoundaryStopReason(options: {
   verifiedTop: boolean;
   startedAt: Date;
 }): CaptureStopReason | null {
-  if (options.extractedCount >= AUTOMATIC_CAPTURE_SAFETY_CAP) {
-    return "automatic-safety-cap";
-  }
   if (
     options.boundary.kind === "messages" &&
     options.extractedCount >= options.boundary.messageLimit
   ) {
-    return "automatic-message-limit";
+    return options.boundary.messageLimit >= AUTOMATIC_CAPTURE_SAFETY_CAP
+      ? "automatic-safety-cap"
+      : "automatic-message-limit";
   }
   if (options.boundary.kind === "days") {
     const oldest = options.oldestTrustedTimestamp
@@ -59,6 +75,9 @@ export function automaticBoundaryStopReason(options: {
     if (cutoff !== null && Number.isFinite(oldest) && oldest <= cutoff) {
       return "automatic-date-boundary";
     }
+  }
+  if (options.extractedCount >= AUTOMATIC_CAPTURE_SAFETY_CAP) {
+    return "automatic-safety-cap";
   }
   if (options.verifiedTop) {
     return "automatic-verified-top";

--- a/apps/chrome-extension/src/automatic-capture.ts
+++ b/apps/chrome-extension/src/automatic-capture.ts
@@ -1,0 +1,67 @@
+import type {
+  AutomaticCaptureBoundary,
+  CaptureStopReason,
+} from "./capture-operation";
+
+export const AUTOMATIC_CAPTURE_SAFETY_CAP = 500;
+export const AUTOMATIC_NO_PROGRESS_LIMIT = 3;
+
+export function normalizeAutomaticBoundary(
+  value: AutomaticCaptureBoundary | undefined,
+): AutomaticCaptureBoundary {
+  if (value?.kind === "days" && (value.days === 7 || value.days === 30)) {
+    return value;
+  }
+  if (value?.kind === "messages") {
+    return {
+      kind: "messages",
+      messageLimit: Math.max(
+        1,
+        Math.min(
+          AUTOMATIC_CAPTURE_SAFETY_CAP,
+          Math.floor(value.messageLimit || AUTOMATIC_CAPTURE_SAFETY_CAP),
+        ),
+      ),
+    };
+  }
+  return { kind: "verified-top" };
+}
+
+export function automaticDateCutoff(
+  boundary: AutomaticCaptureBoundary,
+  startedAt: Date,
+): number | null {
+  if (boundary.kind !== "days") return null;
+  return startedAt.getTime() - boundary.days * 24 * 60 * 60 * 1_000;
+}
+
+export function automaticBoundaryStopReason(options: {
+  boundary: AutomaticCaptureBoundary;
+  extractedCount: number;
+  oldestTrustedTimestamp?: string;
+  verifiedTop: boolean;
+  startedAt: Date;
+}): CaptureStopReason | null {
+  if (options.extractedCount >= AUTOMATIC_CAPTURE_SAFETY_CAP) {
+    return "automatic-safety-cap";
+  }
+  if (
+    options.boundary.kind === "messages" &&
+    options.extractedCount >= options.boundary.messageLimit
+  ) {
+    return "automatic-message-limit";
+  }
+  if (options.boundary.kind === "days") {
+    const oldest = options.oldestTrustedTimestamp
+      ? Date.parse(options.oldestTrustedTimestamp)
+      : Number.NaN;
+    const cutoff = automaticDateCutoff(options.boundary, options.startedAt);
+    if (cutoff !== null && Number.isFinite(oldest) && oldest <= cutoff) {
+      return "automatic-date-boundary";
+    }
+  }
+  if (options.verifiedTop) {
+    return "automatic-verified-top";
+  }
+  return null;
+}

--- a/apps/chrome-extension/src/automatic-capture.ts
+++ b/apps/chrome-extension/src/automatic-capture.ts
@@ -32,7 +32,19 @@ export function automaticDateCutoff(
   startedAt: Date,
 ): number | null {
   if (boundary.kind !== "days") return null;
-  return startedAt.getTime() - boundary.days * 24 * 60 * 60 * 1_000;
+  // Trusted WhatsApp timestamps encode the displayed, timezone-less calendar
+  // fields with Date.UTC. Put the capture start in that same wall-clock
+  // representation before comparing it with those timestamps.
+  const wallClockStartedAt = Date.UTC(
+    startedAt.getFullYear(),
+    startedAt.getMonth(),
+    startedAt.getDate(),
+    startedAt.getHours(),
+    startedAt.getMinutes(),
+    startedAt.getSeconds(),
+    startedAt.getMilliseconds(),
+  );
+  return wallClockStartedAt - boundary.days * 24 * 60 * 60 * 1_000;
 }
 
 export function automaticDateBoundaryStartIndex(

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -26,6 +26,7 @@ import {
   type ConfirmCaptureOperationMessage,
   type CancelCaptureOperationMessage,
   type StopGuidedCaptureOperationMessage,
+  type ControlAutomaticCaptureOperationMessage,
 } from "./config";
 import {
   completeCaptureOperation,
@@ -37,6 +38,7 @@ import {
   type CaptureOperationState,
   type CaptureStopReason,
 } from "./capture-operation";
+import { normalizeAutomaticBoundary } from "./automatic-capture";
 
 // =============================================================================
 // Types
@@ -70,6 +72,10 @@ const guidedStopPromises = new Map<
   string,
   Promise<ExtensionResponse<CaptureOperationSnapshot>>
 >();
+const automaticControlPromises = new Map<
+  string,
+  Promise<ExtensionResponse<CaptureOperationSnapshot>>
+>();
 let captureOperationsLoadPromise: Promise<void> | null = null;
 let captureLifecycleEpoch = 0;
 let captureAuthTransitionCount = 0;
@@ -82,9 +88,13 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   const operation = captureOperations.get(tabId);
   if (
     operation &&
-    ["inspecting", "collecting", "ready-for-review", "retry-required"].includes(
-      operation.state,
-    )
+    [
+      "inspecting",
+      "collecting",
+      "paused",
+      "ready-for-review",
+      "retry-required",
+    ].includes(operation.state)
   ) {
     void finishCaptureOperation(
       operation,
@@ -169,6 +179,9 @@ async function handleMessage(
     case "UPDATE_GUIDED_CAPTURE_OPERATION":
       return await updateGuidedCaptureOperation(message, _sender);
 
+    case "UPDATE_AUTOMATIC_CAPTURE_OPERATION":
+      return await updateAutomaticCaptureOperation(message, _sender);
+
     case "STOP_GUIDED_CAPTURE_OPERATION": {
       const inFlight = guidedStopPromises.get(message.operationId);
       if (inFlight) return await inFlight;
@@ -177,6 +190,21 @@ async function handleMessage(
       });
       guidedStopPromises.set(message.operationId, stop);
       return await stop;
+    }
+
+    case "CONTROL_AUTOMATIC_CAPTURE_OPERATION": {
+      const previous = automaticControlPromises.get(message.operationId);
+      const control = (
+        previous ? previous.catch(() => undefined) : Promise.resolve(undefined)
+      ).then(() => controlAutomaticCaptureOperation(message, _sender));
+      automaticControlPromises.set(message.operationId, control);
+      try {
+        return await control;
+      } finally {
+        if (automaticControlPromises.get(message.operationId) === control) {
+          automaticControlPromises.delete(message.operationId);
+        }
+      }
     }
 
     case "SEND_CHAT_DATA": {
@@ -230,6 +258,9 @@ async function handleMessage(
     case "COLLECT_CAPTURE_OPERATION":
     case "FINALIZE_GUIDED_CAPTURE_OPERATION":
     case "ACTIVATE_GUIDED_CAPTURE_OPERATION":
+    case "ACTIVATE_AUTOMATIC_CAPTURE_OPERATION":
+    case "SET_AUTOMATIC_CAPTURE_PAUSED":
+    case "FINALIZE_AUTOMATIC_CAPTURE_OPERATION":
     case "GET_CAPTURE_OPERATION_PAYLOAD":
     case "VALIDATE_CAPTURE_OPERATION_CONTEXT":
     case "DISCARD_CAPTURE_OPERATION":
@@ -279,10 +310,17 @@ async function loadCaptureOperations(): Promise<void> {
       const operation: CaptureOperationSnapshot = {
         ...(value as CaptureOperationSnapshot),
         authGeneration: captureLifecycleEpoch,
-        mode:
-          (value as CaptureOperationSnapshot).mode === "guided"
-            ? "guided"
-            : "loaded",
+        mode: ["guided", "automatic"].includes(
+          (value as CaptureOperationSnapshot).mode,
+        )
+          ? (value as CaptureOperationSnapshot).mode
+          : "loaded",
+        automaticBoundary:
+          (value as CaptureOperationSnapshot).mode === "automatic"
+            ? normalizeAutomaticBoundary(
+                (value as CaptureOperationSnapshot).automaticBoundary,
+              )
+            : undefined,
         unreadableCount: Number.isInteger(
           (value as CaptureOperationSnapshot).unreadableCount,
         )
@@ -407,13 +445,23 @@ async function startCaptureOperation(
     return { success: true, data: existing };
   }
 
-  let operation = createCaptureOperation(
-    tabId,
-    message.initiator,
-    new Date(),
-    operationEpoch,
-    message.mode === "guided" ? "guided" : "loaded",
-  );
+  const selectedMode = ["guided", "automatic"].includes(message.mode ?? "")
+    ? (message.mode as "guided" | "automatic")
+    : "loaded";
+  const automaticBoundary =
+    selectedMode === "automatic"
+      ? normalizeAutomaticBoundary(message.automaticBoundary)
+      : undefined;
+  let operation: CaptureOperationSnapshot = {
+    ...createCaptureOperation(
+      tabId,
+      message.initiator,
+      new Date(),
+      operationEpoch,
+      selectedMode,
+    ),
+    automaticBoundary,
+  };
   captureOperationEpochs.set(operation.operationId, operationEpoch);
   captureOperationOwnerIds.set(operation.operationId, authenticatedOwnerId);
   await publishCaptureOperation(operation);
@@ -459,7 +507,7 @@ async function startCaptureOperation(
     const summary = response.data.summary;
     operation = {
       ...operation,
-      state: operation.mode === "guided" ? "collecting" : "ready-for-review",
+      state: operation.mode === "loaded" ? "ready-for-review" : "collecting",
       chatKey: summary.chatKey,
       renderedCount: summary.renderedCount,
       collectedCount: summary.extractedCount,
@@ -470,12 +518,13 @@ async function startCaptureOperation(
       alignmentWarningCount: summary.alignmentWarningCount,
       mediaCount: summary.mediaCount,
       oldestTimestamp: summary.oldestTimestamp,
+      oldestTrustedTimestamp: summary.oldestTrustedTimestamp,
       newestTimestamp: summary.newestTimestamp,
       stopReason: operation.mode === "loaded" ? "loaded-window" : undefined,
       reason: undefined,
     };
     await publishCaptureOperation(operation);
-    if (operation.mode === "guided") {
+    if (operation.mode !== "loaded") {
       const currentBeforeActivation = captureOperations.get(tabId);
       if (!isCurrentCaptureOperation(operation, operationEpoch, "collecting")) {
         if (currentBeforeActivation?.operationId === operation.operationId) {
@@ -483,12 +532,18 @@ async function startCaptureOperation(
         }
         return await abandonCaptureOperation(
           operation,
-          "The capture was replaced before guided observation could start.",
+          "The capture was replaced before collection could start.",
         );
       }
       const activation = (await chrome.tabs.sendMessage(tabId, {
-        action: "ACTIVATE_GUIDED_CAPTURE_OPERATION",
+        action:
+          operation.mode === "automatic"
+            ? "ACTIVATE_AUTOMATIC_CAPTURE_OPERATION"
+            : "ACTIVATE_GUIDED_CAPTURE_OPERATION",
         operationId: operation.operationId,
+        ...(operation.mode === "automatic"
+          ? { boundary: operation.automaticBoundary }
+          : {}),
       })) as ExtensionResponse;
       if (!activation.success) {
         const currentAfterActivation = captureOperations.get(tabId);
@@ -501,7 +556,7 @@ async function startCaptureOperation(
         return await finishCaptureOperation(
           operation,
           "cancelled",
-          activation.error || "Guided capture could not observe this chat.",
+          activation.error || "Collection could not observe this chat.",
         );
       }
     }
@@ -576,6 +631,65 @@ async function updateGuidedCaptureOperation(
     alignmentWarningCount: message.summary.alignmentWarningCount,
     mediaCount: message.summary.mediaCount,
     oldestTimestamp: message.summary.oldestTimestamp,
+    oldestTrustedTimestamp: message.summary.oldestTrustedTimestamp,
+    newestTimestamp: message.summary.newestTimestamp,
+  };
+  await publishCaptureOperation(updated);
+  return { success: true, data: updated };
+}
+
+async function updateAutomaticCaptureOperation(
+  message: Extract<
+    ExtensionMessage,
+    { action: "UPDATE_AUTOMATIC_CAPTURE_OPERATION" }
+  >,
+  sender: chrome.runtime.MessageSender,
+): Promise<ExtensionResponse<CaptureOperationSnapshot>> {
+  const tabId = resolveCaptureTabId(undefined, sender);
+  if (tabId === null) {
+    return {
+      success: false,
+      error: "Automatic progress must come from its WhatsApp tab.",
+    };
+  }
+  await loadCaptureOperations();
+  const operation = captureOperations.get(tabId);
+  const operationEpoch = operation
+    ? captureOperationEpochs.get(operation.operationId)
+    : undefined;
+  if (
+    !operation ||
+    operation.operationId !== message.operationId ||
+    operation.mode !== "automatic" ||
+    !["collecting", "paused"].includes(operation.state) ||
+    operationEpoch === undefined ||
+    !isCurrentCaptureOperation(operation, operationEpoch)
+  ) {
+    return {
+      success: false,
+      error: "This automatic capture is no longer active.",
+    };
+  }
+  if (operation.chatKey && operation.chatKey !== message.summary.chatKey) {
+    return await finishCaptureOperation(
+      operation,
+      "cancelled",
+      "The selected chat changed. Nothing was sent.",
+    );
+  }
+  const updated: CaptureOperationSnapshot = {
+    ...operation,
+    chatKey: message.summary.chatKey,
+    renderedCount: message.summary.renderedCount,
+    collectedCount: message.summary.extractedCount,
+    extractedCount: message.summary.extractedCount,
+    skippedCount: message.summary.skippedCount,
+    unreadableCount: message.summary.unreadableCount,
+    participantLabelCount: message.summary.participantLabelCount,
+    alignmentWarningCount: message.summary.alignmentWarningCount,
+    mediaCount: message.summary.mediaCount,
+    oldestTimestamp: message.summary.oldestTimestamp,
+    oldestTrustedTimestamp: message.summary.oldestTrustedTimestamp,
     newestTimestamp: message.summary.newestTimestamp,
   };
   await publishCaptureOperation(updated);
@@ -643,11 +757,123 @@ async function stopGuidedCaptureOperation(
     alignmentWarningCount: summary.alignmentWarningCount,
     mediaCount: summary.mediaCount,
     oldestTimestamp: summary.oldestTimestamp,
+    oldestTrustedTimestamp: summary.oldestTrustedTimestamp,
     newestTimestamp: summary.newestTimestamp,
     stopReason:
       message.stopReason && allowedReasons.has(message.stopReason)
         ? message.stopReason
         : "guided-user-stopped",
+    reason: undefined,
+  };
+  await publishCaptureOperation(ready);
+  return { success: true, data: ready };
+}
+
+async function controlAutomaticCaptureOperation(
+  message: ControlAutomaticCaptureOperationMessage,
+  sender: chrome.runtime.MessageSender,
+): Promise<ExtensionResponse<CaptureOperationSnapshot>> {
+  const tabId = resolveCaptureTabId(message.tabId, sender);
+  if (tabId === null) {
+    return {
+      success: false,
+      error: "The WhatsApp tab is no longer available.",
+    };
+  }
+  await loadCaptureOperations();
+  const operation = captureOperations.get(tabId);
+  if (!operation || operation.operationId !== message.operationId) {
+    return {
+      success: false,
+      error: "This automatic capture operation is no longer current.",
+    };
+  }
+  if (operation.mode !== "automatic") {
+    return { success: true, data: operation };
+  }
+  if (message.command === "pause" || message.command === "resume") {
+    const expectedState = message.command === "pause" ? "collecting" : "paused";
+    if (operation.state !== expectedState) {
+      return { success: true, data: operation };
+    }
+    const paused = message.command === "pause";
+    const response = (await chrome.tabs.sendMessage(tabId, {
+      action: "SET_AUTOMATIC_CAPTURE_PAUSED",
+      operationId: operation.operationId,
+      paused,
+    })) as ExtensionResponse;
+    if (!response.success) {
+      const current = captureOperations.get(tabId);
+      if (current?.operationId !== operation.operationId) {
+        return { success: true, data: current ?? operation };
+      }
+      return { success: false, error: response.error };
+    }
+    const current = captureOperations.get(tabId);
+    if (
+      current?.operationId !== operation.operationId ||
+      current.state !== expectedState
+    ) {
+      return { success: true, data: current ?? operation };
+    }
+    const updated: CaptureOperationSnapshot = {
+      ...current,
+      state: paused ? "paused" : "collecting",
+    };
+    await publishCaptureOperation(updated);
+    return { success: true, data: updated };
+  }
+  if (!["collecting", "paused"].includes(operation.state)) {
+    return { success: true, data: operation };
+  }
+  const response = (await chrome.tabs.sendMessage(tabId, {
+    action: "FINALIZE_AUTOMATIC_CAPTURE_OPERATION",
+    operationId: operation.operationId,
+  })) as ExtensionResponse<{ summary: CaptureCollectionSummary }>;
+  if (!response.success || !response.data?.summary) {
+    return await finishCaptureOperation(
+      operation,
+      "cancelled",
+      response.success
+        ? "The automatic capture buffer is no longer available."
+        : response.error,
+    );
+  }
+  const current = captureOperations.get(tabId);
+  if (
+    current?.operationId !== operation.operationId ||
+    !["collecting", "paused"].includes(current.state)
+  ) {
+    return { success: true, data: current ?? operation };
+  }
+  const allowedReasons = new Set<CaptureStopReason>([
+    "automatic-user-stopped",
+    "automatic-date-boundary",
+    "automatic-message-limit",
+    "automatic-verified-top",
+    "automatic-safety-cap",
+    "automatic-no-progress",
+    "automatic-dom-failure",
+  ]);
+  const summary = response.data.summary;
+  const ready: CaptureOperationSnapshot = {
+    ...current,
+    state: "ready-for-review",
+    renderedCount: summary.renderedCount,
+    collectedCount: summary.extractedCount,
+    extractedCount: summary.extractedCount,
+    skippedCount: summary.skippedCount,
+    unreadableCount: summary.unreadableCount,
+    participantLabelCount: summary.participantLabelCount,
+    alignmentWarningCount: summary.alignmentWarningCount,
+    mediaCount: summary.mediaCount,
+    oldestTimestamp: summary.oldestTimestamp,
+    oldestTrustedTimestamp: summary.oldestTrustedTimestamp,
+    newestTimestamp: summary.newestTimestamp,
+    stopReason:
+      message.stopReason && allowedReasons.has(message.stopReason)
+        ? message.stopReason
+        : "automatic-user-stopped",
     reason: undefined,
   };
   await publishCaptureOperation(ready);

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -559,6 +559,18 @@ async function startCaptureOperation(
           activation.error || "Collection could not observe this chat.",
         );
       }
+      const activatedOperation = captureOperations.get(tabId);
+      if (
+        activatedOperation?.operationId !== operation.operationId ||
+        activatedOperation.state !== "collecting"
+      ) {
+        return { success: true, data: activatedOperation ?? operation };
+      }
+      operation = activatedOperation;
+      if (operation.mode === "automatic") {
+        operation = { ...operation, automaticControlsReady: true };
+        await publishCaptureOperation(operation);
+      }
     }
     return { success: true, data: operation };
   } catch (error) {
@@ -792,6 +804,9 @@ async function controlAutomaticCaptureOperation(
     return { success: true, data: operation };
   }
   if (message.command === "pause" || message.command === "resume") {
+    if (!operation.automaticControlsReady) {
+      return { success: true, data: operation };
+    }
     const expectedState = message.command === "pause" ? "collecting" : "paused";
     if (operation.state !== expectedState) {
       return { success: true, data: operation };

--- a/apps/chrome-extension/src/capture-operation.ts
+++ b/apps/chrome-extension/src/capture-operation.ts
@@ -2,6 +2,7 @@ export type CaptureOperationState =
   | "idle"
   | "inspecting"
   | "collecting"
+  | "paused"
   | "ready-for-review"
   | "uploading"
   | "received"
@@ -11,13 +12,24 @@ export type CaptureOperationState =
   | "cancelled";
 
 export type CaptureOperationInitiator = "popup" | "page";
-export type CaptureOperationMode = "loaded" | "guided";
+export type CaptureOperationMode = "loaded" | "guided" | "automatic";
+export type AutomaticCaptureBoundary =
+  | { kind: "days"; days: 7 | 30 }
+  | { kind: "messages"; messageLimit: number }
+  | { kind: "verified-top" };
 export type CaptureStopReason =
   | "loaded-window"
   | "guided-user-stopped"
   | "guided-safety-limit"
   | "guided-timeout"
-  | "guided-dom-failure";
+  | "guided-dom-failure"
+  | "automatic-user-stopped"
+  | "automatic-date-boundary"
+  | "automatic-message-limit"
+  | "automatic-verified-top"
+  | "automatic-safety-cap"
+  | "automatic-no-progress"
+  | "automatic-dom-failure";
 
 export interface CaptureOperationSnapshot {
   operationId: string;
@@ -25,6 +37,7 @@ export interface CaptureOperationSnapshot {
   tabId: number;
   initiator: CaptureOperationInitiator;
   mode: CaptureOperationMode;
+  automaticBoundary?: AutomaticCaptureBoundary;
   state: CaptureOperationState;
   chatKey?: string;
   renderedCount: number;
@@ -36,6 +49,7 @@ export interface CaptureOperationSnapshot {
   alignmentWarningCount: number;
   mediaCount: number;
   oldestTimestamp?: string;
+  oldestTrustedTimestamp?: string;
   newestTimestamp?: string;
   stopReason?: CaptureStopReason;
   resultPath?: string;
@@ -55,6 +69,7 @@ export interface CaptureCollectionSummary {
   alignmentWarningCount: number;
   mediaCount: number;
   oldestTimestamp?: string;
+  oldestTrustedTimestamp?: string;
   newestTimestamp?: string;
 }
 

--- a/apps/chrome-extension/src/capture-operation.ts
+++ b/apps/chrome-extension/src/capture-operation.ts
@@ -38,6 +38,7 @@ export interface CaptureOperationSnapshot {
   initiator: CaptureOperationInitiator;
   mode: CaptureOperationMode;
   automaticBoundary?: AutomaticCaptureBoundary;
+  automaticControlsReady?: boolean;
   state: CaptureOperationState;
   chatKey?: string;
   renderedCount: number;

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -189,6 +189,7 @@ export interface StartCaptureOperationMessage {
   tabId?: number;
   initiator: "popup" | "page";
   mode?: import("./capture-operation").CaptureOperationMode;
+  automaticBoundary?: import("./capture-operation").AutomaticCaptureBoundary;
 }
 
 export interface GetCaptureOperationMessage {
@@ -219,6 +220,40 @@ export interface UpdateGuidedCaptureOperationMessage {
   action: "UPDATE_GUIDED_CAPTURE_OPERATION";
   operationId: string;
   summary: import("./capture-operation").CaptureCollectionSummary;
+}
+
+export interface UpdateAutomaticCaptureOperationMessage {
+  action: "UPDATE_AUTOMATIC_CAPTURE_OPERATION";
+  operationId: string;
+  summary: import("./capture-operation").CaptureCollectionSummary;
+}
+
+export interface ControlAutomaticCaptureOperationMessage {
+  action: "CONTROL_AUTOMATIC_CAPTURE_OPERATION";
+  tabId?: number;
+  operationId: string;
+  command: "pause" | "resume" | "stop";
+  stopReason?: Extract<
+    import("./capture-operation").CaptureStopReason,
+    `automatic-${string}`
+  >;
+}
+
+export interface ActivateAutomaticCaptureOperationMessage {
+  action: "ACTIVATE_AUTOMATIC_CAPTURE_OPERATION";
+  operationId: string;
+  boundary: import("./capture-operation").AutomaticCaptureBoundary;
+}
+
+export interface SetAutomaticCapturePausedMessage {
+  action: "SET_AUTOMATIC_CAPTURE_PAUSED";
+  operationId: string;
+  paused: boolean;
+}
+
+export interface FinalizeAutomaticCaptureOperationMessage {
+  action: "FINALIZE_AUTOMATIC_CAPTURE_OPERATION";
+  operationId: string;
 }
 
 export interface StopGuidedCaptureOperationMessage {
@@ -318,6 +353,11 @@ export type ExtensionMessage =
   | CancelCaptureOperationMessage
   | CollectCaptureOperationMessage
   | UpdateGuidedCaptureOperationMessage
+  | UpdateAutomaticCaptureOperationMessage
+  | ControlAutomaticCaptureOperationMessage
+  | ActivateAutomaticCaptureOperationMessage
+  | SetAutomaticCapturePausedMessage
+  | FinalizeAutomaticCaptureOperationMessage
   | StopGuidedCaptureOperationMessage
   | FinalizeGuidedCaptureOperationMessage
   | ActivateGuidedCaptureOperationMessage

--- a/apps/chrome-extension/src/content.css
+++ b/apps/chrome-extension/src/content.css
@@ -325,6 +325,39 @@
   opacity: 0.7;
 }
 
+.ws-automatic-options {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 9px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  border-radius: 9px;
+  background: rgba(59, 130, 246, 0.08);
+  color: var(--ws-text);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.ws-automatic-options[hidden] {
+  display: none;
+}
+
+.ws-automatic-options select {
+  width: 100%;
+  padding: 7px;
+  border: 1px solid var(--ws-border);
+  border-radius: 7px;
+  background: var(--ws-surface);
+  color: var(--ws-text);
+}
+
+.ws-automatic-consent {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 7px;
+}
+
 .ws-capture-review {
   display: grid;
   gap: 8px;

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -2188,7 +2188,8 @@ async function drainGuidedWindowReads(
         if (session.limitReached) {
           session.pendingStopReason =
             session.mode === "automatic"
-              ? automaticLimitStopReason(session)
+              ? (automaticBoundaryReason(session, false) ??
+                automaticLimitStopReason(session))
               : "guided-safety-limit";
           session.pendingWindows.length = 0;
           return;

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1740,7 +1740,7 @@ function mergeGuidedPayload(
             addedCount: 0,
             overlapCount: 0,
             ambiguous: true,
-            limitReached: true,
+            limitReached: false,
           }
         : { ...merge, ambiguous: true };
   }
@@ -1754,7 +1754,9 @@ function mergeGuidedPayload(
     }
   }
   reconcileGuidedAlignmentWarnings(session);
-  if (merge.limitReached) session.limitReached = true;
+  if (merge.limitReached && session.items.length >= session.captureLimit) {
+    session.limitReached = true;
+  }
   const incomingSkipped = Math.max(
     0,
     incoming.diagnostics.messageContainerCount -

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -186,6 +186,7 @@ interface GuidedCaptureSession {
   timeoutId?: number;
   consecutiveFailures: number;
   alignmentWarningCount: number;
+  alignmentWarnings: GuidedWindowItem<ExtractedMessage>[][];
   skippedCount: number;
   unreadableCount: number;
   reading: boolean;
@@ -1737,7 +1738,15 @@ function mergeGuidedPayload(
         : { ...merge, ambiguous: true };
   }
   session.items = merge.items;
-  if (merge.ambiguous) session.alignmentWarningCount += 1;
+  if (merge.ambiguous) {
+    const retainedAmbiguousItems = incomingItems.filter((item) =>
+      merge.items.includes(item),
+    );
+    if (retainedAmbiguousItems.length > 0) {
+      session.alignmentWarnings.push(retainedAmbiguousItems);
+    }
+  }
+  reconcileGuidedAlignmentWarnings(session);
   if (merge.limitReached) session.limitReached = true;
   const incomingSkipped = Math.max(
     0,
@@ -1789,6 +1798,14 @@ function mergeGuidedPayload(
     session.unreadableCount,
     session.alignmentWarningCount,
   );
+}
+
+function reconcileGuidedAlignmentWarnings(session: GuidedCaptureSession): void {
+  const retainedItems = new Set(session.items);
+  session.alignmentWarnings = session.alignmentWarnings.filter((warningItems) =>
+    warningItems.some((item) => retainedItems.has(item)),
+  );
+  session.alignmentWarningCount = session.alignmentWarnings.length;
 }
 
 function teardownGuidedCaptureSession(operationId: string): void {
@@ -1938,6 +1955,7 @@ function retainAutomaticItems(
   items: GuidedWindowItem<ExtractedMessage>[],
 ): void {
   session.items = items;
+  reconcileGuidedAlignmentWarnings(session);
   session.payload.messages = items.map((item) => item.value);
   session.payload.messageCount = session.payload.messages.length;
   session.skippedCount = 0;
@@ -2195,6 +2213,7 @@ async function startGuidedCaptureOperation(
     scrollTarget,
     consecutiveFailures: 0,
     alignmentWarningCount: 0,
+    alignmentWarnings: [],
     skippedCount,
     unreadableCount,
     reading: false,

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1940,9 +1940,13 @@ function retainAutomaticItems(
   session.items = items;
   session.payload.messages = items.map((item) => item.value);
   session.payload.messageCount = session.payload.messages.length;
+  session.skippedCount = 0;
+  session.unreadableCount = 0;
   session.payload.diagnostics = {
     ...session.payload.diagnostics,
+    messageContainerCount: session.payload.messages.length,
     extractedMessageCount: session.payload.messages.length,
+    unreadableMessageCount: 0,
     ...summarizeGuidedDiagnosticMethods(session.payload.messages),
   };
   const retainedParticipantRefs = new Set(
@@ -2005,6 +2009,7 @@ async function runAutomaticCapture(
     await waitForAutomaticStabilization(session, beforeObservedWindowCount);
     if (session.drainPromise) await session.drainPromise;
     if (guidedCaptureSession !== session || session.finalizing) return;
+    if (session.automaticPaused) continue;
 
     const verifiedTop = hasVerifiedTopOfHistory(session.scrollTarget);
     const boundaryReason = automaticBoundaryReason(session, verifiedTop);

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -2305,6 +2305,7 @@ async function setAutomaticCapturePaused(
 
 async function finalizeGuidedCaptureOperation(
   operationId: string,
+  prepareSummary?: (session: GuidedCaptureSession) => void,
 ): Promise<CaptureCollectionSummary> {
   const session = guidedCaptureSession;
   if (!session || session.operationId !== operationId) {
@@ -2318,6 +2319,7 @@ async function finalizeGuidedCaptureOperation(
   if (guidedCaptureSession !== session) {
     throw new Error("The guided capture buffer is no longer available.");
   }
+  prepareSummary?.(session);
   const summary = summarizeCapturePayload(
     session.payload,
     session.chatIdentity,
@@ -2346,7 +2348,10 @@ async function finalizeAutomaticCaptureOperation(
   ) {
     throw new Error("The automatic capture buffer is no longer available.");
   }
-  const summary = await finalizeGuidedCaptureOperation(operationId);
+  const summary = await finalizeGuidedCaptureOperation(
+    operationId,
+    trimAutomaticDateBoundary,
+  );
   if (summary.extractedCount === 0) {
     throw new Error(
       "No readable messages fall within the selected automatic boundary. Nothing was sent.",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -2346,7 +2346,13 @@ async function finalizeAutomaticCaptureOperation(
   ) {
     throw new Error("The automatic capture buffer is no longer available.");
   }
-  return await finalizeGuidedCaptureOperation(operationId);
+  const summary = await finalizeGuidedCaptureOperation(operationId);
+  if (summary.extractedCount === 0) {
+    throw new Error(
+      "No readable messages fall within the selected automatic boundary. Nothing was sent.",
+    );
+  }
+  return summary;
 }
 
 async function collectCaptureOperation(

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -197,6 +197,7 @@ interface GuidedCaptureSession {
   limitReached: boolean;
   automaticBoundary?: AutomaticCaptureBoundary;
   automaticStartedAt?: Date;
+  automaticDateBoundaryProven: boolean;
   automaticPaused: boolean;
   automaticRunner?: Promise<void>;
   originalScrollTop?: number;
@@ -1995,12 +1996,14 @@ function trimAutomaticDateBoundary(session: GuidedCaptureSession): void {
     session.automaticStartedAt,
   );
   if (startIndex !== null) {
+    session.automaticDateBoundaryProven = true;
     retainAutomaticItems(session, session.items.slice(startIndex));
   }
 }
 
 function prepareAutomaticCaptureSummary(session: GuidedCaptureSession): void {
   if (session.automaticBoundary?.kind !== "days") return;
+  if (session.automaticDateBoundaryProven) return;
   const startedAt = session.automaticStartedAt;
   const trustedTimestamps = session.items.map((item) =>
     item.value.captureTimestampMethod === "metadata"
@@ -2024,6 +2027,7 @@ function prepareAutomaticCaptureSummary(session: GuidedCaptureSession): void {
     );
   }
   if (startIndex !== null) {
+    session.automaticDateBoundaryProven = true;
     retainAutomaticItems(session, session.items.slice(startIndex));
   }
 }
@@ -2257,6 +2261,7 @@ async function startGuidedCaptureOperation(
     finalizing: false,
     limitReached: false,
     automaticPaused: false,
+    automaticDateBoundaryProven: false,
     noProgressCount: 0,
     observedWindowCount: 0,
   };

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -36,6 +36,7 @@ import {
   AUTOMATIC_CAPTURE_SAFETY_CAP,
   AUTOMATIC_NO_PROGRESS_LIMIT,
   automaticBoundaryStopReason,
+  automaticDateBoundaryStartIndex,
   normalizeAutomaticBoundary,
 } from "./automatic-capture";
 import { parseWhatsAppMessageMetadata } from "./whatsapp-metadata";
@@ -1615,6 +1616,11 @@ function summarizeCapturePayload(
     .map((message) => message.timestamp)
     .filter(Boolean)
     .sort();
+  const trustedTimestamps = payload.messages
+    .filter((message) => message.captureTimestampMethod === "metadata")
+    .map((message) => message.timestamp)
+    .filter(Boolean)
+    .sort();
   return {
     chatKey: getOpaqueChatKey(chatIdentity),
     renderedCount: payload.messages.length + skippedCount + unreadableCount,
@@ -1634,6 +1640,7 @@ function summarizeCapturePayload(
     alignmentWarningCount,
     mediaCount: payload.messages.filter((message) => message.isMedia).length,
     oldestTimestamp: timestamps[0],
+    oldestTrustedTimestamp: trustedTimestamps[0],
     newestTimestamp: timestamps[timestamps.length - 1],
   };
 }
@@ -1918,6 +1925,44 @@ function automaticBoundaryReason(
   return reason === "loaded-window" ? null : reason;
 }
 
+function retainAutomaticItems(
+  session: GuidedCaptureSession,
+  items: GuidedWindowItem<ExtractedMessage>[],
+): void {
+  session.items = items;
+  session.payload.messages = items.map((item) => item.value);
+  session.payload.messageCount = session.payload.messages.length;
+  session.payload.diagnostics = {
+    ...session.payload.diagnostics,
+    extractedMessageCount: session.payload.messages.length,
+    ...summarizeGuidedDiagnosticMethods(session.payload.messages),
+  };
+  const retainedParticipantRefs = new Set(
+    session.payload.messages.flatMap((message) =>
+      [message.senderRef].filter((value): value is string => Boolean(value)),
+    ),
+  );
+  session.payload.participants = session.payload.participants.filter(
+    (participant) => retainedParticipantRefs.has(participant.ref),
+  );
+}
+
+function trimAutomaticDateBoundary(session: GuidedCaptureSession): void {
+  if (!session.automaticBoundary || !session.automaticStartedAt) return;
+  const startIndex = automaticDateBoundaryStartIndex(
+    session.items.map((item) =>
+      item.value.captureTimestampMethod === "metadata"
+        ? item.value.timestamp
+        : undefined,
+    ),
+    session.automaticBoundary,
+    session.automaticStartedAt,
+  );
+  if (startIndex !== null) {
+    retainAutomaticItems(session, session.items.slice(startIndex));
+  }
+}
+
 async function runAutomaticCapture(
   session: GuidedCaptureSession,
 ): Promise<void> {
@@ -1931,6 +1976,9 @@ async function runAutomaticCapture(
       hasVerifiedTopOfHistory(session.scrollTarget),
     );
     if (existingReason) {
+      if (existingReason === "automatic-date-boundary") {
+        trimAutomaticDateBoundary(session);
+      }
       session.pendingStopReason = existingReason;
       if (!session.drainPromise) startGuidedWindowDrain(session);
       return;
@@ -1952,6 +2000,9 @@ async function runAutomaticCapture(
     const verifiedTop = hasVerifiedTopOfHistory(session.scrollTarget);
     const boundaryReason = automaticBoundaryReason(session, verifiedTop);
     if (boundaryReason) {
+      if (boundaryReason === "automatic-date-boundary") {
+        trimAutomaticDateBoundary(session);
+      }
       session.pendingStopReason = boundaryReason;
       if (!session.drainPromise) startGuidedWindowDrain(session);
       return;
@@ -2186,25 +2237,7 @@ function activateAutomaticCaptureOperation(
       ? Math.min(AUTOMATIC_CAPTURE_SAFETY_CAP, boundary.messageLimit)
       : AUTOMATIC_CAPTURE_SAFETY_CAP;
   if (session.items.length > session.captureLimit) {
-    session.items = session.items.slice(-session.captureLimit);
-    session.payload.messages = session.items.map((item) => item.value);
-    session.payload.messageCount = session.payload.messages.length;
-    const diagnosticMethods = summarizeGuidedDiagnosticMethods(
-      session.payload.messages,
-    );
-    session.payload.diagnostics = {
-      ...session.payload.diagnostics,
-      extractedMessageCount: session.payload.messages.length,
-      ...diagnosticMethods,
-    };
-    const retainedParticipantRefs = new Set(
-      session.payload.messages.flatMap((message) =>
-        [message.senderRef].filter((value): value is string => Boolean(value)),
-      ),
-    );
-    session.payload.participants = session.payload.participants.filter(
-      (participant) => retainedParticipantRefs.has(participant.ref),
-    );
+    retainAutomaticItems(session, session.items.slice(-session.captureLimit));
   }
   session.originalScrollTop = session.scrollTarget.scrollTop;
   session.originalBottomOffset =
@@ -2220,7 +2253,10 @@ function activateAutomaticCaptureOperation(
   });
 }
 
-function setAutomaticCapturePaused(operationId: string, paused: boolean): void {
+async function setAutomaticCapturePaused(
+  operationId: string,
+  paused: boolean,
+): Promise<void> {
   const session = guidedCaptureSession;
   if (
     !session ||
@@ -2231,6 +2267,18 @@ function setAutomaticCapturePaused(operationId: string, paused: boolean): void {
     throw new Error("The automatic capture buffer is no longer available.");
   }
   session.automaticPaused = paused;
+  if (paused) {
+    session.observer.disconnect();
+    if (session.drainPromise) await session.drainPromise;
+    return;
+  }
+  if (guidedCaptureSession !== session || session.finalizing) {
+    throw new Error("The automatic capture buffer is no longer available.");
+  }
+  session.observer.observe(session.scrollTarget, {
+    childList: true,
+    subtree: true,
+  });
 }
 
 async function finalizeGuidedCaptureOperation(
@@ -3020,13 +3068,12 @@ function handleMessage(
       break;
 
     case "SET_AUTOMATIC_CAPTURE_PAUSED":
-      try {
-        setAutomaticCapturePaused(message.operationId, message.paused);
-        sendResponse({ success: true });
-      } catch (error) {
-        sendResponse({ success: false, error: normalizeErrorMessage(error) });
-      }
-      break;
+      setAutomaticCapturePaused(message.operationId, message.paused)
+        .then(() => sendResponse({ success: true }))
+        .catch((error) =>
+          sendResponse({ success: false, error: normalizeErrorMessage(error) }),
+        );
+      return true;
 
     case "FINALIZE_AUTOMATIC_CAPTURE_OPERATION":
       finalizeAutomaticCaptureOperation(message.operationId)

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -26,10 +26,18 @@ import {
   type AuthStatusData,
 } from "./config";
 import type {
+  AutomaticCaptureBoundary,
   CaptureCollectionSummary,
   CaptureOperationSnapshot,
   CaptureOperationState,
+  CaptureStopReason,
 } from "./capture-operation";
+import {
+  AUTOMATIC_CAPTURE_SAFETY_CAP,
+  AUTOMATIC_NO_PROGRESS_LIMIT,
+  automaticBoundaryStopReason,
+  normalizeAutomaticBoundary,
+} from "./automatic-capture";
 import { parseWhatsAppMessageMetadata } from "./whatsapp-metadata";
 import {
   combineSenderEvidence,
@@ -126,6 +134,7 @@ interface CapturePreviewSummary {
   chatName: string;
   loadedMessageCount: number;
   oldestTimestamp?: string;
+  oldestTrustedTimestamp?: string;
   newestTimestamp?: string;
   participantLabelCount: number;
   mediaCount: number;
@@ -168,9 +177,11 @@ interface GuidedCaptureSession {
   operationId: string;
   chatIdentity: string;
   payload: ExtractedChat;
+  mode: "guided" | "automatic";
+  captureLimit: number;
   items: GuidedWindowItem<ExtractedMessage>[];
   observer: MutationObserver;
-  scrollTarget: Element;
+  scrollTarget: HTMLElement;
   timeoutId?: number;
   consecutiveFailures: number;
   alignmentWarningCount: number;
@@ -179,13 +190,22 @@ interface GuidedCaptureSession {
   reading: boolean;
   pendingWindows: Promise<ExtractedChat | null>[];
   drainPromise?: Promise<void>;
-  pendingStopReason?: "guided-safety-limit" | "guided-dom-failure";
+  pendingStopReason?: Exclude<CaptureStopReason, "loaded-window">;
   finalizing: boolean;
   limitReached: boolean;
+  automaticBoundary?: AutomaticCaptureBoundary;
+  automaticStartedAt?: Date;
+  automaticPaused: boolean;
+  automaticRunner?: Promise<void>;
+  originalScrollTop?: number;
+  originalBottomOffset?: number;
+  noProgressCount: number;
 }
 
 const GUIDED_CAPTURE_LIMIT = 2_000;
 const GUIDED_CAPTURE_TIMEOUT_MS = 10 * 60 * 1_000;
+const AUTOMATIC_STABILIZATION_TIMEOUT_MS = 3_000;
+const AUTOMATIC_STABILIZATION_INTERVAL_MS = 120;
 
 let activeCaptureOperation: ActiveCaptureOperation | null = null;
 let guidedCaptureSession: GuidedCaptureSession | null = null;
@@ -351,21 +371,37 @@ async function injectUI(): Promise<void> {
           <span><strong>Capture as I scroll</strong><small>Guided collection while you scroll</small></span>
           <em>Available</em>
         </label>
-        <label class="ws-capture-mode ws-capture-mode-disabled">
-          <input type="radio" name="ws-capture-mode" value="automatic" disabled>
+        <label class="ws-capture-mode">
+          <input type="radio" name="ws-capture-mode" value="automatic">
           <span><strong>Load older messages for me</strong><small>Automatic older-history loading</small></span>
-          <em>Soon · Phase 7</em>
+          <em>Available</em>
         </label>
       </fieldset>
+      <div id="ws-automatic-options" class="ws-automatic-options" hidden>
+        <label for="ws-automatic-boundary"><strong>Stop boundary</strong></label>
+        <select id="ws-automatic-boundary">
+          <option value="days-7">Last 7 days</option>
+          <option value="days-30">Last 30 days</option>
+          <option value="messages-100">100 messages</option>
+          <option value="messages-250">250 messages</option>
+          <option value="messages-500">500 messages (safety cap)</option>
+          <option value="verified-top">Verified top of history</option>
+        </select>
+        <label class="ws-automatic-consent">
+          <input id="ws-automatic-consent" type="checkbox">
+          <span>I understand WhatsApp will scroll this chat. I can pause, stop and review, or cancel.</span>
+        </label>
+      </div>
       <button id="ws-extract-btn" class="ws-capture-btn" type="button" disabled>
         Sign in to capture
       </button>
       <section id="ws-guided-progress" class="ws-guided-progress" aria-live="polite" hidden>
-        <strong>Guided capture is active</strong>
-        <span>Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.</span>
+        <strong id="ws-collection-title">Guided capture is active</strong>
+        <span id="ws-collection-instruction">Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.</span>
         <p><b id="ws-guided-count">0</b> unique messages · oldest <span id="ws-guided-oldest">Not detected</span></p>
         <p id="ws-guided-warning" class="ws-guided-warning" hidden></p>
         <div class="ws-preview-actions">
+          <button id="ws-pause-automatic" class="ws-secondary-btn" type="button" hidden>Pause</button>
           <button id="ws-stop-guided" class="ws-capture-btn" type="button">Stop and review</button>
           <button id="ws-cancel-guided" class="ws-secondary-btn" type="button">Cancel</button>
         </div>
@@ -433,8 +469,13 @@ async function injectUI(): Promise<void> {
       if (launcherOperation) void reviewPageCapture(launcherOperation, false);
     });
   document.getElementById("ws-stop-guided")?.addEventListener("click", () => {
-    if (launcherOperation) void stopPageGuidedCapture(launcherOperation);
+    if (launcherOperation) void stopPageCollection(launcherOperation);
   });
+  document
+    .getElementById("ws-pause-automatic")
+    ?.addEventListener("click", () => {
+      if (launcherOperation) void togglePageAutomaticCapture(launcherOperation);
+    });
   document.getElementById("ws-cancel-guided")?.addEventListener("click", () => {
     if (launcherOperation) void reviewPageCapture(launcherOperation, false);
   });
@@ -764,11 +805,17 @@ function getCapturePreviewSummary(
     .map((message) => message.timestamp)
     .filter(Boolean)
     .sort();
+  const trustedTimestamps = payload.messages
+    .filter((message) => message.captureTimestampMethod === "metadata")
+    .map((message) => message.timestamp)
+    .filter(Boolean)
+    .sort();
   const unreadableCount = payload.diagnostics.unreadableMessageCount;
   return {
     chatName: payload.chatName,
     loadedMessageCount: payload.messages.length,
     oldestTimestamp: timestamps[0],
+    oldestTrustedTimestamp: trustedTimestamps[0],
     newestTimestamp: timestamps[timestamps.length - 1],
     participantLabelCount: payload.participants.filter(
       (participant) =>
@@ -830,14 +877,16 @@ function renderPageCapturePreview(operation: CaptureOperationSnapshot): void {
   const countLabel = document.getElementById("ws-preview-count-label");
   if (countLabel) {
     countLabel.textContent =
-      operation.mode === "guided" ? "Captured messages" : "Loaded messages";
+      operation.mode === "loaded" ? "Loaded messages" : "Captured messages";
   }
   const scopeCopy = document.getElementById("ws-scope-copy");
   if (scopeCopy) {
     scopeCopy.textContent =
       operation.mode === "guided"
         ? "Only the guided messages counted above will be uploaded. Collection stopped before review, and nothing is sent until you confirm."
-        : "Only the loaded messages counted above will be uploaded. Older messages WhatsApp has not loaded are excluded. Nothing is sent until you confirm.";
+        : operation.mode === "automatic"
+          ? `Only the automatically collected messages counted above will be uploaded. ${automaticStopReasonLabel(operation.stopReason)} Nothing is sent until you confirm.`
+          : "Only the loaded messages counted above will be uploaded. Older messages WhatsApp has not loaded are excluded. Nothing is sent until you confirm.";
   }
   const warning = document.getElementById("ws-preview-warning");
   if (warning) {
@@ -860,10 +909,12 @@ function applyPageCaptureMode(selectedMode: string): void {
       if (input) input.checked = selected;
       label.classList.toggle("ws-capture-mode-selected", selected);
       const status = label.querySelector("em");
-      if (status && input?.value !== "automatic") {
+      if (status) {
         status.textContent = selected ? "Selected" : "Available";
       }
     });
+  const automaticOptions = document.getElementById("ws-automatic-options");
+  if (automaticOptions) automaticOptions.hidden = selectedMode !== "automatic";
 }
 
 function handleCaptureModeChange(event: Event): void {
@@ -873,10 +924,16 @@ function handleCaptureModeChange(event: Event): void {
   if (
     launcherOperation &&
     ((launcherOperation.mode === "loaded" && selectedMode !== "loaded") ||
-      (launcherOperation.mode === "guided" && selectedMode !== "scroll")) &&
-    ["inspecting", "collecting", "ready-for-review", "retry-required"].includes(
-      launcherOperation.state,
-    )
+      (launcherOperation.mode === "guided" && selectedMode !== "scroll") ||
+      (launcherOperation.mode === "automatic" &&
+        selectedMode !== "automatic")) &&
+    [
+      "inspecting",
+      "collecting",
+      "paused",
+      "ready-for-review",
+      "retry-required",
+    ].includes(launcherOperation.state)
   ) {
     void reviewPageCapture(launcherOperation, false)
       .catch((error) => updateStatus(normalizeErrorMessage(error), "error"))
@@ -888,12 +945,27 @@ function handleCaptureModeChange(event: Event): void {
   }
 }
 
-function selectedPageCaptureMode(): "loaded" | "guided" {
-  return document.querySelector<HTMLInputElement>(
+function selectedPageCaptureMode(): "loaded" | "guided" | "automatic" {
+  const selected = document.querySelector<HTMLInputElement>(
     'input[name="ws-capture-mode"]:checked',
-  )?.value === "scroll"
+  )?.value;
+  return selected === "scroll"
     ? "guided"
-    : "loaded";
+    : selected === "automatic"
+      ? "automatic"
+      : "loaded";
+}
+
+function selectedPageAutomaticBoundary(): AutomaticCaptureBoundary {
+  const value = (
+    document.getElementById("ws-automatic-boundary") as HTMLSelectElement | null
+  )?.value;
+  if (value === "days-7") return { kind: "days", days: 7 };
+  if (value === "days-30") return { kind: "days", days: 30 };
+  if (value?.startsWith("messages-")) {
+    return { kind: "messages", messageLimit: Number(value.slice(9)) };
+  }
+  return { kind: "verified-top" };
 }
 
 async function handleExtractClick(): Promise<void> {
@@ -918,7 +990,7 @@ async function handleExtractClick(): Promise<void> {
     }
     if (
       existingOperation &&
-      ["inspecting", "collecting", "uploading"].includes(
+      ["inspecting", "collecting", "paused", "uploading"].includes(
         existingOperation.state,
       )
     ) {
@@ -939,10 +1011,28 @@ async function handleExtractClick(): Promise<void> {
   }
 
   try {
+    const mode = selectedPageCaptureMode();
+    if (
+      mode === "automatic" &&
+      !(
+        document.getElementById(
+          "ws-automatic-consent",
+        ) as HTMLInputElement | null
+      )?.checked
+    ) {
+      updateStatus(
+        "Confirm that WhatsApp may scroll this chat before starting automatic capture.",
+        "error",
+      );
+      return;
+    }
     const response = (await chrome.runtime.sendMessage({
       action: "START_CAPTURE_OPERATION",
       initiator: "page",
-      mode: selectedPageCaptureMode(),
+      mode,
+      ...(mode === "automatic"
+        ? { automaticBoundary: selectedPageAutomaticBoundary() }
+        : {}),
     })) as ExtensionResponse<CaptureOperationSnapshot>;
     if (!response.success || !response.data) {
       updateStatus(
@@ -962,21 +1052,30 @@ async function handleExtractClick(): Promise<void> {
   }
 }
 
-async function stopPageGuidedCapture(
+async function stopPageCollection(
   operation: CaptureOperationSnapshot,
 ): Promise<void> {
-  if (operation.mode !== "guided" || operation.state !== "collecting") return;
+  if (
+    !["guided", "automatic"].includes(operation.mode) ||
+    !["collecting", "paused"].includes(operation.state)
+  )
+    return;
   try {
+    const automatic = operation.mode === "automatic";
     const response = (await chrome.runtime.sendMessage({
-      action: "STOP_GUIDED_CAPTURE_OPERATION",
+      action: automatic
+        ? "CONTROL_AUTOMATIC_CAPTURE_OPERATION"
+        : "STOP_GUIDED_CAPTURE_OPERATION",
       operationId: operation.operationId,
-      stopReason: "guided-user-stopped",
+      ...(automatic
+        ? { command: "stop", stopReason: "automatic-user-stopped" }
+        : { stopReason: "guided-user-stopped" }),
     })) as ExtensionResponse<CaptureOperationSnapshot>;
     if (response.success && response.data) {
       renderCaptureOperation(response.data);
     } else {
       updateStatus(
-        response.success ? "Guided capture could not stop." : response.error,
+        response.success ? "Collection could not stop." : response.error,
         "error",
       );
     }
@@ -1048,7 +1147,7 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
   if (operation.authGeneration !== launcherCaptureAuthGeneration) return false;
   launcherOperationRenderGeneration += 1;
   launcherOperation = operation;
-  const modeValue = operation.mode === "guided" ? "scroll" : "loaded";
+  const modeValue = operation.mode === "guided" ? "scroll" : operation.mode;
   document
     .querySelectorAll<HTMLInputElement>('input[name="ws-capture-mode"]')
     .forEach((input) => {
@@ -1057,10 +1156,12 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
         .closest(".ws-capture-mode")
         ?.classList.toggle("ws-capture-mode-selected", input.checked);
       const status = input.closest(".ws-capture-mode")?.querySelector("em");
-      if (status && input.value !== "automatic") {
+      if (status) {
         status.textContent = input.checked ? "Selected" : "Available";
       }
     });
+  const automaticOptions = document.getElementById("ws-automatic-options");
+  if (automaticOptions) automaticOptions.hidden = modeValue !== "automatic";
   updateLauncherBadge(operation);
   renderPageCapturePreview(operation);
   renderPageGuidedProgress(operation);
@@ -1071,9 +1172,12 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
     "ws-extract-btn",
   ) as HTMLButtonElement | null;
   if (button) {
-    button.disabled = ["inspecting", "collecting", "uploading"].includes(
-      operation.state,
-    );
+    button.disabled = [
+      "inspecting",
+      "collecting",
+      "paused",
+      "uploading",
+    ].includes(operation.state);
     button.textContent = getLauncherActionLabel(operation);
   }
 
@@ -1086,17 +1190,28 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
       updateStatus(
         operation.mode === "guided"
           ? `Guided capture active: ${operation.extractedCount} unique message${operation.extractedCount === 1 ? "" : "s"}. Scroll upward, then stop and review.`
-          : "Reading loaded messages…",
+          : operation.mode === "automatic"
+            ? `Automatic capture active: ${operation.extractedCount} unique message${operation.extractedCount === 1 ? "" : "s"}.`
+            : "Reading loaded messages…",
         "loading",
       );
       updateProgress(operation.mode === "guided" ? 0 : 35);
+      break;
+    case "paused":
+      updateStatus(
+        `Automatic capture paused at ${operation.extractedCount} unique message${operation.extractedCount === 1 ? "" : "s"}.`,
+        "info",
+      );
+      updateProgress(0);
       break;
     case "ready-for-review":
       updateProgress(0);
       updateStatus(
         operation.mode === "guided"
           ? `${operation.extractedCount} guided message${operation.extractedCount === 1 ? "" : "s"} ready for review. ${guidedStopReasonLabel(operation.stopReason)}`
-          : `${operation.extractedCount} loaded message${operation.extractedCount === 1 ? "" : "s"} ready for review.`,
+          : operation.mode === "automatic"
+            ? `${operation.extractedCount} automatic message${operation.extractedCount === 1 ? "" : "s"} ready for review. ${automaticStopReasonLabel(operation.stopReason)}`
+            : `${operation.extractedCount} loaded message${operation.extractedCount === 1 ? "" : "s"} ready for review.`,
         "info",
       );
       break;
@@ -1155,13 +1270,57 @@ function guidedStopReasonLabel(
   }
 }
 
+function automaticStopReasonLabel(
+  reason: CaptureOperationSnapshot["stopReason"],
+): string {
+  switch (reason) {
+    case "automatic-date-boundary":
+      return "The selected date boundary was reached.";
+    case "automatic-message-limit":
+      return "The selected message limit was reached.";
+    case "automatic-verified-top":
+      return "WhatsApp exposed a verified top-of-history marker.";
+    case "automatic-safety-cap":
+      return "The 500-message automatic safety cap was reached.";
+    case "automatic-no-progress":
+      return "WhatsApp made no further progress; the top was not verified.";
+    case "automatic-dom-failure":
+      return "Collection stopped after repeated WhatsApp DOM failures.";
+    default:
+      return "You stopped automatic collection.";
+  }
+}
+
 function renderPageGuidedProgress(operation: CaptureOperationSnapshot): void {
   const panel = document.getElementById("ws-guided-progress");
   if (!panel) return;
   const active =
-    operation.mode === "guided" && operation.state === "collecting";
+    ["guided", "automatic"].includes(operation.mode) &&
+    ["collecting", "paused"].includes(operation.state);
   panel.hidden = !active;
   if (!active) return;
+  const automatic = operation.mode === "automatic";
+  const title = document.getElementById("ws-collection-title");
+  const instruction = document.getElementById("ws-collection-instruction");
+  const pauseButton = document.getElementById(
+    "ws-pause-automatic",
+  ) as HTMLButtonElement | null;
+  if (title) {
+    title.textContent = automatic
+      ? operation.state === "paused"
+        ? "Automatic capture is paused"
+        : "Automatic capture is active"
+      : "Guided capture is active";
+  }
+  if (instruction) {
+    instruction.textContent = automatic
+      ? "Keep this chat open. ConvoLens is loading older history within the selected boundary."
+      : "Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.";
+  }
+  if (pauseButton) {
+    pauseButton.hidden = !automatic;
+    pauseButton.textContent = operation.state === "paused" ? "Resume" : "Pause";
+  }
   const count = document.getElementById("ws-guided-count");
   const oldest = document.getElementById("ws-guided-oldest");
   const warning = document.getElementById("ws-guided-warning");
@@ -1183,7 +1342,11 @@ function getLauncherActionLabel(operation: CaptureOperationSnapshot): string {
     case "collecting":
       return operation.mode === "guided"
         ? `Guided: ${operation.extractedCount} captured`
-        : "Reading loaded messages…";
+        : operation.mode === "automatic"
+          ? `Automatic: ${operation.extractedCount} captured`
+          : "Reading loaded messages…";
+    case "paused":
+      return `Automatic paused: ${operation.extractedCount}`;
     case "ready-for-review":
       return `Review ${operation.extractedCount} loaded message${operation.extractedCount === 1 ? "" : "s"}`;
     case "uploading":
@@ -1551,11 +1714,11 @@ function mergeGuidedPayload(
     session.items,
     incomingItems,
     mergeEdge || "prepend",
-    mergeEdge ? GUIDED_CAPTURE_LIMIT : undefined,
+    mergeEdge ? session.captureLimit : undefined,
   );
   if (mergeEdge === null) {
     merge =
-      merge.items.length > GUIDED_CAPTURE_LIMIT
+      merge.items.length > session.captureLimit
         ? {
             items: session.items,
             addedCount: 0,
@@ -1623,6 +1786,7 @@ function mergeGuidedPayload(
 function teardownGuidedCaptureSession(operationId: string): void {
   const session = guidedCaptureSession;
   if (!session || session.operationId !== operationId) return;
+  restoreAutomaticScrollAnchor(session);
   pauseGuidedCaptureSession(session);
   guidedCaptureSession = null;
 }
@@ -1632,6 +1796,179 @@ function pauseGuidedCaptureSession(session: GuidedCaptureSession): void {
   session.scrollTarget.removeEventListener("scroll", queueGuidedWindowRead);
   if (session.timeoutId !== undefined) window.clearTimeout(session.timeoutId);
   session.timeoutId = undefined;
+}
+
+function resolveAutomaticScrollTarget(messageList: Element): HTMLElement {
+  let candidate: HTMLElement | null = messageList as HTMLElement;
+  for (let depth = 0; candidate && depth < 8; depth += 1) {
+    if (candidate.scrollHeight > candidate.clientHeight + 1) return candidate;
+    candidate = candidate.parentElement;
+  }
+  return messageList as HTMLElement;
+}
+
+function restoreAutomaticScrollAnchor(session: GuidedCaptureSession): void {
+  if (
+    session.mode !== "automatic" ||
+    session.originalBottomOffset === undefined ||
+    getCurrentChatIdentity() !== session.chatIdentity
+  ) {
+    return;
+  }
+  const targetTop = Math.max(
+    0,
+    session.scrollTarget.scrollHeight - session.originalBottomOffset,
+  );
+  session.scrollTarget.scrollTop = Number.isFinite(targetTop)
+    ? targetTop
+    : session.originalScrollTop || 0;
+}
+
+function hasVerifiedTopOfHistory(scrollTarget: HTMLElement): boolean {
+  if (scrollTarget.scrollTop > 1) return false;
+  return Boolean(
+    scrollTarget.querySelector(
+      '[data-testid="conversation-start"], [data-testid="chat-history-start"], [aria-rowindex="1"]',
+    ),
+  );
+}
+
+async function waitForAutomaticStabilization(
+  session: GuidedCaptureSession,
+): Promise<void> {
+  const started = Date.now();
+  let previousTop = session.scrollTarget.scrollTop;
+  let previousHeight = session.scrollTarget.scrollHeight;
+  let stableSamples = 0;
+  while (
+    guidedCaptureSession === session &&
+    !session.finalizing &&
+    Date.now() - started < AUTOMATIC_STABILIZATION_TIMEOUT_MS
+  ) {
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, AUTOMATIC_STABILIZATION_INTERVAL_MS),
+    );
+    const nextTop = session.scrollTarget.scrollTop;
+    const nextHeight = session.scrollTarget.scrollHeight;
+    if (nextTop === previousTop && nextHeight === previousHeight) {
+      stableSamples += 1;
+      if (stableSamples >= 2) return;
+    } else {
+      stableSamples = 0;
+      previousTop = nextTop;
+      previousHeight = nextHeight;
+    }
+  }
+}
+
+async function togglePageAutomaticCapture(
+  operation: CaptureOperationSnapshot,
+): Promise<void> {
+  if (
+    operation.mode !== "automatic" ||
+    !["collecting", "paused"].includes(operation.state)
+  )
+    return;
+  try {
+    const response = (await chrome.runtime.sendMessage({
+      action: "CONTROL_AUTOMATIC_CAPTURE_OPERATION",
+      operationId: operation.operationId,
+      command: operation.state === "paused" ? "resume" : "pause",
+    })) as ExtensionResponse<CaptureOperationSnapshot>;
+    if (response.success && response.data)
+      renderCaptureOperation(response.data);
+    else
+      updateStatus(
+        response.success
+          ? "Automatic capture could not be updated."
+          : response.error,
+        "error",
+      );
+  } catch (error) {
+    updateStatus(normalizeErrorMessage(error), "error");
+  }
+}
+
+function automaticLimitStopReason(
+  session: GuidedCaptureSession,
+): Exclude<CaptureStopReason, "loaded-window"> {
+  return session.automaticBoundary?.kind === "messages" &&
+    session.captureLimit < AUTOMATIC_CAPTURE_SAFETY_CAP
+    ? "automatic-message-limit"
+    : "automatic-safety-cap";
+}
+
+function automaticBoundaryReason(
+  session: GuidedCaptureSession,
+  verifiedTop: boolean,
+): Exclude<CaptureStopReason, "loaded-window"> | null {
+  if (!session.automaticBoundary || !session.automaticStartedAt) return null;
+  const oldestTrustedTimestamp = session.items
+    .filter((item) => item.value.captureTimestampMethod === "metadata")
+    .map((item) => item.value.timestamp)
+    .filter(Boolean)
+    .sort()[0];
+  const reason = automaticBoundaryStopReason({
+    boundary: session.automaticBoundary,
+    extractedCount: session.items.length,
+    oldestTrustedTimestamp,
+    verifiedTop,
+    startedAt: session.automaticStartedAt,
+  });
+  return reason === "loaded-window" ? null : reason;
+}
+
+async function runAutomaticCapture(
+  session: GuidedCaptureSession,
+): Promise<void> {
+  while (guidedCaptureSession === session && !session.finalizing) {
+    if (session.automaticPaused) {
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+      continue;
+    }
+    const existingReason = automaticBoundaryReason(
+      session,
+      hasVerifiedTopOfHistory(session.scrollTarget),
+    );
+    if (existingReason) {
+      session.pendingStopReason = existingReason;
+      if (!session.drainPromise) startGuidedWindowDrain(session);
+      return;
+    }
+
+    const beforeTop = session.scrollTarget.scrollTop;
+    const beforeHeight = session.scrollTarget.scrollHeight;
+    const beforeCount = session.items.length;
+    const step = Math.max(
+      320,
+      Math.floor(session.scrollTarget.clientHeight * 0.8),
+    );
+    session.scrollTarget.scrollTop = Math.max(0, beforeTop - step);
+    queueGuidedWindowRead();
+    await waitForAutomaticStabilization(session);
+    if (session.drainPromise) await session.drainPromise;
+    if (guidedCaptureSession !== session || session.finalizing) return;
+
+    const verifiedTop = hasVerifiedTopOfHistory(session.scrollTarget);
+    const boundaryReason = automaticBoundaryReason(session, verifiedTop);
+    if (boundaryReason) {
+      session.pendingStopReason = boundaryReason;
+      if (!session.drainPromise) startGuidedWindowDrain(session);
+      return;
+    }
+    const progressed =
+      session.items.length > beforeCount ||
+      session.scrollTarget.scrollTop !== beforeTop ||
+      session.scrollTarget.scrollHeight !== beforeHeight;
+    session.noProgressCount = progressed ? 0 : session.noProgressCount + 1;
+    if (session.noProgressCount >= AUTOMATIC_NO_PROGRESS_LIMIT) {
+      session.pendingStopReason = verifiedTop
+        ? "automatic-verified-top"
+        : "automatic-no-progress";
+      if (!session.drainPromise) startGuidedWindowDrain(session);
+      return;
+    }
+  }
 }
 
 function queueGuidedWindowRead(): void {
@@ -1659,11 +1996,20 @@ function startGuidedWindowDrain(session: GuidedCaptureSession): void {
     ) {
       const stopReason = session.pendingStopReason;
       session.pendingStopReason = undefined;
-      void chrome.runtime.sendMessage({
-        action: "STOP_GUIDED_CAPTURE_OPERATION",
-        operationId: session.operationId,
-        stopReason,
-      });
+      void chrome.runtime.sendMessage(
+        session.mode === "automatic"
+          ? {
+              action: "CONTROL_AUTOMATIC_CAPTURE_OPERATION",
+              operationId: session.operationId,
+              command: "stop",
+              stopReason,
+            }
+          : {
+              action: "STOP_GUIDED_CAPTURE_OPERATION",
+              operationId: session.operationId,
+              stopReason,
+            },
+      );
     }
   };
   void drain.then(finishDrain, finishDrain);
@@ -1707,19 +2053,28 @@ async function drainGuidedWindowReads(
         session.consecutiveFailures = 0;
         const summary = mergeGuidedPayload(session, incoming);
         await chrome.runtime.sendMessage({
-          action: "UPDATE_GUIDED_CAPTURE_OPERATION",
+          action:
+            session.mode === "automatic"
+              ? "UPDATE_AUTOMATIC_CAPTURE_OPERATION"
+              : "UPDATE_GUIDED_CAPTURE_OPERATION",
           operationId: session.operationId,
           summary,
         });
         if (session.limitReached) {
-          session.pendingStopReason = "guided-safety-limit";
+          session.pendingStopReason =
+            session.mode === "automatic"
+              ? automaticLimitStopReason(session)
+              : "guided-safety-limit";
           session.pendingWindows.length = 0;
           return;
         }
       } catch {
         session.consecutiveFailures += 1;
         if (session.consecutiveFailures >= 3) {
-          session.pendingStopReason = "guided-dom-failure";
+          session.pendingStopReason =
+            session.mode === "automatic"
+              ? "automatic-dom-failure"
+              : "guided-dom-failure";
           session.pendingWindows.length = 0;
           return;
         }
@@ -1734,6 +2089,7 @@ async function startGuidedCaptureOperation(
   operationId: string,
   chatIdentity: string,
   initialPayload: ExtractedChat,
+  mode: "guided" | "automatic",
 ): Promise<CaptureCollectionSummary> {
   const messageList = findConversationRoot(
     document,
@@ -1749,13 +2105,22 @@ async function startGuidedCaptureOperation(
       unreadableCount,
   );
   const observer = new MutationObserver(queueGuidedWindowRead);
+  const scrollTarget =
+    mode === "automatic"
+      ? resolveAutomaticScrollTarget(messageList)
+      : (messageList as HTMLElement);
   const session: GuidedCaptureSession = {
     operationId,
     chatIdentity,
     payload: initialPayload,
+    mode,
+    captureLimit:
+      mode === "automatic"
+        ? AUTOMATIC_CAPTURE_SAFETY_CAP
+        : GUIDED_CAPTURE_LIMIT,
     items: guidedItems(initialPayload.messages),
     observer,
-    scrollTarget: messageList,
+    scrollTarget,
     consecutiveFailures: 0,
     alignmentWarningCount: 0,
     skippedCount,
@@ -1764,6 +2129,8 @@ async function startGuidedCaptureOperation(
     pendingWindows: [],
     finalizing: false,
     limitReached: false,
+    automaticPaused: false,
+    noProgressCount: 0,
   };
   guidedCaptureSession = session;
   return summarizeCapturePayload(
@@ -1798,6 +2165,74 @@ function activateGuidedCaptureOperation(operationId: string): void {
   }, GUIDED_CAPTURE_TIMEOUT_MS);
 }
 
+function activateAutomaticCaptureOperation(
+  operationId: string,
+  requestedBoundary: AutomaticCaptureBoundary,
+): void {
+  const session = guidedCaptureSession;
+  if (
+    !session ||
+    session.operationId !== operationId ||
+    session.mode !== "automatic"
+  ) {
+    throw new Error("The automatic capture buffer is no longer available.");
+  }
+  if (session.automaticRunner) return;
+  const boundary = normalizeAutomaticBoundary(requestedBoundary);
+  session.automaticBoundary = boundary;
+  session.automaticStartedAt = new Date();
+  session.captureLimit =
+    boundary.kind === "messages"
+      ? Math.min(AUTOMATIC_CAPTURE_SAFETY_CAP, boundary.messageLimit)
+      : AUTOMATIC_CAPTURE_SAFETY_CAP;
+  if (session.items.length > session.captureLimit) {
+    session.items = session.items.slice(-session.captureLimit);
+    session.payload.messages = session.items.map((item) => item.value);
+    session.payload.messageCount = session.payload.messages.length;
+    const diagnosticMethods = summarizeGuidedDiagnosticMethods(
+      session.payload.messages,
+    );
+    session.payload.diagnostics = {
+      ...session.payload.diagnostics,
+      extractedMessageCount: session.payload.messages.length,
+      ...diagnosticMethods,
+    };
+    const retainedParticipantRefs = new Set(
+      session.payload.messages.flatMap((message) =>
+        [message.senderRef].filter((value): value is string => Boolean(value)),
+      ),
+    );
+    session.payload.participants = session.payload.participants.filter(
+      (participant) => retainedParticipantRefs.has(participant.ref),
+    );
+  }
+  session.originalScrollTop = session.scrollTarget.scrollTop;
+  session.originalBottomOffset =
+    session.scrollTarget.scrollHeight - session.scrollTarget.scrollTop;
+  session.observer.observe(session.scrollTarget, {
+    childList: true,
+    subtree: true,
+  });
+  session.automaticRunner = runAutomaticCapture(session).catch(() => {
+    if (guidedCaptureSession !== session || session.finalizing) return;
+    session.pendingStopReason = "automatic-dom-failure";
+    if (!session.drainPromise) startGuidedWindowDrain(session);
+  });
+}
+
+function setAutomaticCapturePaused(operationId: string, paused: boolean): void {
+  const session = guidedCaptureSession;
+  if (
+    !session ||
+    session.operationId !== operationId ||
+    session.mode !== "automatic" ||
+    session.finalizing
+  ) {
+    throw new Error("The automatic capture buffer is no longer available.");
+  }
+  session.automaticPaused = paused;
+}
+
 async function finalizeGuidedCaptureOperation(
   operationId: string,
 ): Promise<CaptureCollectionSummary> {
@@ -1830,9 +2265,23 @@ async function finalizeGuidedCaptureOperation(
   return summary;
 }
 
+async function finalizeAutomaticCaptureOperation(
+  operationId: string,
+): Promise<CaptureCollectionSummary> {
+  const session = guidedCaptureSession;
+  if (
+    !session ||
+    session.operationId !== operationId ||
+    session.mode !== "automatic"
+  ) {
+    throw new Error("The automatic capture buffer is no longer available.");
+  }
+  return await finalizeGuidedCaptureOperation(operationId);
+}
+
 async function collectCaptureOperation(
   operationId: string,
-  mode: "loaded" | "guided" = "loaded",
+  mode: "loaded" | "guided" | "automatic" = "loaded",
 ): Promise<CaptureCollectionSummary> {
   if (
     activeCaptureOperation &&
@@ -1879,46 +2328,30 @@ async function collectCaptureOperation(
     activeCaptureOperation = {
       operationId,
       chatIdentity,
-      state: mode === "guided" ? "collecting" : "ready-for-review",
+      state: mode === "loaded" ? "ready-for-review" : "collecting",
       payload,
     };
-    if (mode === "guided") {
+    if (mode !== "loaded") {
       return await startGuidedCaptureOperation(
         operationId,
         chatIdentity,
         payload,
+        mode,
       );
     }
-    const timestamps = payload.messages
-      .map((message) => message.timestamp)
-      .filter(Boolean)
-      .sort();
-    return {
-      chatKey: getOpaqueChatKey(chatIdentity),
-      renderedCount: payload.diagnostics.messageContainerCount,
-      extractedCount: payload.messages.length,
-      skippedCount: Math.max(
+    const unreadableCount = payload.diagnostics.unreadableMessageCount;
+    return summarizeCapturePayload(
+      payload,
+      chatIdentity,
+      Math.max(
         0,
         payload.diagnostics.messageContainerCount -
           payload.messages.length -
-          payload.diagnostics.unreadableMessageCount,
+          unreadableCount,
       ),
-      unreadableCount: payload.diagnostics.unreadableMessageCount,
-      participantLabelCount: payload.participants.filter(
-        (participant) =>
-          participant.isSelf ||
-          Boolean(
-            participant.rawDisplayName ||
-              participant.rawUsername ||
-              participant.normalizedPhone ||
-              participant.platformUserId,
-          ),
-      ).length,
-      alignmentWarningCount: 0,
-      mediaCount: payload.messages.filter((message) => message.isMedia).length,
-      oldestTimestamp: timestamps[0],
-      newestTimestamp: timestamps[timestamps.length - 1],
-    };
+      unreadableCount,
+      0,
+    );
   } catch (error) {
     if (activeCaptureOperation?.operationId === operationId) {
       activeCaptureOperation = null;
@@ -2574,6 +3007,43 @@ function handleMessage(
       }
       break;
 
+    case "ACTIVATE_AUTOMATIC_CAPTURE_OPERATION":
+      try {
+        activateAutomaticCaptureOperation(
+          message.operationId,
+          message.boundary,
+        );
+        sendResponse({ success: true });
+      } catch (error) {
+        sendResponse({ success: false, error: normalizeErrorMessage(error) });
+      }
+      break;
+
+    case "SET_AUTOMATIC_CAPTURE_PAUSED":
+      try {
+        setAutomaticCapturePaused(message.operationId, message.paused);
+        sendResponse({ success: true });
+      } catch (error) {
+        sendResponse({ success: false, error: normalizeErrorMessage(error) });
+      }
+      break;
+
+    case "FINALIZE_AUTOMATIC_CAPTURE_OPERATION":
+      finalizeAutomaticCaptureOperation(message.operationId)
+        .then((summary) =>
+          respondSafely(sendResponse, {
+            success: true,
+            data: { summary },
+          }),
+        )
+        .catch((error) =>
+          respondSafely(sendResponse, {
+            success: false,
+            error: normalizeErrorMessage(error),
+          }),
+        );
+      return true;
+
     case "GET_CAPTURE_PREVIEW": {
       const preview = getCapturePreviewSummary(message.operationId);
       if (!preview) {
@@ -2643,7 +3113,7 @@ function handleMessage(
           state.isExtracting ||
           Boolean(
             activeCaptureOperation &&
-              ["collecting", "uploading"].includes(
+              ["collecting", "paused", "uploading"].includes(
                 activeCaptureOperation.state,
               ),
           ),

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1308,6 +1308,9 @@ function renderPageGuidedProgress(operation: CaptureOperationSnapshot): void {
   const pauseButton = document.getElementById(
     "ws-pause-automatic",
   ) as HTMLButtonElement | null;
+  const stopButton = document.getElementById(
+    "ws-stop-guided",
+  ) as HTMLButtonElement | null;
   if (title) {
     title.textContent = automatic
       ? operation.state === "paused"
@@ -1323,6 +1326,9 @@ function renderPageGuidedProgress(operation: CaptureOperationSnapshot): void {
   if (pauseButton) {
     pauseButton.hidden = !automatic || !operation.automaticControlsReady;
     pauseButton.textContent = operation.state === "paused" ? "Resume" : "Pause";
+  }
+  if (stopButton) {
+    stopButton.hidden = automatic && !operation.automaticControlsReady;
   }
   const count = document.getElementById("ws-guided-count");
   const oldest = document.getElementById("ws-guided-oldest");
@@ -1993,6 +1999,35 @@ function trimAutomaticDateBoundary(session: GuidedCaptureSession): void {
   }
 }
 
+function prepareAutomaticCaptureSummary(session: GuidedCaptureSession): void {
+  if (session.automaticBoundary?.kind !== "days") return;
+  const startedAt = session.automaticStartedAt;
+  const trustedTimestamps = session.items.map((item) =>
+    item.value.captureTimestampMethod === "metadata"
+      ? item.value.timestamp
+      : undefined,
+  );
+  const startIndex = startedAt
+    ? automaticDateBoundaryStartIndex(
+        trustedTimestamps,
+        session.automaticBoundary,
+        startedAt,
+      )
+    : null;
+  const everyRetainedDateIsTrusted = trustedTimestamps.every(
+    (timestamp) =>
+      Boolean(timestamp) && Number.isFinite(Date.parse(timestamp!)),
+  );
+  if (!startedAt || (startIndex === null && !everyRetainedDateIsTrusted)) {
+    throw new Error(
+      "The selected date boundary could not be verified from WhatsApp date metadata. Nothing was sent.",
+    );
+  }
+  if (startIndex !== null) {
+    retainAutomaticItems(session, session.items.slice(startIndex));
+  }
+}
+
 async function runAutomaticCapture(
   session: GuidedCaptureSession,
 ): Promise<void> {
@@ -2369,7 +2404,7 @@ async function finalizeAutomaticCaptureOperation(
   }
   const summary = await finalizeGuidedCaptureOperation(
     operationId,
-    trimAutomaticDateBoundary,
+    prepareAutomaticCaptureSummary,
   );
   if (summary.extractedCount === 0) {
     throw new Error(

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -201,6 +201,7 @@ interface GuidedCaptureSession {
   originalScrollTop?: number;
   originalBottomOffset?: number;
   noProgressCount: number;
+  observedWindowCount: number;
 }
 
 const GUIDED_CAPTURE_LIMIT = 2_000;
@@ -1842,6 +1843,7 @@ function hasVerifiedTopOfHistory(scrollTarget: HTMLElement): boolean {
 
 async function waitForAutomaticStabilization(
   session: GuidedCaptureSession,
+  baselineObservedWindowCount: number,
 ): Promise<void> {
   const started = Date.now();
   let previousTop = session.scrollTarget.scrollTop;
@@ -1857,7 +1859,13 @@ async function waitForAutomaticStabilization(
     );
     const nextTop = session.scrollTarget.scrollTop;
     const nextHeight = session.scrollTarget.scrollHeight;
-    if (nextTop === previousTop && nextHeight === previousHeight) {
+    const observedChange =
+      session.observedWindowCount > baselineObservedWindowCount;
+    if (
+      observedChange &&
+      nextTop === previousTop &&
+      nextHeight === previousHeight
+    ) {
       stableSamples += 1;
       if (stableSamples >= 2) return;
     } else {
@@ -1987,13 +1995,14 @@ async function runAutomaticCapture(
     const beforeTop = session.scrollTarget.scrollTop;
     const beforeHeight = session.scrollTarget.scrollHeight;
     const beforeCount = session.items.length;
+    const beforeObservedWindowCount = session.observedWindowCount;
     const step = Math.max(
       320,
       Math.floor(session.scrollTarget.clientHeight * 0.8),
     );
     session.scrollTarget.scrollTop = Math.max(0, beforeTop - step);
     queueGuidedWindowRead();
-    await waitForAutomaticStabilization(session);
+    await waitForAutomaticStabilization(session, beforeObservedWindowCount);
     if (session.drainPromise) await session.drainPromise;
     if (guidedCaptureSession !== session || session.finalizing) return;
 
@@ -2025,6 +2034,7 @@ async function runAutomaticCapture(
 function queueGuidedWindowRead(): void {
   const session = guidedCaptureSession;
   if (!session || session.finalizing) return;
+  session.observedWindowCount += 1;
   // Start extraction in the observer callback so the current virtualized DOM
   // window is snapshotted before WhatsApp can replace it. The promises are
   // merged in FIFO order to keep progress updates and retained order stable.
@@ -2182,6 +2192,7 @@ async function startGuidedCaptureOperation(
     limitReached: false,
     automaticPaused: false,
     noProgressCount: 0,
+    observedWindowCount: 0,
   };
   guidedCaptureSession = session;
   return summarizeCapturePayload(

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -197,7 +197,7 @@ interface GuidedCaptureSession {
   limitReached: boolean;
   automaticBoundary?: AutomaticCaptureBoundary;
   automaticStartedAt?: Date;
-  automaticDateBoundaryProven: boolean;
+  automaticDateBoundaryProofItems?: GuidedWindowItem<ExtractedMessage>[];
   automaticPaused: boolean;
   automaticRunner?: Promise<void>;
   originalScrollTop?: number;
@@ -1996,14 +1996,20 @@ function trimAutomaticDateBoundary(session: GuidedCaptureSession): void {
     session.automaticStartedAt,
   );
   if (startIndex !== null) {
-    session.automaticDateBoundaryProven = true;
     retainAutomaticItems(session, session.items.slice(startIndex));
+    session.automaticDateBoundaryProofItems = [...session.items];
   }
 }
 
 function prepareAutomaticCaptureSummary(session: GuidedCaptureSession): void {
   if (session.automaticBoundary?.kind !== "days") return;
-  if (session.automaticDateBoundaryProven) return;
+  const provenItems = session.automaticDateBoundaryProofItems;
+  if (
+    provenItems?.length === session.items.length &&
+    provenItems.every((item, index) => item === session.items[index])
+  ) {
+    return;
+  }
   const startedAt = session.automaticStartedAt;
   const trustedTimestamps = session.items.map((item) =>
     item.value.captureTimestampMethod === "metadata"
@@ -2027,8 +2033,8 @@ function prepareAutomaticCaptureSummary(session: GuidedCaptureSession): void {
     );
   }
   if (startIndex !== null) {
-    session.automaticDateBoundaryProven = true;
     retainAutomaticItems(session, session.items.slice(startIndex));
+    session.automaticDateBoundaryProofItems = [...session.items];
   }
 }
 
@@ -2261,7 +2267,6 @@ async function startGuidedCaptureOperation(
     finalizing: false,
     limitReached: false,
     automaticPaused: false,
-    automaticDateBoundaryProven: false,
     noProgressCount: 0,
     observedWindowCount: 0,
   };

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -2034,12 +2034,18 @@ async function runAutomaticCapture(
 function queueGuidedWindowRead(): void {
   const session = guidedCaptureSession;
   if (!session || session.finalizing) return;
-  session.observedWindowCount += 1;
   // Start extraction in the observer callback so the current virtualized DOM
   // window is snapshotted before WhatsApp can replace it. The promises are
   // merged in FIFO order to keep progress updates and retained order stable.
   session.pendingWindows.push(extractCurrentChat(true).catch(() => null));
   startGuidedWindowDrain(session);
+}
+
+function queueObservedGuidedWindowRead(): void {
+  const session = guidedCaptureSession;
+  if (!session || session.finalizing) return;
+  session.observedWindowCount += 1;
+  queueGuidedWindowRead();
 }
 
 function startGuidedWindowDrain(session: GuidedCaptureSession): void {
@@ -2165,7 +2171,7 @@ async function startGuidedCaptureOperation(
       initialPayload.messages.length -
       unreadableCount,
   );
-  const observer = new MutationObserver(queueGuidedWindowRead);
+  const observer = new MutationObserver(queueObservedGuidedWindowRead);
   const scrollTarget =
     mode === "automatic"
       ? resolveAutomaticScrollTarget(messageList)

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1321,7 +1321,7 @@ function renderPageGuidedProgress(operation: CaptureOperationSnapshot): void {
       : "Scroll upward in this chat. ConvoLens will retain each message window before WhatsApp removes it.";
   }
   if (pauseButton) {
-    pauseButton.hidden = !automatic;
+    pauseButton.hidden = !automatic || !operation.automaticControlsReady;
     pauseButton.textContent = operation.state === "paused" ? "Resume" : "Pause";
   }
   const count = document.getElementById("ws-guided-count");

--- a/apps/chrome-extension/tests/automatic-capture.test.ts
+++ b/apps/chrome-extension/tests/automatic-capture.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AUTOMATIC_CAPTURE_SAFETY_CAP,
+  automaticBoundaryStopReason,
+  normalizeAutomaticBoundary,
+} from "../src/automatic-capture";
+
+test("normalizes automatic message boundaries within the safety cap", () => {
+  assert.deepEqual(
+    normalizeAutomaticBoundary({ kind: "messages", messageLimit: 900 }),
+    { kind: "messages", messageLimit: AUTOMATIC_CAPTURE_SAFETY_CAP },
+  );
+  assert.deepEqual(normalizeAutomaticBoundary(undefined), {
+    kind: "verified-top",
+  });
+});
+
+test("stops date capture only from a trusted oldest timestamp", () => {
+  const startedAt = new Date("2026-07-29T12:00:00.000Z");
+  const boundary = { kind: "days", days: 7 } as const;
+  assert.equal(
+    automaticBoundaryStopReason({
+      boundary,
+      extractedCount: 20,
+      oldestTrustedTimestamp: "2026-07-21T11:59:59.000Z",
+      verifiedTop: false,
+      startedAt,
+    }),
+    "automatic-date-boundary",
+  );
+  assert.equal(
+    automaticBoundaryStopReason({
+      boundary,
+      extractedCount: 20,
+      verifiedTop: false,
+      startedAt,
+    }),
+    null,
+  );
+});
+
+test("distinguishes message, verified-top, and safety-cap completion", () => {
+  const startedAt = new Date("2026-07-29T12:00:00.000Z");
+  assert.equal(
+    automaticBoundaryStopReason({
+      boundary: { kind: "messages", messageLimit: 100 },
+      extractedCount: 100,
+      verifiedTop: false,
+      startedAt,
+    }),
+    "automatic-message-limit",
+  );
+  assert.equal(
+    automaticBoundaryStopReason({
+      boundary: { kind: "verified-top" },
+      extractedCount: 40,
+      verifiedTop: true,
+      startedAt,
+    }),
+    "automatic-verified-top",
+  );
+  assert.equal(
+    automaticBoundaryStopReason({
+      boundary: { kind: "messages", messageLimit: 500 },
+      extractedCount: 500,
+      verifiedTop: false,
+      startedAt,
+    }),
+    "automatic-safety-cap",
+  );
+});

--- a/apps/chrome-extension/tests/automatic-capture.test.ts
+++ b/apps/chrome-extension/tests/automatic-capture.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   AUTOMATIC_CAPTURE_SAFETY_CAP,
   automaticBoundaryStopReason,
+  automaticDateBoundaryStartIndex,
   normalizeAutomaticBoundary,
 } from "../src/automatic-capture";
 
@@ -16,13 +17,29 @@ test("normalizes automatic message boundaries within the safety cap", () => {
   });
 });
 
+test("trims a boundary-spanning window after the last trusted old message", () => {
+  assert.equal(
+    automaticDateBoundaryStartIndex(
+      [
+        "2026-07-20T12:00:00.000Z",
+        undefined,
+        "2026-07-21T12:00:01.000Z",
+        "2026-07-24T12:00:00.000Z",
+      ],
+      { kind: "days", days: 7 },
+      new Date("2026-07-29T12:00:00.000Z"),
+    ),
+    3,
+  );
+});
+
 test("stops date capture only from a trusted oldest timestamp", () => {
   const startedAt = new Date("2026-07-29T12:00:00.000Z");
   const boundary = { kind: "days", days: 7 } as const;
   assert.equal(
     automaticBoundaryStopReason({
       boundary,
-      extractedCount: 20,
+      extractedCount: AUTOMATIC_CAPTURE_SAFETY_CAP,
       oldestTrustedTimestamp: "2026-07-21T11:59:59.000Z",
       verifiedTop: false,
       startedAt,

--- a/apps/chrome-extension/tests/automatic-capture.test.ts
+++ b/apps/chrome-extension/tests/automatic-capture.test.ts
@@ -44,9 +44,20 @@ test("trims a boundary-spanning window after the last trusted old message", () =
         "2026-07-24T12:00:00.000Z",
       ],
       { kind: "days", days: 7 },
-      new Date("2026-07-29T12:00:00.000Z"),
+      new Date(2026, 6, 29, 12, 0, 0, 0),
     ),
     3,
+  );
+});
+
+test("trims the untrusted gap through the first trusted in-range anchor", () => {
+  assert.equal(
+    automaticDateBoundaryStartIndex(
+      ["2026-07-22T11:00:00.000Z", undefined, "2026-07-22T12:30:00.000Z"],
+      { kind: "days", days: 7 },
+      new Date(2026, 6, 29, 12, 0, 0, 0),
+    ),
+    2,
   );
 });
 

--- a/apps/chrome-extension/tests/automatic-capture.test.ts
+++ b/apps/chrome-extension/tests/automatic-capture.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   AUTOMATIC_CAPTURE_SAFETY_CAP,
   automaticBoundaryStopReason,
+  automaticDateCutoff,
   automaticDateBoundaryStartIndex,
   normalizeAutomaticBoundary,
 } from "../src/automatic-capture";
@@ -15,6 +16,22 @@ test("normalizes automatic message boundaries within the safety cap", () => {
   assert.deepEqual(normalizeAutomaticBoundary(undefined), {
     kind: "verified-top",
   });
+});
+
+test("aligns the cutoff with WhatsApp wall-clock timestamps", () => {
+  const startedAt = new Date("2026-07-28T13:00:00.000Z");
+  startedAt.getFullYear = () => 2026;
+  startedAt.getMonth = () => 6;
+  startedAt.getDate = () => 29;
+  startedAt.getHours = () => 1;
+  startedAt.getMinutes = () => 0;
+  startedAt.getSeconds = () => 0;
+  startedAt.getMilliseconds = () => 0;
+
+  assert.equal(
+    automaticDateCutoff({ kind: "days", days: 7 }, startedAt),
+    Date.UTC(2026, 6, 22, 1, 0, 0, 0),
+  );
 });
 
 test("trims a boundary-spanning window after the last trusted old message", () => {

--- a/apps/chrome-extension/tests/phase5-preview.test.ts
+++ b/apps/chrome-extension/tests/phase5-preview.test.ts
@@ -39,13 +39,14 @@ test("renders an ephemeral exact-count preview in both capture surfaces", () => 
   );
 });
 
-test("enables guided capture while keeping automatic mode disabled", () => {
+test("offers all capture modes while requiring explicit automatic scroll consent", () => {
   for (const surface of [popupHtml, contentSource]) {
     assert.match(surface, /Capture as I scroll/);
     assert.match(surface, /Available/);
     assert.match(surface, /Load older messages for me/);
-    assert.match(surface, /Soon · Phase 7/);
-    assert.match(surface, /value="automatic"[\s\S]{0,40}disabled/);
+    assert.match(surface, /value="automatic"/);
+    assert.match(surface, /WhatsApp will scroll/);
+    assert.doesNotMatch(surface, /value="automatic"[\s\S]{0,40}disabled/);
   }
   assert.match(popupHtml, /value="loaded"[\s\S]{0,40}checked/);
   assert.match(contentSource, /value="loaded"[\s\S]{0,40}checked/);

--- a/apps/chrome-extension/tests/phase6-guided-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase6-guided-lifecycle.test.ts
@@ -107,7 +107,10 @@ test("preserves the requested mode after launcher cancellation renders", () => {
 });
 
 test("keeps guided capture user-controlled while automatic capture owns its scroll", () => {
-  assert.match(contentSource, /new MutationObserver\(queueGuidedWindowRead\)/);
+  assert.match(
+    contentSource,
+    /new MutationObserver\(queueObservedGuidedWindowRead\)/,
+  );
   assert.match(
     contentSource,
     /addEventListener\("scroll", queueGuidedWindowRead/,

--- a/apps/chrome-extension/tests/phase6-guided-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase6-guided-lifecycle.test.ts
@@ -12,12 +12,15 @@ const popupHtml = read("../popup/popup.html");
 const popupSource = read("../popup/popup.js");
 
 test("keeps the background as owner of guided progress and finalization", () => {
-  assert.match(captureSource, /CaptureOperationMode = "loaded" \| "guided"/);
+  assert.match(
+    captureSource,
+    /CaptureOperationMode = "loaded" \| "guided" \| "automatic"/,
+  );
   assert.match(backgroundSource, /case "UPDATE_GUIDED_CAPTURE_OPERATION"/);
   assert.match(backgroundSource, /case "STOP_GUIDED_CAPTURE_OPERATION"/);
   assert.match(
     backgroundSource,
-    /state: operation\.mode === "guided" \? "collecting"/,
+    /state: operation\.mode === "loaded" \? "ready-for-review" : "collecting"/,
   );
   assert.match(backgroundSource, /action: "FINALIZE_GUIDED_CAPTURE_OPERATION"/);
   assert.match(backgroundSource, /state: "ready-for-review"/);
@@ -65,17 +68,17 @@ test("offers start, running count, stop-and-review, and cancel on both surfaces"
     assert.match(surface, /Stop and review/);
     assert.match(surface, /Guided capture is active/);
   }
-  assert.match(popupSource, /mode === "guided" \? "Start guided capture"/);
-  assert.match(popupSource, /action: "STOP_GUIDED_CAPTURE_OPERATION"/);
+  assert.match(popupSource, /"Start guided capture"/);
+  assert.match(popupSource, /STOP_GUIDED_CAPTURE_OPERATION/);
   assert.match(contentSource, /selectedPageCaptureMode/);
-  assert.match(contentSource, /stopPageGuidedCapture/);
+  assert.match(contentSource, /stopPageCollection/);
 });
 
 test("preserves the requested mode after popup cancellation renders", () => {
   assert.match(popupSource, /captureModeChangeGeneration/);
   assert.match(
     popupSource,
-    /\[\s*"inspecting",\s*"collecting",\s*"ready-for-review",\s*"retry-required",?\s*\]/,
+    /\[\s*"inspecting",\s*"collecting",\s*"paused",\s*"ready-for-review",\s*"retry-required",?\s*\]/,
   );
   assert.match(
     popupSource,
@@ -87,7 +90,7 @@ test("preserves the requested mode after launcher cancellation renders", () => {
   assert.match(contentSource, /launcherModeChangeGeneration/);
   assert.match(
     contentSource,
-    /\[\s*"inspecting",\s*"collecting",\s*"ready-for-review",\s*"retry-required",?\s*\]/,
+    /\[\s*"inspecting",\s*"collecting",\s*"paused",\s*"ready-for-review",\s*"retry-required",?\s*\]/,
   );
   assert.match(
     contentSource,
@@ -103,13 +106,18 @@ test("preserves the requested mode after launcher cancellation renders", () => {
   );
 });
 
-test("observes user scrolling without programmatically taking scroll control", () => {
+test("keeps guided capture user-controlled while automatic capture owns its scroll", () => {
   assert.match(contentSource, /new MutationObserver\(queueGuidedWindowRead\)/);
   assert.match(
     contentSource,
     /addEventListener\("scroll", queueGuidedWindowRead/,
   );
-  assert.doesNotMatch(contentSource, /scrollTop\s*=/);
+  const guidedActivation = contentSource.slice(
+    contentSource.indexOf("function activateGuidedCaptureOperation"),
+    contentSource.indexOf("function activateAutomaticCaptureOperation"),
+  );
+  assert.doesNotMatch(guidedActivation, /scrollTop\s*=/);
+  assert.match(contentSource, /session\.scrollTarget\.scrollTop = Math\.max/);
   assert.doesNotMatch(contentSource, /scrollTo\(/);
 });
 

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -77,6 +77,15 @@ test("bounds automatic collection and distinguishes truthful completion", () => 
     contentSource,
     /session\.observedWindowCount > baselineObservedWindowCount/,
   );
+  assert.match(
+    contentSource,
+    /function queueObservedGuidedWindowRead[\s\S]*session\.observedWindowCount \+= 1[\s\S]*queueGuidedWindowRead\(\)/,
+  );
+  const eagerQueue = contentSource.slice(
+    contentSource.indexOf("function queueGuidedWindowRead"),
+    contentSource.indexOf("function queueObservedGuidedWindowRead"),
+  );
+  assert.doesNotMatch(eagerQueue, /observedWindowCount/);
   for (const reason of [
     "automatic-date-boundary",
     "automatic-message-limit",

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -144,7 +144,7 @@ test("trims date boundaries after queued work drains on every finalization", () 
   );
   assert.match(
     contentSource,
-    /finalizeAutomaticCaptureOperation[\s\S]*finalizeGuidedCaptureOperation\(\s*operationId,\s*trimAutomaticDateBoundary/,
+    /finalizeAutomaticCaptureOperation[\s\S]*finalizeGuidedCaptureOperation\(\s*operationId,\s*prepareAutomaticCaptureSummary/,
   );
 });
 
@@ -179,5 +179,27 @@ test("publishes automatic pause controls only after runner activation", () => {
   assert.match(
     contentSource,
     /pauseButton\.hidden = !automatic \|\| !operation\.automaticControlsReady/,
+  );
+});
+
+test("fails closed when a date scope cannot be proven", () => {
+  assert.match(
+    contentSource,
+    /function prepareAutomaticCaptureSummary[\s\S]*automaticDateBoundaryStartIndex[\s\S]*trustedTimestamps\.every[\s\S]*selected date boundary could not be verified from WhatsApp date metadata\. Nothing was sent\./,
+  );
+  assert.match(
+    contentSource,
+    /finalizeAutomaticCaptureOperation[\s\S]*prepareAutomaticCaptureSummary/,
+  );
+});
+
+test("keeps stop-and-review hidden until automatic activation", () => {
+  assert.match(
+    popupSource,
+    /stopGuidedCapture\.hidden =[\s\S]*automatic && !operation\.automaticControlsReady/,
+  );
+  assert.match(
+    contentSource,
+    /stopButton\.hidden = automatic && !operation\.automaticControlsReady/,
   );
 });

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -214,11 +214,17 @@ test("prefers a proven date boundary when the same merge reaches the cap", () =>
 test("preserves trusted date-boundary proof through early trimming", () => {
   assert.match(
     contentSource,
-    /function trimAutomaticDateBoundary[\s\S]*automaticDateBoundaryProven = true[\s\S]*retainAutomaticItems/,
+    /function trimAutomaticDateBoundary[\s\S]*retainAutomaticItems[\s\S]*automaticDateBoundaryProofItems = \[\.\.\.session\.items\]/,
   );
   assert.match(
     contentSource,
-    /function prepareAutomaticCaptureSummary[\s\S]*if \(session\.automaticDateBoundaryProven\) return/,
+    /function prepareAutomaticCaptureSummary[\s\S]*provenItems\?\.length === session\.items\.length[\s\S]*provenItems\.every\(\(item, index\) => item === session\.items\[index\]\)/,
   );
-  assert.match(contentSource, /automaticDateBoundaryProven: false/);
+});
+
+test("revalidates date proof whenever the retained item sequence changes", () => {
+  assert.match(
+    contentSource,
+    /provenItems\.every\(\(item, index\) => item === session\.items\[index\]\)[\s\S]*automaticDateBoundaryStartIndex/,
+  );
 });

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -36,6 +36,14 @@ test("keeps automatic control background-owned and serializes every command", ()
     /command === "pause" \|\| message\.command === "resume"/,
   );
   assert.match(
+    contentSource,
+    /if \(paused\) \{[\s\S]*session\.observer\.disconnect\(\)[\s\S]*await session\.drainPromise/,
+  );
+  assert.match(
+    contentSource,
+    /session\.observer\.observe\(session\.scrollTarget/,
+  );
+  assert.match(
     backgroundSource,
     /action: "FINALIZE_AUTOMATIC_CAPTURE_OPERATION"/,
   );

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -136,3 +136,14 @@ test("cancels rather than offering an empty automatic review", () => {
     /finalizeAutomaticCaptureOperation[\s\S]*summary\.extractedCount === 0[\s\S]*No readable messages fall within the selected automatic boundary\. Nothing was sent\./,
   );
 });
+
+test("trims date boundaries after queued work drains on every finalization", () => {
+  assert.match(
+    contentSource,
+    /if \(session\.drainPromise\) await session\.drainPromise;[\s\S]*prepareSummary\?\.\(session\);[\s\S]*summarizeCapturePayload/,
+  );
+  assert.match(
+    contentSource,
+    /finalizeAutomaticCaptureOperation[\s\S]*finalizeGuidedCaptureOperation\(\s*operationId,\s*trimAutomaticDateBoundary/,
+  );
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -210,3 +210,15 @@ test("prefers a proven date boundary when the same merge reaches the cap", () =>
     /if \(session\.limitReached\)[\s\S]*automaticBoundaryReason\(session, false\) \?\?[\s\S]*automaticLimitStopReason\(session\)/,
   );
 });
+
+test("preserves trusted date-boundary proof through early trimming", () => {
+  assert.match(
+    contentSource,
+    /function trimAutomaticDateBoundary[\s\S]*automaticDateBoundaryProven = true[\s\S]*retainAutomaticItems/,
+  );
+  assert.match(
+    contentSource,
+    /function prepareAutomaticCaptureSummary[\s\S]*if \(session\.automaticDateBoundaryProven\) return/,
+  );
+  assert.match(contentSource, /automaticDateBoundaryProven: false/);
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -44,6 +44,10 @@ test("keeps automatic control background-owned and serializes every command", ()
     /session\.observer\.observe\(session\.scrollTarget/,
   );
   assert.match(
+    contentSource,
+    /if \(session\.drainPromise\) await session\.drainPromise;[\s\S]*if \(session\.automaticPaused\) continue/,
+  );
+  assert.match(
     backgroundSource,
     /action: "FINALIZE_AUTOMATIC_CAPTURE_OPERATION"/,
   );
@@ -113,4 +117,15 @@ test("restores an approximate anchor and retains raw messages only in tab memory
     /\[STORAGE_KEYS\.captureOperations\]: Object\.fromEntries\(captureOperations\)/,
   );
   assert.doesNotMatch(captureSource, /messages:/);
+});
+
+test("rebuilds trimmed diagnostics from only the retained readable payload", () => {
+  assert.match(
+    contentSource,
+    /function retainAutomaticItems[\s\S]*session\.skippedCount = 0[\s\S]*session\.unreadableCount = 0/,
+  );
+  assert.match(
+    contentSource,
+    /messageContainerCount: session\.payload\.messages\.length[\s\S]*unreadableMessageCount: 0/,
+  );
 });

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -73,6 +73,10 @@ test("bounds automatic collection and distinguishes truthful completion", () => 
   assert.match(contentSource, /AUTOMATIC_NO_PROGRESS_LIMIT/);
   assert.match(contentSource, /hasVerifiedTopOfHistory/);
   assert.match(contentSource, /waitForAutomaticStabilization/);
+  assert.match(
+    contentSource,
+    /session\.observedWindowCount > baselineObservedWindowCount/,
+  );
   for (const reason of [
     "automatic-date-boundary",
     "automatic-message-limit",

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -129,3 +129,10 @@ test("rebuilds trimmed diagnostics from only the retained readable payload", () 
     /messageContainerCount: session\.payload\.messages\.length[\s\S]*unreadableMessageCount: 0/,
   );
 });
+
+test("cancels rather than offering an empty automatic review", () => {
+  assert.match(
+    contentSource,
+    /finalizeAutomaticCaptureOperation[\s\S]*summary\.extractedCount === 0[\s\S]*No readable messages fall within the selected automatic boundary\. Nothing was sent\./,
+  );
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -203,3 +203,10 @@ test("keeps stop-and-review hidden until automatic activation", () => {
     /stopButton\.hidden = automatic && !operation\.automaticControlsReady/,
   );
 });
+
+test("prefers a proven date boundary when the same merge reaches the cap", () => {
+  assert.match(
+    contentSource,
+    /if \(session\.limitReached\)[\s\S]*automaticBoundaryReason\(session, false\) \?\?[\s\S]*automaticLimitStopReason\(session\)/,
+  );
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -147,3 +147,18 @@ test("trims date boundaries after queued work drains on every finalization", () 
     /finalizeAutomaticCaptureOperation[\s\S]*finalizeGuidedCaptureOperation\(\s*operationId,\s*trimAutomaticDateBoundary/,
   );
 });
+
+test("keeps alignment warnings only while their ambiguous candidates remain", () => {
+  assert.match(
+    contentSource,
+    /retainedAmbiguousItems = incomingItems\.filter[\s\S]*session\.alignmentWarnings\.push\(retainedAmbiguousItems\)/,
+  );
+  assert.match(
+    contentSource,
+    /function reconcileGuidedAlignmentWarnings[\s\S]*warningItems\.some\(\(item\) => retainedItems\.has\(item\)\)[\s\S]*alignmentWarningCount = session\.alignmentWarnings\.length/,
+  );
+  assert.match(
+    contentSource,
+    /function retainAutomaticItems[\s\S]*reconcileGuidedAlignmentWarnings\(session\)/,
+  );
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path: string) =>
+  readFileSync(new URL(path, import.meta.url), "utf8");
+
+const backgroundSource = read("../src/background.ts");
+const captureSource = read("../src/capture-operation.ts");
+const contentSource = read("../src/content.ts");
+const popupHtml = read("../popup/popup.html");
+const popupSource = read("../popup/popup.js");
+
+test("requires explicit consent and exposes bounded automatic choices", () => {
+  for (const surface of [popupHtml, contentSource]) {
+    assert.match(surface, /last 7 days/i);
+    assert.match(surface, /last 30 days/i);
+    assert.match(surface, /100 messages/);
+    assert.match(surface, /250 messages/);
+    assert.match(surface, /500 messages/);
+    assert.match(surface, /Verified top of (?:history|conversation)/);
+    assert.match(surface, /WhatsApp will scroll/);
+  }
+  assert.match(popupSource, /automaticConsent\.checked/);
+  assert.match(contentSource, /ws-automatic-consent/);
+});
+
+test("keeps automatic control background-owned and serializes every command", () => {
+  assert.match(backgroundSource, /case "CONTROL_AUTOMATIC_CAPTURE_OPERATION"/);
+  assert.match(
+    backgroundSource,
+    /const previous = automaticControlPromises\.get[\s\S]*previous\.catch[\s\S]*controlAutomaticCaptureOperation/,
+  );
+  assert.match(
+    backgroundSource,
+    /command === "pause" \|\| message\.command === "resume"/,
+  );
+  assert.match(
+    backgroundSource,
+    /action: "FINALIZE_AUTOMATIC_CAPTURE_OPERATION"/,
+  );
+  assert.match(captureSource, /\| "paused"/);
+});
+
+test("supports pause, resume, stop-and-review, and cancel on both surfaces", () => {
+  for (const surface of [popupHtml, contentSource]) {
+    assert.match(surface, />\s*Pause/);
+    assert.match(surface, /Stop and review/);
+    assert.match(surface, />Cancel</);
+  }
+  assert.match(
+    popupSource,
+    /command: currentOperation\.state === "paused" \? "resume" : "pause"/,
+  );
+  assert.match(
+    contentSource,
+    /command: operation\.state === "paused" \? "resume" : "pause"/,
+  );
+  assert.match(popupSource, /stopReason: "automatic-user-stopped"/);
+  assert.match(contentSource, /stopReason: "automatic-user-stopped"/);
+});
+
+test("bounds automatic collection and distinguishes truthful completion", () => {
+  assert.match(contentSource, /AUTOMATIC_CAPTURE_SAFETY_CAP/);
+  assert.match(contentSource, /AUTOMATIC_NO_PROGRESS_LIMIT/);
+  assert.match(contentSource, /hasVerifiedTopOfHistory/);
+  assert.match(contentSource, /waitForAutomaticStabilization/);
+  for (const reason of [
+    "automatic-date-boundary",
+    "automatic-message-limit",
+    "automatic-verified-top",
+    "automatic-safety-cap",
+    "automatic-no-progress",
+    "automatic-dom-failure",
+  ]) {
+    assert.match(
+      captureSource + backgroundSource + contentSource,
+      new RegExp(reason),
+    );
+  }
+});
+
+test("restores an approximate anchor and retains raw messages only in tab memory", () => {
+  assert.match(contentSource, /originalBottomOffset/);
+  assert.match(contentSource, /restoreAutomaticScrollAnchor/);
+  assert.match(
+    contentSource,
+    /getCurrentChatIdentity\(\) !== session\.chatIdentity/,
+  );
+  assert.match(
+    backgroundSource,
+    /\[STORAGE_KEYS\.captureOperations\]: Object\.fromEntries\(captureOperations\)/,
+  );
+  assert.doesNotMatch(captureSource, /messages:/);
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -228,3 +228,14 @@ test("revalidates date proof whenever the retained item sequence changes", () =>
     /provenItems\.every\(\(item, index\) => item === session\.items\[index\]\)[\s\S]*automaticDateBoundaryStartIndex/,
   );
 });
+
+test("an ambiguous no-add merge cannot claim the selected limit", () => {
+  assert.match(
+    contentSource,
+    /items: session\.items,[\s\S]*addedCount: 0,[\s\S]*ambiguous: true,[\s\S]*limitReached: false/,
+  );
+  assert.match(
+    contentSource,
+    /merge\.limitReached &&[\s\S]*session\.items\.length >= session\.captureLimit[\s\S]*session\.limitReached = true/,
+  );
+});

--- a/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
+++ b/apps/chrome-extension/tests/phase7-automatic-lifecycle.test.ts
@@ -162,3 +162,22 @@ test("keeps alignment warnings only while their ambiguous candidates remain", ()
     /function retainAutomaticItems[\s\S]*reconcileGuidedAlignmentWarnings\(session\)/,
   );
 });
+
+test("publishes automatic pause controls only after runner activation", () => {
+  assert.match(
+    backgroundSource,
+    /ACTIVATE_AUTOMATIC_CAPTURE_OPERATION[\s\S]*activation\.success[\s\S]*automaticControlsReady: true[\s\S]*publishCaptureOperation\(operation\)/,
+  );
+  assert.match(
+    backgroundSource,
+    /message\.command === "pause" \|\| message\.command === "resume"[\s\S]*!operation\.automaticControlsReady/,
+  );
+  assert.match(
+    popupSource,
+    /pauseAutomaticCapture\.hidden =[\s\S]*!operation\.automaticControlsReady/,
+  );
+  assert.match(
+    contentSource,
+    /pauseButton\.hidden = !automatic \|\| !operation\.automaticControlsReady/,
+  );
+});

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.17");
+  assert.equal(manifest.version, "1.0.18");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -11,6 +11,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Date cutoffs use the same timezone-less wall-clock representation as WhatsApp's displayed metadata, preventing browser timezone offsets from widening or narrowing the selected range.
 - A date-scoped review fails closed unless the trusted cutoff was crossed or every retained message has a valid trusted in-range metadata date; unproven visible-time/fallback ranges cancel with nothing sent.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
+- Any untrusted gap after that excluded message is also discarded through the first trusted in-range anchor; without an in-range anchor, the scope trims to empty and cancels.
 - The trusted-date trim runs after queued snapshots drain for every automatic finalization, including user stop-and-review while loading or paused.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
@@ -42,13 +43,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 118 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 119 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `BEBAF938D6E982206522CBBD2F9625C2847508B942E30F15DE62D1646A00A084`.
+- Packaged ZIP SHA-256: `9505D101363066EBE366850E517ED7B98A828EAC2194BCFB99620BA6C19FF72D`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -1,0 +1,51 @@
+# ConvoLens extension capture Phase 7 handoff — 2026-07-28
+
+## Outcome
+
+Phase 7 enables explicitly confirmed automatic older-history loading while retaining the Phase 6 review, accumulator, and privacy boundaries.
+
+- `Load older messages for me` is available in both the popup and WhatsApp launcher.
+- Starting automatic capture requires an explicit acknowledgement that WhatsApp will scroll the selected chat.
+- Operators can select the last 7 days, last 30 days, 100/250/500 messages, or a verified top-of-history marker. Every automatic run is capped at 500 retained messages.
+- Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
+- Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
+- Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
+- Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
+- Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
+- Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
+- Cancellation, chat change, tab teardown, authentication transition, or background restart remains fail-closed and sends nothing.
+- The original bottom-relative scroll position is captured before automatic movement and approximately restored only while the same chat remains selected.
+- The background service worker persists only aggregate operation snapshots, including the selected boundary and progress counts. Raw messages, raw WhatsApp IDs, and alignment evidence remain in the WhatsApp tab's memory.
+- Final upload still requires exact-count review and explicit confirmation. Automatic completion never uploads by itself.
+- Extension runtime and package metadata are synchronized at `1.0.18`.
+
+## Repository state
+
+- Base: `origin/main` at `f85eac938d9dac746e6c84bfad0063b2141b7cd5` (merged PR #154).
+- Branch: `agent/extension-capture-phase7`.
+- Worktree: `C:/tmp/convolens-extension-phase7`.
+- Pull request: pending.
+- The primary checkout and its pre-existing untracked handoff remain untouched.
+
+## Validation
+
+- Chrome extension Node tests: 108 passed, 0 failed, including automatic boundary normalization, trusted-date gating, consent and controls on both surfaces, serialized background controls, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension TypeScript: passed.
+- Prettier and `git diff --check`: passed.
+- Repository Turbo build: 8 of 8 packages passed.
+- Production extension build and package: passed.
+- Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
+- Packaged ZIP SHA-256: `0218880B840524CFE8707ED9D306B329D275CB08B97CA6631B3C7D591E01DCE9`.
+- No visual or authentic WhatsApp acceptance is claimed.
+
+## Boundaries still open
+
+- No extension, API, web, database, or Azure deployment is included.
+- No authentic WhatsApp automatic-scroll, connected-send, popup-close, navigation, persistence, deduplication, restart, isolation, deletion, scroll-anchor, or console-attribution evidence is claimed.
+- A verified top is reported only when a conservative WhatsApp marker is visible at scroll position zero; no-progress is not promoted to top-of-history proof.
+- Approximate anchor restoration cannot guarantee WhatsApp retained identical virtualization geometry.
+- No durable offline raw-message queue is introduced.
+
+## Continuation
+
+After Phase 7 is reviewed and merged, begin Phase 8 from current `origin/main` and keep authentic WhatsApp acceptance operator-held.

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -8,6 +8,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Starting automatic capture requires an explicit acknowledgement that WhatsApp will scroll the selected chat.
 - Operators can select the last 7 days, last 30 days, 100/250/500 messages, or a verified top-of-history marker. Every automatic run is capped at 500 retained messages.
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
+- Date cutoffs use the same timezone-less wall-clock representation as WhatsApp's displayed metadata, preventing browser timezone offsets from widening or narrowing the selected range.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
@@ -35,13 +36,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 111 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 112 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and boundary-spanning cutoff trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `DCE2F909DA8800BACE2768945EB33F185486624C3508C63F233E24FF6874C0D8`.
+- Packaged ZIP SHA-256: `3D6604668ECE14DC7E6F2C8036C6F8410DCE45D7295CB52180C80D5B4F9D7B7C`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -17,6 +17,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
+- When one merge proves a date cutoff and also reaches the cap, the truthful date-boundary reason takes precedence before the out-of-range prefix is trimmed.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
 - Pause is published only after the content-side automatic runner has activated; pre-activation control messages are inert and cannot strand a capture without a runner.
 - Stop-and-review is also hidden until activation; Cancel remains available throughout startup.
@@ -41,13 +42,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 117 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 118 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `D0F4F56E0686444147D0AB5F54E4F8BE5F8D40881819C1352E024E80DFC21B32`.
+- Packaged ZIP SHA-256: `BEBAF938D6E982206522CBBD2F9625C2847508B942E30F15DE62D1646A00A084`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -16,9 +16,11 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
 - Pause disconnects DOM observation and drains already-snapshotted work before it is acknowledged; resume reconnects observation before automatic scrolling continues.
+- The runner rechecks pause after stabilization and draining, before any boundary or no-progress completion can be emitted.
 - Cancellation, chat change, tab teardown, authentication transition, or background restart remains fail-closed and sends nothing.
 - The original bottom-relative scroll position is captured before automatic movement and approximately restored only while the same chat remains selected.
 - The background service worker persists only aggregate operation snapshots, including the selected boundary and progress counts. Raw messages, raw WhatsApp IDs, and alignment evidence remain in the WhatsApp tab's memory.
+- When an automatic boundary deliberately trims retained items, skipped, unreadable, container, diagnostic-method, and participant counts are rebuilt from the retained readable payload rather than leaking counts from the excluded window.
 - Final upload still requires exact-count review and explicit confirmation. Automatic completion never uploads by itself.
 - Extension runtime and package metadata are synchronized at `1.0.18`.
 
@@ -32,13 +34,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 109 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 110 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `D275B45B15C3A53A97B1CE53EA13186530BE5AD0FE6F1C7C34ED5695D220BC5C`.
+- Packaged ZIP SHA-256: `AE41F0543FC3DE038643A80A82CFE180A93515A96A0B273C3C413D5B9DCA8A34`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -10,6 +10,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
+- Stabilization accepts early stable samples only after a DOM-window observation; when WhatsApp has not begun changing the history DOM, it waits through the full three-second window before contributing to no-progress detection.
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
@@ -37,7 +38,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `CDF61C5798670ADBE9E888B274020E0D693F8F57C0EE21DE2DE5BCB92D3E5B98`.
+- Packaged ZIP SHA-256: `13AE9CDFB561B5EF1AE830F019CCADA7FAC5630662A60F5A19D6666FCED0136D`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -8,11 +8,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Starting automatic capture requires an explicit acknowledgement that WhatsApp will scroll the selected chat.
 - Operators can select the last 7 days, last 30 days, 100/250/500 messages, or a verified top-of-history marker. Every automatic run is capped at 500 retained messages.
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
+- A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
+- Pause disconnects DOM observation and drains already-snapshotted work before it is acknowledged; resume reconnects observation before automatic scrolling continues.
 - Cancellation, chat change, tab teardown, authentication transition, or background restart remains fail-closed and sends nothing.
 - The original bottom-relative scroll position is captured before automatic movement and approximately restored only while the same chat remains selected.
 - The background service worker persists only aggregate operation snapshots, including the selected boundary and progress counts. Raw messages, raw WhatsApp IDs, and alignment evidence remain in the WhatsApp tab's memory.
@@ -29,13 +31,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 108 passed, 0 failed, including automatic boundary normalization, trusted-date gating, consent and controls on both surfaces, serialized background controls, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 109 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `0218880B840524CFE8707ED9D306B329D275CB08B97CA6631B3C7D591E01DCE9`.
+- Packaged ZIP SHA-256: `CDF61C5798670ADBE9E888B274020E0D693F8F57C0EE21DE2DE5BCB92D3E5B98`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -12,7 +12,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - A date-scoped review fails closed unless the trusted cutoff was crossed or every retained message has a valid trusted in-range metadata date; unproven visible-time/fallback ranges cancel with nothing sent.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Any untrusted gap after that excluded message is also discarded through the first trusted in-range anchor; without an in-range anchor, the scope trims to empty and cancels.
-- Established trusted-cutoff proof remains only in the live tab session, so a later finalization can verify an already-trimmed suffix without reintroducing excluded evidence or cancelling safe fallback items after the in-range anchor.
+- Established trusted-cutoff proof remains only as the exact retained item sequence in the live tab session. Finalization reuses it only while that sequence is unchanged; any later DOM merge forces full trimming or fail-closed validation again.
 - The trusted-date trim runs after queued snapshots drain for every automatic finalization, including user stop-and-review while loading or paused.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
@@ -44,13 +44,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 120 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, proof-preserving, and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 121 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, exact-proof-preserving, and every-finalization boundary trimming, late-merge revalidation, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `87A466C9E0DFA1C9FBBBFA3EDA9408A2C30F6D747C3BCB795B0B3726EFA31A64`.
+- Packaged ZIP SHA-256: `3950FF4A69169D2E8E670D007248744B8936ADB6BBBB89730C393F87A64E8D3D`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -10,6 +10,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
 - Date cutoffs use the same timezone-less wall-clock representation as WhatsApp's displayed metadata, preventing browser timezone offsets from widening or narrowing the selected range.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
+- The trusted-date trim runs after queued snapshots drain for every automatic finalization, including user stop-and-review while loading or paused.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
@@ -36,13 +37,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 112 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and boundary-spanning cutoff trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 113 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `3D6604668ECE14DC7E6F2C8036C6F8410DCE45D7295CB52180C80D5B4F9D7B7C`.
+- Packaged ZIP SHA-256: `C796ED87BEC3546947DC62385EEA5852C33D6C6960F1DA366EFA8EB68916E2E6`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -12,6 +12,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - A date-scoped review fails closed unless the trusted cutoff was crossed or every retained message has a valid trusted in-range metadata date; unproven visible-time/fallback ranges cancel with nothing sent.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Any untrusted gap after that excluded message is also discarded through the first trusted in-range anchor; without an in-range anchor, the scope trims to empty and cancels.
+- Established trusted-cutoff proof remains only in the live tab session, so a later finalization can verify an already-trimmed suffix without reintroducing excluded evidence or cancelling safe fallback items after the in-range anchor.
 - The trusted-date trim runs after queued snapshots drain for every automatic finalization, including user stop-and-review while loading or paused.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
@@ -43,13 +44,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 119 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 120 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, proof-preserving, and every-finalization boundary trimming, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `9505D101363066EBE366850E517ED7B98A828EAC2194BCFB99620BA6C19FF72D`.
+- Packaged ZIP SHA-256: `87A466C9E0DFA1C9FBBBFA3EDA9408A2C30F6D747C3BCB795B0B3726EFA31A64`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -18,6 +18,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
+- An ambiguous fallback-only window that adds nothing cannot claim the selected limit; limit completion requires the retained buffer to have actually reached that limit.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
 - When one merge proves a date cutoff and also reaches the cap, the truthful date-boundary reason takes precedence before the out-of-range prefix is trimmed.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
@@ -44,13 +45,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 121 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, exact-proof-preserving, and every-finalization boundary trimming, late-merge revalidation, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 122 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned, untrusted-gap, exact-proof-preserving, and every-finalization boundary trimming, late-merge revalidation, ambiguous no-add limit handling, date-over-cap reason precedence, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `3950FF4A69169D2E8E670D007248744B8936ADB6BBBB89730C393F87A64E8D3D`.
+- Packaged ZIP SHA-256: `2A3280F35BF26275297A2B3B9F607F31073914C86142160E22EBD45DD75A9EEE`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -17,6 +17,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
+- Pause is published only after the content-side automatic runner has activated; pre-activation control messages are inert and cannot strand a capture without a runner.
 - Pause disconnects DOM observation and drains already-snapshotted work before it is acknowledged; resume reconnects observation before automatic scrolling continues.
 - The runner rechecks pause after stabilization and draining, before any boundary or no-progress completion can be emitted.
 - Cancellation, chat change, tab teardown, authentication transition, or background restart remains fail-closed and sends nothing.
@@ -38,13 +39,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 114 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, retained-scope alignment warnings, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 115 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `46EA4350A7616E8B9CDE033AADDA2FBC40CCDBC41197C6C44565C7A12EDC02E9`.
+- Packaged ZIP SHA-256: `30112EC254484DDA8110D137E8ED0D23B45A5EFB9EA0BEFD149259F9DCD63610`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -21,6 +21,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - The original bottom-relative scroll position is captured before automatic movement and approximately restored only while the same chat remains selected.
 - The background service worker persists only aggregate operation snapshots, including the selected boundary and progress counts. Raw messages, raw WhatsApp IDs, and alignment evidence remain in the WhatsApp tab's memory.
 - When an automatic boundary deliberately trims retained items, skipped, unreadable, container, diagnostic-method, and participant counts are rebuilt from the retained readable payload rather than leaking counts from the excluded window.
+- If the selected automatic boundary retains zero readable messages, the operation cancels with an explicit nothing-sent result instead of offering an empty review or creating an empty conversation.
 - Final upload still requires exact-count review and explicit confirmation. Automatic completion never uploads by itself.
 - Extension runtime and package metadata are synchronized at `1.0.18`.
 
@@ -29,18 +30,18 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Base: `origin/main` at `f85eac938d9dac746e6c84bfad0063b2141b7cd5` (merged PR #154).
 - Branch: `agent/extension-capture-phase7`.
 - Worktree: `C:/tmp/convolens-extension-phase7`.
-- Pull request: pending.
+- Pull request: [#155](https://github.com/neuralliquid/convolens/pull/155).
 - The primary checkout and its pre-existing untracked handoff remain untouched.
 
 ## Validation
 
-- Chrome extension Node tests: 110 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 111 passed, 0 failed, including automatic boundary normalization, boundary-spanning cutoff trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `AE41F0543FC3DE038643A80A82CFE180A93515A96A0B273C3C413D5B9DCA8A34`.
+- Packaged ZIP SHA-256: `DCE2F909DA8800BACE2768945EB33F185486624C3508C63F233E24FF6874C0D8`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -10,7 +10,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
-- Stabilization accepts early stable samples only after a DOM-window observation; when WhatsApp has not begun changing the history DOM, it waits through the full three-second window before contributing to no-progress detection.
+- Stabilization accepts early stable samples only after an actual MutationObserver callback. The eager post-scroll snapshot does not advance that generation; when WhatsApp has not begun changing the history DOM, collection waits through the full three-second window before contributing to no-progress detection.
 - Automatic scroll events are not separately subscribed, preventing the programmatic step and its scroll event from double-enqueuing the same fallback-only window.
 - Three consecutive cycles without count, scroll-position, or scroll-height progress stop with `automatic-no-progress`; this is distinct from a verified WhatsApp top marker.
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
@@ -38,7 +38,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `13AE9CDFB561B5EF1AE830F019CCADA7FAC5630662A60F5A19D6666FCED0136D`.
+- Packaged ZIP SHA-256: `D275B45B15C3A53A97B1CE53EA13186530BE5AD0FE6F1C7C34ED5695D220BC5C`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -23,6 +23,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - The original bottom-relative scroll position is captured before automatic movement and approximately restored only while the same chat remains selected.
 - The background service worker persists only aggregate operation snapshots, including the selected boundary and progress counts. Raw messages, raw WhatsApp IDs, and alignment evidence remain in the WhatsApp tab's memory.
 - When an automatic boundary deliberately trims retained items, skipped, unreadable, container, diagnostic-method, and participant counts are rebuilt from the retained readable payload rather than leaking counts from the excluded window.
+- Ambiguous-alignment warnings retain in-tab candidate provenance and are removed when all affected candidates leave the retained upload scope.
 - If the selected automatic boundary retains zero readable messages, the operation cancels with an explicit nothing-sent result instead of offering an empty review or creating an empty conversation.
 - Final upload still requires exact-count review and explicit confirmation. Automatic completion never uploads by itself.
 - Extension runtime and package metadata are synchronized at `1.0.18`.
@@ -37,13 +38,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 113 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 114 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, retained-scope alignment warnings, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `C796ED87BEC3546947DC62385EEA5852C33D6C6960F1DA366EFA8EB68916E2E6`.
+- Packaged ZIP SHA-256: `46EA4350A7616E8B9CDE033AADDA2FBC40CCDBC41197C6C44565C7A12EDC02E9`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
+++ b/docs/HANDOFF-2026-07-28-EXTENSION-CAPTURE-PHASE7.md
@@ -9,6 +9,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Operators can select the last 7 days, last 30 days, 100/250/500 messages, or a verified top-of-history marker. Every automatic run is capped at 500 retained messages.
 - Date boundaries rely only on trusted date-bearing WhatsApp metadata. Date-less visible times and generated fallback timestamps cannot claim that a date boundary was reached.
 - Date cutoffs use the same timezone-less wall-clock representation as WhatsApp's displayed metadata, preventing browser timezone offsets from widening or narrowing the selected range.
+- A date-scoped review fails closed unless the trusted cutoff was crossed or every retained message has a valid trusted in-range metadata date; unproven visible-time/fallback ranges cancel with nothing sent.
 - A mounted window that crosses a date cutoff is trimmed after its last trusted out-of-scope message before review, so older messages from that window are not included in the selected upload scope.
 - The trusted-date trim runs after queued snapshots drain for every automatic finalization, including user stop-and-review while loading or paused.
 - Automatic collection scrolls upward in bounded steps, snapshots the mounted window immediately, waits for DOM/scroll-height stabilization, and reuses the Phase 6 FIFO virtualized-window accumulator.
@@ -18,6 +19,7 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 - Completion reasons distinguish user stop, date boundary, message limit, verified top, the 500-message safety cap, no progress, and repeated DOM failures.
 - Pause, resume, stop-and-review, and cancel are available from both surfaces. Background control commands are serialized per operation so rapid commands are not collapsed into an unrelated in-flight response.
 - Pause is published only after the content-side automatic runner has activated; pre-activation control messages are inert and cannot strand a capture without a runner.
+- Stop-and-review is also hidden until activation; Cancel remains available throughout startup.
 - Pause disconnects DOM observation and drains already-snapshotted work before it is acknowledged; resume reconnects observation before automatic scrolling continues.
 - The runner rechecks pause after stabilization and draining, before any boundary or no-progress completion can be emitted.
 - Cancellation, chat change, tab teardown, authentication transition, or background restart remains fail-closed and sends nothing.
@@ -39,13 +41,13 @@ Phase 7 enables explicitly confirmed automatic older-history loading while retai
 
 ## Validation
 
-- Chrome extension Node tests: 115 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
+- Chrome extension Node tests: 117 passed, 0 failed, including automatic boundary normalization, wall-clock-aligned and every-finalization boundary trimming, unproven-date and zero-retained-scope cancellation, retained-scope alignment warnings, activation-gated controls, trusted-date gating, consent and controls on both surfaces, serialized background controls, paused-observer suspension and post-await recheck, trimmed diagnostic rebuilding, truthful completion, anchor restoration, accumulator reuse, privacy, and all prior capture safety coverage.
 - Chrome extension TypeScript: passed.
 - Prettier and `git diff --check`: passed.
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.18`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `30112EC254484DDA8110D137E8ED0D23B45A5EFB9EA0BEFD149259F9DCD63610`.
+- Packaged ZIP SHA-256: `D0F4F56E0686444147D0AB5F54E4F8BE5F8D40881819C1352E024E80DFC21B32`.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open


### PR DESCRIPTION
## Summary

- enable explicitly confirmed automatic older-history loading in popup and WhatsApp launcher
- add 7/30-day, 100/250/500-message, and verified-top boundaries with a hard 500-message cap
- add pause/resume, stop-and-review, cancel, stabilization/no-progress handling, and approximate same-chat scroll-anchor restoration
- retain Phase 6 FIFO accumulation, explicit final review, and tab-memory-only raw capture

## Validation

- 108/108 Chrome extension tests
- Chrome extension TypeScript
- Prettier and git diff --check
- production extension build/package
- monorepo build: 8/8 packages
- packaged version: 1.0.18
- ZIP SHA-256: 