### PR TITLE
feat(extension): add operational capture actions

### DIFF
--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.html
+++ b/apps/chrome-extension/popup/popup.html
@@ -367,6 +367,37 @@
         font-size: 12px;
       }
 
+      .preview-actions .wide-action {
+        grid-column: 1 / -1;
+      }
+
+      .operational-actions,
+      .roadmap-preview {
+        display: grid;
+        gap: 6px;
+        padding: 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 10px;
+        background: #f9fafb;
+        color: #374151;
+        font-size: 12px;
+      }
+
+      .operational-actions[hidden] {
+        display: none;
+      }
+
+      .operational-actions span,
+      .roadmap-preview span {
+        color: #6b7280;
+      }
+
+      .roadmap-preview b {
+        color: #166534;
+        font-size: 10px;
+        text-transform: uppercase;
+      }
+
       .user-info {
         display: flex;
         align-items: center;
@@ -587,8 +618,31 @@
                   Confirm upload
                 </button>
                 <button class="btn-secondary" id="cancelCapture">Cancel</button>
+                <button class="btn-secondary wide-action" id="exportCapture">
+                  Export reviewed JSON
+                </button>
               </div>
             </div>
+            <section
+              class="operational-actions"
+              id="operationalActions"
+              aria-label="Capture result"
+              hidden
+            >
+              <strong id="captureResult">No capture result yet</strong>
+              <span id="lastCapture">Last capture: none yet</span>
+              <button class="btn-secondary" id="openConversation" hidden>
+                Open received conversation
+              </button>
+            </section>
+            <section
+              class="roadmap-preview"
+              aria-label="Planned capture actions"
+            >
+              <strong>Coming next</strong>
+              <span>Select individual messages — <b>Soon</b></span>
+              <span>Match participants — <b>Soon</b></span>
+            </section>
             <button class="btn-secondary" id="logoutBtn">Sign Out</button>
             <div
               class="action-status"

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -144,9 +144,9 @@ function renderOperationalActions() {
       : null;
   const resultState =
     terminalOperation?.state || operationalState.lastCapture?.state;
-  const reconciliationRequired =
-    terminalOperation?.reconciliationRequired ||
-    operationalState.lastCapture?.reconciliationRequired;
+  const reconciliationRequired = terminalOperation
+    ? Boolean(terminalOperation.reconciliationRequired)
+    : Boolean(operationalState.lastCapture?.reconciliationRequired);
   captureResult.textContent = reconciliationRequired
     ? "New conversation stored separately — reconciliation needed"
     : resultState === "duplicate"

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -458,18 +458,7 @@ async function init() {
 
   if (authStatus.data?.isAuthenticated) {
     showLoggedIn(authStatus.data.user);
-    const operationalResponse = await sendRuntimeMessage({
-      action: "GET_CAPTURE_OPERATIONAL_STATE",
-    });
-    if (operationalResponse.success && operationalResponse.data) {
-      operationalState = operationalResponse.data;
-      applyPopupCaptureMode(
-        operationalState.preferredMode === "guided"
-          ? "scroll"
-          : operationalState.preferredMode,
-      );
-    }
-    renderOperationalActions();
+    await refreshOperationalState();
   } else {
     showLoggedOut();
     operationalActions.hidden = true;
@@ -486,6 +475,21 @@ async function init() {
       renderCaptureOperation(operationResponse.data);
     }
   }
+}
+
+async function refreshOperationalState() {
+  const operationalResponse = await sendRuntimeMessage({
+    action: "GET_CAPTURE_OPERATIONAL_STATE",
+  });
+  if (operationalResponse.success && operationalResponse.data) {
+    operationalState = operationalResponse.data;
+    applyPopupCaptureMode(
+      operationalState.preferredMode === "guided"
+        ? "scroll"
+        : operationalState.preferredMode,
+    );
+  }
+  renderOperationalActions();
 }
 
 // Show logged in state
@@ -547,6 +551,7 @@ loginBtn.addEventListener("click", async () => {
     const result = await sendRuntimeMessage({ action: "SYNC_MYSTIRA_AUTH" });
     if (result.success) {
       showLoggedIn(result.data?.user);
+      await refreshOperationalState();
       loginError.textContent = "";
       setActionStatus(
         "Connected. Choose a WhatsApp chat and review its loaded messages.",

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -50,10 +50,16 @@ const collectionProgressTitle = document.getElementById(
 const collectionProgressInstruction = document.getElementById(
   "collectionProgressInstruction",
 );
+const exportCapture = document.getElementById("exportCapture");
+const operationalActions = document.getElementById("operationalActions");
+const captureResult = document.getElementById("captureResult");
+const lastCapture = document.getElementById("lastCapture");
+const openConversation = document.getElementById("openConversation");
 
 let currentOperation = null;
 let activeWhatsAppTabId = null;
 let captureModeChangeGeneration = 0;
+let operationalState = { preferredMode: "loaded" };
 
 extensionVersion.textContent = `v${chrome.runtime.getManifest().version}`;
 dashboardLink.href = `${DASHBOARD_URL}/dashboard`;
@@ -116,6 +122,43 @@ function formatPreviewTimestamp(value) {
   if (!value) return "Not detected";
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? "Not detected" : date.toLocaleString();
+}
+
+function currentResultPath() {
+  if (
+    currentOperation &&
+    ["received", "duplicate"].includes(currentOperation.state) &&
+    currentOperation.resultPath
+  ) {
+    return currentOperation.resultPath;
+  }
+  return operationalState.lastCapture?.resultPath;
+}
+
+function renderOperationalActions() {
+  operationalActions.hidden = false;
+  const terminalOperation =
+    currentOperation &&
+    ["received", "duplicate"].includes(currentOperation.state)
+      ? currentOperation
+      : null;
+  const resultState =
+    terminalOperation?.state || operationalState.lastCapture?.state;
+  const reconciliationRequired =
+    terminalOperation?.reconciliationRequired ||
+    operationalState.lastCapture?.reconciliationRequired;
+  captureResult.textContent = reconciliationRequired
+    ? "New conversation stored separately — reconciliation needed"
+    : resultState === "duplicate"
+      ? "Existing conversation found — no duplicate created"
+      : resultState === "received"
+        ? "New conversation received"
+        : "No capture result yet";
+  const last = operationalState.lastCapture;
+  lastCapture.textContent = last
+    ? `Last capture: ${last.count} message${last.count === 1 ? "" : "s"} · ${formatPreviewTimestamp(last.completedAt)}`
+    : "Last capture: none yet";
+  openConversation.hidden = !currentResultPath();
 }
 
 function guidedStopReasonLabel(reason) {
@@ -213,7 +256,34 @@ async function renderCapturePreview(operation) {
 function renderCaptureOperation(operation) {
   if (!operation) return;
   currentOperation = operation;
-  const modeValue = operation.mode === "guided" ? "scroll" : operation.mode;
+  if (
+    ["received", "duplicate"].includes(operation.state) &&
+    operation.completedAt
+  ) {
+    operationalState = {
+      ...operationalState,
+      lastCapture: {
+        count: operation.extractedCount,
+        completedAt: operation.completedAt,
+        state: operation.state,
+        resultPath: operation.resultPath,
+        reconciliationRequired: Boolean(operation.reconciliationRequired),
+      },
+    };
+  }
+  renderOperationalActions();
+  const operationOwnsMode = [
+    "inspecting",
+    "collecting",
+    "paused",
+    "ready-for-review",
+    "uploading",
+    "retry-required",
+  ].includes(operation.state);
+  const selectedMode = operationOwnsMode
+    ? operation.mode
+    : operationalState.preferredMode;
+  const modeValue = selectedMode === "guided" ? "scroll" : selectedMode;
   document.querySelectorAll('input[name="captureMode"]').forEach((input) => {
     input.checked = input.value === modeValue;
     input.closest(".capture-mode")?.classList.toggle("selected", input.checked);
@@ -231,12 +301,13 @@ function renderCaptureOperation(operation) {
   confirmCapture.disabled = operation.state === "uploading";
   cancelCapture.disabled = operation.state === "uploading";
   extractBtn.textContent =
-    operation.mode === "guided"
-      ? operation.state === "collecting"
+    selectedMode === "guided"
+      ? operationOwnsMode && operation.state === "collecting"
         ? `Guided: ${count} captured`
         : "Start guided capture"
-      : operation.mode === "automatic"
-        ? ["collecting", "paused"].includes(operation.state)
+      : selectedMode === "automatic"
+        ? operationOwnsMode &&
+          ["collecting", "paused"].includes(operation.state)
           ? `Automatic: ${count} captured`
           : "Load older messages"
         : "Review loaded messages";
@@ -387,8 +458,21 @@ async function init() {
 
   if (authStatus.data?.isAuthenticated) {
     showLoggedIn(authStatus.data.user);
+    const operationalResponse = await sendRuntimeMessage({
+      action: "GET_CAPTURE_OPERATIONAL_STATE",
+    });
+    if (operationalResponse.success && operationalResponse.data) {
+      operationalState = operationalResponse.data;
+      applyPopupCaptureMode(
+        operationalState.preferredMode === "guided"
+          ? "scroll"
+          : operationalState.preferredMode,
+      );
+    }
+    renderOperationalActions();
   } else {
     showLoggedOut();
+    operationalActions.hidden = true;
   }
 
   // Check WhatsApp Web connection
@@ -757,6 +841,17 @@ document.querySelectorAll('input[name="captureMode"]').forEach((input) => {
     const selectedMode = input.value;
     const generation = ++captureModeChangeGeneration;
     applyPopupCaptureMode(selectedMode);
+    const preferredMode =
+      selectedMode === "scroll"
+        ? "guided"
+        : selectedMode === "automatic"
+          ? "automatic"
+          : "loaded";
+    operationalState = { ...operationalState, preferredMode };
+    void sendRuntimeMessage({
+      action: "SET_PREFERRED_CAPTURE_MODE",
+      mode: preferredMode,
+    }).catch(() => undefined);
     void discardUnconfirmedCaptureForModeChange(selectedMode)
       .catch((error) =>
         setActionStatus(normalizeExtensionError(error), "error"),
@@ -780,6 +875,40 @@ chrome.runtime.onMessage.addListener((message) => {
 
 openDashboard.addEventListener("click", () => {
   openTab(`${DASHBOARD_URL}/dashboard`);
+});
+
+openConversation.addEventListener("click", async () => {
+  try {
+    const path = currentResultPath();
+    if (!path) return;
+    const response = await sendRuntimeMessage({
+      action: "OPEN_DASHBOARD",
+      path,
+    });
+    if (!response.success) setActionStatus(response.error, "error");
+  } catch (error) {
+    setActionStatus(normalizeExtensionError(error), "error");
+  }
+});
+
+exportCapture.addEventListener("click", async () => {
+  try {
+    if (!activeWhatsAppTabId || !currentOperation) return;
+    const response = await sendToWhatsApp(activeWhatsAppTabId, {
+      action: "EXPORT_CAPTURE_OPERATION_PAYLOAD",
+      operationId: currentOperation.operationId,
+    });
+    if (response.success) {
+      setActionStatus(
+        `Exported ${response.data?.filename || "reviewed capture"}.`,
+        "success",
+      );
+    } else {
+      setActionStatus(response.error, "error");
+    }
+  } catch (error) {
+    setActionStatus(normalizeExtensionError(error), "error");
+  }
 });
 
 // Initialize

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -258,7 +258,10 @@ function renderCaptureOperation(operation) {
   currentOperation = operation;
   if (
     ["received", "duplicate"].includes(operation.state) &&
-    operation.completedAt
+    operation.completedAt &&
+    (!operationalState.lastCapture ||
+      Date.parse(operation.completedAt) >=
+        Date.parse(operationalState.lastCapture.completedAt))
   ) {
     operationalState = {
       ...operationalState,

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -127,8 +127,7 @@ function formatPreviewTimestamp(value) {
 function currentResultPath() {
   if (
     currentOperation &&
-    ["received", "duplicate"].includes(currentOperation.state) &&
-    currentOperation.resultPath
+    ["received", "duplicate"].includes(currentOperation.state)
   ) {
     return currentOperation.resultPath;
   }

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -46,8 +46,8 @@ import {
   normalizeCaptureMode,
   normalizeConversationResultPath,
   operationalStateForOwner,
+  withOperationalStateForOwner,
   type CaptureOperationalState,
-  type StoredCaptureOperationalState,
 } from "./capture-operational";
 
 // =============================================================================
@@ -1973,7 +1973,11 @@ async function mutateCaptureOperationalState(
         ownerId,
       ),
     );
-    const persisted: StoredCaptureOperationalState = { ownerId, ...state };
+    const persisted = withOperationalStateForOwner(
+      stored[STORAGE_KEYS.captureOperationalState],
+      ownerId,
+      state,
+    );
     await chrome.storage.local.set({
       [STORAGE_KEYS.captureOperationalState]: persisted,
     });

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -198,6 +198,9 @@ async function handleMessage(
       );
 
     case "REFRESH_LAUNCHER_STATE":
+      await updateToolbarBadge().catch((error) =>
+        console.warn("[Background] Toolbar badge update failed:", error),
+      );
       await notifyLauncherStateRefresh();
       return { success: true };
 
@@ -2039,6 +2042,7 @@ async function recordSuccessfulCapture(
       reconciliationRequired: Boolean(operation.reconciliationRequired),
     },
   }));
+  await notifyLauncherStateRefresh();
 }
 
 async function getApiConfig() {

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -1983,6 +1983,7 @@ async function setPreferredCaptureMode(
     ...current,
     preferredMode: normalizeCaptureMode(requestedMode),
   }));
+  await notifyLauncherStateRefresh();
   return { success: true, data: state };
 }
 

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -42,6 +42,7 @@ import {
 import { normalizeAutomaticBoundary } from "./automatic-capture";
 import {
   canRestoreReviewedRetry,
+  captureOwnerMatches,
   deriveToolbarBadge,
   normalizeCaptureMode,
   normalizeConversationResultPath,
@@ -74,6 +75,7 @@ const RATE_LIMIT_STORAGE_KEY = "ws_rate_limit_state";
 const captureOperations = new Map<number, CaptureOperationSnapshot>();
 const captureOperationEpochs = new Map<string, number>();
 const captureOperationOwnerIds = new Map<string, string>();
+const closedCaptureTabIds = new Set<number>();
 const captureUploadPromises = new Map<
   string,
   Promise<ExtensionResponse<CaptureOperationSnapshot>>
@@ -102,8 +104,12 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 async function handleCaptureTabRemoved(tabId: number): Promise<void> {
   await loadCaptureOperations();
   const operation = captureOperations.get(tabId);
+  if (!operation) return;
+  if (operation.state === "uploading") {
+    closedCaptureTabIds.add(tabId);
+    return;
+  }
   if (
-    operation &&
     [
       "inspecting",
       "collecting",
@@ -118,13 +124,8 @@ async function handleCaptureTabRemoved(tabId: number): Promise<void> {
       "The WhatsApp tab was closed.",
       false,
     );
-    if (captureOperations.get(tabId)?.operationId === operation.operationId) {
-      captureOperations.delete(tabId);
-      captureOperationEpochs.delete(operation.operationId);
-      captureOperationOwnerIds.delete(operation.operationId);
-      await persistCaptureOperations();
-    }
   }
+  await removeCaptureOperation(operation);
 }
 
 // =============================================================================
@@ -337,6 +338,7 @@ async function loadCaptureOperations(): Promise<void> {
     const persistedOwners = stored[STORAGE_KEYS.captureOperationOwners];
 
     const interrupted: CaptureOperationSnapshot[] = [];
+    const discarded: CaptureOperationSnapshot[] = [];
     for (const [tabIdValue, value] of Object.entries(
       persisted && typeof persisted === "object" ? persisted : {},
     )) {
@@ -378,6 +380,10 @@ async function loadCaptureOperations(): Promise<void> {
         persistedOwners && typeof persistedOwners === "object"
           ? (persistedOwners as Record<string, unknown>)[operation.operationId]
           : undefined;
+      if (!captureOwnerMatches(persistedOwnerId, restoredOwnerId)) {
+        discarded.push(operation);
+        continue;
+      }
       const restoreReviewedRetry = canRestoreReviewedRetry(
         operation,
         persistedOwnerId,
@@ -393,15 +399,16 @@ async function loadCaptureOperations(): Promise<void> {
           : operation;
       captureOperations.set(tabId, restored);
       captureOperationEpochs.set(restored.operationId, captureLifecycleEpoch);
-      if (restoreReviewedRetry) {
-        captureOperationOwnerIds.set(
-          restored.operationId,
-          persistedOwnerId as string,
-        );
-      }
+      captureOperationOwnerIds.set(
+        restored.operationId,
+        persistedOwnerId as string,
+      );
       if (restored !== operation) interrupted.push(restored);
     }
     await persistCaptureOperations();
+    for (const operation of discarded) {
+      await discardCapturePayload(operation);
+    }
     for (const operation of interrupted) {
       chrome.runtime
         .sendMessage({ action: "CAPTURE_OPERATION_UPDATED", operation })
@@ -453,11 +460,34 @@ async function persistCaptureOperations(): Promise<void> {
   );
 }
 
+async function removeCaptureOperation(
+  operation: CaptureOperationSnapshot,
+): Promise<void> {
+  if (
+    captureOperations.get(operation.tabId)?.operationId !==
+    operation.operationId
+  ) {
+    return;
+  }
+  captureOperations.delete(operation.tabId);
+  captureOperationEpochs.delete(operation.operationId);
+  captureOperationOwnerIds.delete(operation.operationId);
+  closedCaptureTabIds.delete(operation.tabId);
+  await persistCaptureOperations();
+}
+
 async function publishCaptureOperation(
   operation: CaptureOperationSnapshot,
   notifyTab: boolean = true,
 ): Promise<void> {
   captureOperations.set(operation.tabId, operation);
+  if (
+    closedCaptureTabIds.has(operation.tabId) &&
+    operation.state !== "uploading"
+  ) {
+    await removeCaptureOperation(operation);
+    return;
+  }
   await persistCaptureOperations();
 
   chrome.runtime

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -27,6 +27,7 @@ import {
   type CancelCaptureOperationMessage,
   type StopGuidedCaptureOperationMessage,
   type ControlAutomaticCaptureOperationMessage,
+  type SetPreferredCaptureModeMessage,
 } from "./config";
 import {
   completeCaptureOperation,
@@ -39,6 +40,14 @@ import {
   type CaptureStopReason,
 } from "./capture-operation";
 import { normalizeAutomaticBoundary } from "./automatic-capture";
+import {
+  deriveToolbarBadge,
+  normalizeCaptureMode,
+  normalizeConversationResultPath,
+  operationalStateForOwner,
+  type CaptureOperationalState,
+  type StoredCaptureOperationalState,
+} from "./capture-operational";
 
 // =============================================================================
 // Types
@@ -83,8 +92,14 @@ let authenticationWriteTail: Promise<void> = Promise.resolve();
 let authenticationIntentGeneration = 0;
 let committedAuthenticationIntentGeneration = 0;
 const activeAuthenticationClearIntents = new Set<number>();
+let captureOperationalStateWriteTail: Promise<void> = Promise.resolve();
 
 chrome.tabs.onRemoved.addListener((tabId) => {
+  void handleCaptureTabRemoved(tabId);
+});
+
+async function handleCaptureTabRemoved(tabId: number): Promise<void> {
+  await loadCaptureOperations();
   const operation = captureOperations.get(tabId);
   if (
     operation &&
@@ -103,7 +118,7 @@ chrome.tabs.onRemoved.addListener((tabId) => {
       false,
     );
   }
-});
+}
 
 // =============================================================================
 // Message Handler
@@ -165,6 +180,14 @@ async function handleMessage(
 
     case "GET_LEGACY_QUEUE_SUMMARY":
       return await getLegacyQueueSummary();
+
+    case "GET_CAPTURE_OPERATIONAL_STATE":
+      return await getCaptureOperationalState();
+
+    case "SET_PREFERRED_CAPTURE_MODE":
+      return await setPreferredCaptureMode(
+        (message as SetPreferredCaptureModeMessage).mode,
+      );
 
     case "REFRESH_LAUNCHER_STATE":
       await notifyLauncherStateRefresh();
@@ -265,6 +288,7 @@ async function handleMessage(
     case "VALIDATE_CAPTURE_OPERATION_CONTEXT":
     case "DISCARD_CAPTURE_OPERATION":
     case "CAPTURE_OPERATION_UPDATED":
+    case "EXPORT_CAPTURE_OPERATION_PAYLOAD":
       // These are handled by content script, not background
       return { success: false, error: "Action handled by content script" };
 
@@ -288,10 +312,14 @@ function resolveCaptureTabId(
 async function loadCaptureOperations(): Promise<void> {
   if (captureOperationsLoadPromise) return await captureOperationsLoadPromise;
   captureOperationsLoadPromise = (async () => {
-    const stored = await chrome.storage.session.get([
-      STORAGE_KEYS.captureOperations,
-      STORAGE_KEYS.captureLifecycleEpoch,
+    const [stored, ownerState] = await Promise.all([
+      chrome.storage.session.get([
+        STORAGE_KEYS.captureOperations,
+        STORAGE_KEYS.captureLifecycleEpoch,
+      ]),
+      chrome.storage.local.get([STORAGE_KEYS.user]),
     ]);
+    const restoredOwnerId = ownerState[STORAGE_KEYS.user]?.id;
     const persistedEpoch = stored[STORAGE_KEYS.captureLifecycleEpoch];
     captureLifecycleEpoch =
       Number.isInteger(persistedEpoch) && persistedEpoch >= 0
@@ -337,15 +365,22 @@ async function loadCaptureOperations(): Promise<void> {
           ? (value as CaptureOperationSnapshot).alignmentWarningCount
           : 0,
       };
-      const restored = isActiveCaptureState(operation.state)
-        ? completeCaptureOperation(
-            operation,
-            "cancelled",
-            "The extension background restarted. Recapture and review the loaded messages.",
-          )
-        : operation;
+      const canRestoreReviewedRetry =
+        operation.state === "retry-required" &&
+        typeof restoredOwnerId === "string";
+      const restored =
+        isActiveCaptureState(operation.state) && !canRestoreReviewedRetry
+          ? completeCaptureOperation(
+              operation,
+              "cancelled",
+              "The extension background restarted. Recapture and review the loaded messages.",
+            )
+          : operation;
       captureOperations.set(tabId, restored);
       captureOperationEpochs.set(restored.operationId, captureLifecycleEpoch);
+      if (canRestoreReviewedRetry) {
+        captureOperationOwnerIds.set(restored.operationId, restoredOwnerId);
+      }
       if (restored !== operation) interrupted.push(restored);
     }
     await persistCaptureOperations();
@@ -365,11 +400,28 @@ async function loadCaptureOperations(): Promise<void> {
   return await captureOperationsLoadPromise;
 }
 
+async function updateToolbarBadge(): Promise<void> {
+  const stored = await chrome.storage.local.get([STORAGE_KEYS.pendingUploads]);
+  const pending = stored[STORAGE_KEYS.pendingUploads];
+  const badge = deriveToolbarBadge(
+    captureOperations.values(),
+    Array.isArray(pending) ? pending.length : 0,
+  );
+  await Promise.all([
+    chrome.action.setBadgeText({ text: badge.text }),
+    chrome.action.setBadgeBackgroundColor({ color: badge.color }),
+    chrome.action.setTitle({ title: badge.title }),
+  ]);
+}
+
 async function persistCaptureOperations(): Promise<void> {
   await chrome.storage.session.set({
     [STORAGE_KEYS.captureOperations]: Object.fromEntries(captureOperations),
     [STORAGE_KEYS.captureLifecycleEpoch]: captureLifecycleEpoch,
   });
+  await updateToolbarBadge().catch((error) =>
+    console.warn("[Background] Toolbar badge update failed:", error),
+  );
 }
 
 async function publishCaptureOperation(
@@ -1066,11 +1118,14 @@ async function uploadCaptureOperation(
       {
         ...operation,
         reconciliationRequired: Boolean(result?.reconciliationRequired),
-        resultPath: result?.data?.dashboardUrl,
+        resultPath: normalizeConversationResultPath(result?.data?.dashboardUrl),
       },
       duplicate ? "duplicate" : "received",
     );
     await publishCaptureOperation(operation);
+    await recordSuccessfulCapture(operation, expectedOwnerId).catch((error) =>
+      console.warn("[Background] Last capture metadata update failed:", error),
+    );
     await discardCapturePayload(operation);
     return { success: true, data: operation };
   } catch (error) {
@@ -1824,6 +1879,105 @@ async function updateSettings(
   return { success: true, data: settings };
 }
 
+async function getCurrentOwnerId(): Promise<string | null> {
+  const stored = await chrome.storage.local.get([STORAGE_KEYS.user]);
+  const ownerId = stored[STORAGE_KEYS.user]?.id;
+  return typeof ownerId === "string" ? ownerId : null;
+}
+
+async function getCaptureOperationalState(): Promise<
+  ExtensionResponse<CaptureOperationalState>
+> {
+  const ownerId = await getCurrentOwnerId();
+  if (!ownerId) {
+    return {
+      success: false,
+      error: "Sign in to read capture preferences.",
+    };
+  }
+  const stored = await chrome.storage.local.get([
+    STORAGE_KEYS.captureOperationalState,
+  ]);
+  return {
+    success: true,
+    data: operationalStateForOwner(
+      stored[STORAGE_KEYS.captureOperationalState],
+      ownerId,
+    ),
+  };
+}
+
+async function setPreferredCaptureMode(
+  requestedMode: SetPreferredCaptureModeMessage["mode"],
+): Promise<ExtensionResponse<CaptureOperationalState>> {
+  const ownerId = await getCurrentOwnerId();
+  if (!ownerId) {
+    return {
+      success: false,
+      error: "Sign in before saving a capture preference.",
+    };
+  }
+  const state = await mutateCaptureOperationalState(ownerId, (current) => ({
+    ...current,
+    preferredMode: normalizeCaptureMode(requestedMode),
+  }));
+  return { success: true, data: state };
+}
+
+async function mutateCaptureOperationalState(
+  ownerId: string,
+  update: (current: CaptureOperationalState) => CaptureOperationalState,
+): Promise<CaptureOperationalState> {
+  let releaseWrite: () => void = () => undefined;
+  const previousWrite = captureOperationalStateWriteTail;
+  captureOperationalStateWriteTail = new Promise<void>((resolve) => {
+    releaseWrite = resolve;
+  });
+  await previousWrite;
+  try {
+    const stored = await chrome.storage.local.get([
+      STORAGE_KEYS.captureOperationalState,
+    ]);
+    const state = update(
+      operationalStateForOwner(
+        stored[STORAGE_KEYS.captureOperationalState],
+        ownerId,
+      ),
+    );
+    const persisted: StoredCaptureOperationalState = { ownerId, ...state };
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.captureOperationalState]: persisted,
+    });
+    return state;
+  } finally {
+    releaseWrite();
+  }
+}
+
+async function recordSuccessfulCapture(
+  operation: CaptureOperationSnapshot,
+  ownerId: string,
+): Promise<void> {
+  if (
+    (operation.state !== "received" && operation.state !== "duplicate") ||
+    !operation.completedAt
+  ) {
+    return;
+  }
+  const completedAt = operation.completedAt;
+  const resultState = operation.state;
+  await mutateCaptureOperationalState(ownerId, (current) => ({
+    preferredMode: current.preferredMode,
+    lastCapture: {
+      count: operation.extractedCount,
+      completedAt,
+      state: resultState,
+      resultPath: normalizeConversationResultPath(operation.resultPath),
+      reconciliationRequired: Boolean(operation.reconciliationRequired),
+    },
+  }));
+}
+
 async function getApiConfig() {
   const stored = await chrome.storage.local.get([STORAGE_KEYS.settings]);
   const settings = stored[STORAGE_KEYS.settings] || {};
@@ -1843,6 +1997,10 @@ async function getApiConfig() {
 
 async function clearPendingUploads(): Promise<ExtensionResponse> {
   await chrome.storage.local.remove(STORAGE_KEYS.pendingUploads);
+  await updateToolbarBadge().catch((error) =>
+    console.warn("[Background] Toolbar badge update failed:", error),
+  );
+  await notifyLauncherStateRefresh();
   return { success: true };
 }
 
@@ -1944,7 +2102,14 @@ async function checkApiRateLimit(): Promise<boolean> {
 
 async function openDashboard(path?: string): Promise<ExtensionResponse> {
   const config = await getApiConfig();
-  const url = `${config.dashboardUrl}${path || "/dashboard"}`;
+  const safePath = path ? normalizeConversationResultPath(path) : "/dashboard";
+  if (!safePath) {
+    return {
+      success: false,
+      error: "The received conversation link is not valid.",
+    };
+  }
+  const url = `${config.dashboardUrl}${safePath}`;
   await chrome.tabs.create({ url });
   return { success: true };
 }
@@ -1973,3 +2138,6 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 });
 
 console.log("[Background] Service worker initialized");
+void loadCaptureOperations().catch((error) =>
+  console.warn("[Background] Capture state initialization failed:", error),
+);

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -41,6 +41,7 @@ import {
 } from "./capture-operation";
 import { normalizeAutomaticBoundary } from "./automatic-capture";
 import {
+  canRestoreReviewedRetry,
   deriveToolbarBadge,
   normalizeCaptureMode,
   normalizeConversationResultPath,
@@ -111,12 +112,18 @@ async function handleCaptureTabRemoved(tabId: number): Promise<void> {
       "retry-required",
     ].includes(operation.state)
   ) {
-    void finishCaptureOperation(
+    await finishCaptureOperation(
       operation,
       "cancelled",
       "The WhatsApp tab was closed.",
       false,
     );
+    if (captureOperations.get(tabId)?.operationId === operation.operationId) {
+      captureOperations.delete(tabId);
+      captureOperationEpochs.delete(operation.operationId);
+      captureOperationOwnerIds.delete(operation.operationId);
+      await persistCaptureOperations();
+    }
   }
 }
 
@@ -315,6 +322,7 @@ async function loadCaptureOperations(): Promise<void> {
     const [stored, ownerState] = await Promise.all([
       chrome.storage.session.get([
         STORAGE_KEYS.captureOperations,
+        STORAGE_KEYS.captureOperationOwners,
         STORAGE_KEYS.captureLifecycleEpoch,
       ]),
       chrome.storage.local.get([STORAGE_KEYS.user]),
@@ -326,6 +334,7 @@ async function loadCaptureOperations(): Promise<void> {
         ? persistedEpoch
         : 0;
     const persisted = stored[STORAGE_KEYS.captureOperations];
+    const persistedOwners = stored[STORAGE_KEYS.captureOperationOwners];
 
     const interrupted: CaptureOperationSnapshot[] = [];
     for (const [tabIdValue, value] of Object.entries(
@@ -365,11 +374,17 @@ async function loadCaptureOperations(): Promise<void> {
           ? (value as CaptureOperationSnapshot).alignmentWarningCount
           : 0,
       };
-      const canRestoreReviewedRetry =
-        operation.state === "retry-required" &&
-        typeof restoredOwnerId === "string";
+      const persistedOwnerId =
+        persistedOwners && typeof persistedOwners === "object"
+          ? (persistedOwners as Record<string, unknown>)[operation.operationId]
+          : undefined;
+      const restoreReviewedRetry = canRestoreReviewedRetry(
+        operation,
+        persistedOwnerId,
+        restoredOwnerId,
+      );
       const restored =
-        isActiveCaptureState(operation.state) && !canRestoreReviewedRetry
+        isActiveCaptureState(operation.state) && !restoreReviewedRetry
           ? completeCaptureOperation(
               operation,
               "cancelled",
@@ -378,8 +393,11 @@ async function loadCaptureOperations(): Promise<void> {
           : operation;
       captureOperations.set(tabId, restored);
       captureOperationEpochs.set(restored.operationId, captureLifecycleEpoch);
-      if (canRestoreReviewedRetry) {
-        captureOperationOwnerIds.set(restored.operationId, restoredOwnerId);
+      if (restoreReviewedRetry) {
+        captureOperationOwnerIds.set(
+          restored.operationId,
+          persistedOwnerId as string,
+        );
       }
       if (restored !== operation) interrupted.push(restored);
     }
@@ -415,8 +433,19 @@ async function updateToolbarBadge(): Promise<void> {
 }
 
 async function persistCaptureOperations(): Promise<void> {
+  const retainedOperationIds = new Set(
+    [...captureOperations.values()].map((operation) => operation.operationId),
+  );
+  for (const operationId of captureOperationOwnerIds.keys()) {
+    if (!retainedOperationIds.has(operationId)) {
+      captureOperationOwnerIds.delete(operationId);
+    }
+  }
   await chrome.storage.session.set({
     [STORAGE_KEYS.captureOperations]: Object.fromEntries(captureOperations),
+    [STORAGE_KEYS.captureOperationOwners]: Object.fromEntries(
+      captureOperationOwnerIds,
+    ),
     [STORAGE_KEYS.captureLifecycleEpoch]: captureLifecycleEpoch,
   });
   await updateToolbarBadge().catch((error) =>

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -2033,16 +2033,24 @@ async function recordSuccessfulCapture(
   }
   const completedAt = operation.completedAt;
   const resultState = operation.state;
-  await mutateCaptureOperationalState(ownerId, (current) => ({
-    preferredMode: current.preferredMode,
-    lastCapture: {
-      count: operation.extractedCount,
-      completedAt,
-      state: resultState,
-      resultPath: normalizeConversationResultPath(operation.resultPath),
-      reconciliationRequired: Boolean(operation.reconciliationRequired),
-    },
-  }));
+  await mutateCaptureOperationalState(ownerId, (current) => {
+    if (
+      current.lastCapture &&
+      Date.parse(current.lastCapture.completedAt) >= Date.parse(completedAt)
+    ) {
+      return current;
+    }
+    return {
+      preferredMode: current.preferredMode,
+      lastCapture: {
+        count: operation.extractedCount,
+        completedAt,
+        state: resultState,
+        resultPath: normalizeConversationResultPath(operation.resultPath),
+        reconciliationRequired: Boolean(operation.reconciliationRequired),
+      },
+    };
+  });
   await notifyLauncherStateRefresh();
 }
 

--- a/apps/chrome-extension/src/capture-operational.ts
+++ b/apps/chrome-extension/src/capture-operational.ts
@@ -1,0 +1,118 @@
+import type {
+  CaptureOperationMode,
+  CaptureOperationSnapshot,
+} from "./capture-operation";
+
+export interface LastCaptureSummary {
+  count: number;
+  completedAt: string;
+  state: "received" | "duplicate";
+  resultPath?: string;
+  reconciliationRequired: boolean;
+}
+
+export interface CaptureOperationalState {
+  preferredMode: CaptureOperationMode;
+  lastCapture?: LastCaptureSummary;
+}
+
+export interface StoredCaptureOperationalState extends CaptureOperationalState {
+  ownerId: string;
+}
+
+export interface ToolbarBadgeState {
+  text: "" | "!";
+  color: string;
+  title: string;
+}
+
+export function normalizeCaptureMode(value: unknown): CaptureOperationMode {
+  return value === "guided" || value === "automatic" ? value : "loaded";
+}
+
+export function normalizeConversationResultPath(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return /^\/dashboard\/conversations\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    trimmed,
+  )
+    ? trimmed
+    : undefined;
+}
+
+function normalizeLastCapture(value: unknown): LastCaptureSummary | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = value as Partial<LastCaptureSummary>;
+  if (
+    !Number.isInteger(candidate.count) ||
+    (candidate.count ?? -1) < 0 ||
+    typeof candidate.completedAt !== "string" ||
+    !Number.isFinite(Date.parse(candidate.completedAt)) ||
+    (candidate.state !== "received" && candidate.state !== "duplicate")
+  ) {
+    return undefined;
+  }
+  return {
+    count: candidate.count as number,
+    completedAt: candidate.completedAt,
+    state: candidate.state,
+    resultPath: normalizeConversationResultPath(candidate.resultPath),
+    reconciliationRequired: Boolean(candidate.reconciliationRequired),
+  };
+}
+
+export function operationalStateForOwner(
+  value: unknown,
+  ownerId: string,
+): CaptureOperationalState {
+  if (!value || typeof value !== "object") {
+    return { preferredMode: "loaded" };
+  }
+  const candidate = value as Partial<StoredCaptureOperationalState>;
+  if (candidate.ownerId !== ownerId) {
+    return { preferredMode: "loaded" };
+  }
+  return {
+    preferredMode: normalizeCaptureMode(candidate.preferredMode),
+    lastCapture: normalizeLastCapture(candidate.lastCapture),
+  };
+}
+
+export function deriveToolbarBadge(
+  operations: Iterable<CaptureOperationSnapshot>,
+  legacyQueueCount: number,
+): ToolbarBadgeState {
+  const values = [...operations];
+  if (values.some((operation) => operation.state === "retry-required")) {
+    return {
+      text: "!",
+      color: "#b42318",
+      title: "ConvoLens: reviewed capture needs retry",
+    };
+  }
+  if (legacyQueueCount > 0) {
+    return {
+      text: "!",
+      color: "#b54708",
+      title: "ConvoLens: legacy captures need export or deletion",
+    };
+  }
+  if (
+    values.some(
+      (operation) =>
+        operation.state === "ready-for-review" ||
+        operation.state === "failed" ||
+        operation.state === "cancelled" ||
+        Boolean(operation.reconciliationRequired),
+    )
+  ) {
+    return {
+      text: "!",
+      color: "#175cd3",
+      title: "ConvoLens: capture needs attention",
+    };
+  }
+  return { text: "", color: "#175cd3", title: "ConvoLens" };
+}

--- a/apps/chrome-extension/src/capture-operational.ts
+++ b/apps/chrome-extension/src/capture-operational.ts
@@ -16,9 +16,10 @@ export interface CaptureOperationalState {
   lastCapture?: LastCaptureSummary;
 }
 
-export interface StoredCaptureOperationalState extends CaptureOperationalState {
-  ownerId: string;
-}
+export type StoredCaptureOperationalStates = Record<
+  string,
+  CaptureOperationalState
+>;
 
 export interface ToolbarBadgeState {
   text: "" | "!";
@@ -67,17 +68,47 @@ export function operationalStateForOwner(
   value: unknown,
   ownerId: string,
 ): CaptureOperationalState {
-  if (!value || typeof value !== "object") {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !Object.prototype.hasOwnProperty.call(value, ownerId)
+  ) {
     return { preferredMode: "loaded" };
   }
-  const candidate = value as Partial<StoredCaptureOperationalState>;
-  if (candidate.ownerId !== ownerId) {
+  const candidate = (value as Record<string, unknown>)[ownerId];
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     return { preferredMode: "loaded" };
   }
+  const state = candidate as Partial<CaptureOperationalState>;
   return {
-    preferredMode: normalizeCaptureMode(candidate.preferredMode),
-    lastCapture: normalizeLastCapture(candidate.lastCapture),
+    preferredMode: normalizeCaptureMode(state.preferredMode),
+    lastCapture: normalizeLastCapture(state.lastCapture),
   };
+}
+
+export function withOperationalStateForOwner(
+  value: unknown,
+  ownerId: string,
+  state: CaptureOperationalState,
+): StoredCaptureOperationalStates {
+  const records: StoredCaptureOperationalStates = {};
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [storedOwnerId, candidate] of Object.entries(value)) {
+      if (
+        candidate &&
+        typeof candidate === "object" &&
+        !Array.isArray(candidate)
+      ) {
+        records[storedOwnerId] = operationalStateForOwner(value, storedOwnerId);
+      }
+    }
+  }
+  records[ownerId] = {
+    preferredMode: normalizeCaptureMode(state.preferredMode),
+    lastCapture: normalizeLastCapture(state.lastCapture),
+  };
+  return records;
 }
 
 export function canRestoreReviewedRetry(

--- a/apps/chrome-extension/src/capture-operational.ts
+++ b/apps/chrome-extension/src/capture-operational.ts
@@ -80,6 +80,18 @@ export function operationalStateForOwner(
   };
 }
 
+export function canRestoreReviewedRetry(
+  operation: CaptureOperationSnapshot,
+  persistedOwnerId: unknown,
+  currentOwnerId: unknown,
+): boolean {
+  return (
+    operation.state === "retry-required" &&
+    typeof persistedOwnerId === "string" &&
+    persistedOwnerId === currentOwnerId
+  );
+}
+
 export function deriveToolbarBadge(
   operations: Iterable<CaptureOperationSnapshot>,
   legacyQueueCount: number,
@@ -104,7 +116,6 @@ export function deriveToolbarBadge(
       (operation) =>
         operation.state === "ready-for-review" ||
         operation.state === "failed" ||
-        operation.state === "cancelled" ||
         Boolean(operation.reconciliationRequired),
     )
   ) {

--- a/apps/chrome-extension/src/capture-operational.ts
+++ b/apps/chrome-extension/src/capture-operational.ts
@@ -123,6 +123,15 @@ export function canRestoreReviewedRetry(
   );
 }
 
+export function captureOwnerMatches(
+  persistedOwnerId: unknown,
+  currentOwnerId: unknown,
+): boolean {
+  return (
+    typeof persistedOwnerId === "string" && persistedOwnerId === currentOwnerId
+  );
+}
+
 export function deriveToolbarBadge(
   operations: Iterable<CaptureOperationSnapshot>,
   legacyQueueCount: number,

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -94,6 +94,7 @@ export const STORAGE_KEYS = {
   captureOperations: "captureOperations",
   captureLifecycleEpoch: "captureLifecycleEpoch",
   launcherPosition: "launcherPosition",
+  captureOperationalState: "captureOperationalState",
 };
 
 // =============================================================================
@@ -340,6 +341,20 @@ export interface RefreshLauncherStateMessage {
   action: "REFRESH_LAUNCHER_STATE";
 }
 
+export interface GetCaptureOperationalStateMessage {
+  action: "GET_CAPTURE_OPERATIONAL_STATE";
+}
+
+export interface SetPreferredCaptureModeMessage {
+  action: "SET_PREFERRED_CAPTURE_MODE";
+  mode: import("./capture-operation").CaptureOperationMode;
+}
+
+export interface ExportCaptureOperationPayloadMessage {
+  action: "EXPORT_CAPTURE_OPERATION_PAYLOAD";
+  operationId: string;
+}
+
 // Union type of all message types
 export type ExtensionMessage =
   | GetCurrentChatMessage
@@ -374,7 +389,10 @@ export type ExtensionMessage =
   | UpdateSettingsMessage
   | ClearPendingUploadsMessage
   | GetLegacyQueueSummaryMessage
-  | RefreshLauncherStateMessage;
+  | RefreshLauncherStateMessage
+  | GetCaptureOperationalStateMessage
+  | SetPreferredCaptureModeMessage
+  | ExportCaptureOperationPayloadMessage;
 
 // Helper type to extract action names
 export type MessageAction = ExtensionMessage["action"];

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -92,6 +92,7 @@ export const STORAGE_KEYS = {
   extractionHistory: "extractionHistory",
   pendingUploads: "pendingUploads",
   captureOperations: "captureOperations",
+  captureOperationOwners: "captureOperationOwners",
   captureLifecycleEpoch: "captureLifecycleEpoch",
   launcherPosition: "launcherPosition",
   captureOperationalState: "captureOperationalState",

--- a/apps/chrome-extension/src/content.css
+++ b/apps/chrome-extension/src/content.css
@@ -139,6 +139,7 @@
 
 .ws-launcher-panel[hidden],
 .ws-capture-review[hidden],
+.ws-operational-actions[hidden],
 .ws-legacy-attention[hidden] {
   display: none !important;
 }
@@ -450,6 +451,10 @@
   margin-top: 0;
 }
 
+.ws-wide-action {
+  grid-column: 1 / -1;
+}
+
 .ws-secondary-btn {
   min-height: 40px;
   padding: 9px 12px;
@@ -475,6 +480,29 @@
   border-radius: 10px;
   background: #fff7e8;
   color: #7a2e0e;
+}
+
+.ws-operational-actions,
+.ws-roadmap-preview {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid var(--ws-border);
+  border-radius: 10px;
+  background: var(--ws-surface-muted);
+  font-size: 12px;
+}
+
+.ws-operational-actions span,
+.ws-roadmap-preview span {
+  color: var(--ws-text-muted);
+}
+
+.ws-roadmap-preview b {
+  color: var(--ws-accent-strong);
+  font-size: 10px;
+  text-transform: uppercase;
 }
 
 .ws-legacy-attention strong {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -728,9 +728,9 @@ function renderOperationalActions(): void {
       ? launcherOperation
       : null;
   const resultState = terminalOperation?.state || lastCapture?.state;
-  const reconciliationRequired =
-    terminalOperation?.reconciliationRequired ||
-    lastCapture?.reconciliationRequired;
+  const reconciliationRequired = terminalOperation
+    ? Boolean(terminalOperation.reconciliationRequired)
+    : Boolean(lastCapture?.reconciliationRequired);
   result.textContent = reconciliationRequired
     ? "New conversation stored separately — reconciliation needed"
     : resultState === "duplicate"

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -702,8 +702,7 @@ function updateLegacyQueueState(count: number): void {
 function currentResultPath(): string | undefined {
   if (
     launcherOperation &&
-    ["received", "duplicate"].includes(launcherOperation.state) &&
-    launcherOperation.resultPath
+    ["received", "duplicate"].includes(launcherOperation.state)
   ) {
     return launcherOperation.resultPath;
   }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1310,7 +1310,10 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
   launcherOperation = operation;
   if (
     (operation.state === "received" || operation.state === "duplicate") &&
-    operation.completedAt
+    operation.completedAt &&
+    (!launcherOperationalState.lastCapture ||
+      Date.parse(operation.completedAt) >=
+        Date.parse(launcherOperationalState.lastCapture.completedAt))
   ) {
     launcherOperationalState = {
       ...launcherOperationalState,

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -32,6 +32,7 @@ import type {
   CaptureOperationState,
   CaptureStopReason,
 } from "./capture-operation";
+import type { CaptureOperationalState } from "./capture-operational";
 import {
   AUTOMATIC_CAPTURE_SAFETY_CAP,
   AUTOMATIC_NO_PROGRESS_LIMIT,
@@ -219,6 +220,9 @@ let lastCountedTerminalOperationId: string | null = null;
 const chatIdentityTokens = new Map<string, string>();
 let launcherPosition: LauncherPosition = DEFAULT_LAUNCHER_POSITION;
 let launcherOperation: CaptureOperationSnapshot | null = null;
+let launcherOperationalState: CaptureOperationalState = {
+  preferredMode: "loaded",
+};
 let legacyQueueCount = 0;
 let launcherSuppressClick = false;
 let launcherAuthRefreshGeneration = 0;
@@ -426,7 +430,18 @@ async function injectUI(): Promise<void> {
         <div class="ws-preview-actions">
           <button id="ws-confirm-capture" class="ws-capture-btn" type="button">Confirm upload</button>
           <button id="ws-cancel-capture" class="ws-secondary-btn" type="button">Cancel</button>
+          <button id="ws-export-capture" class="ws-secondary-btn ws-wide-action" type="button">Export reviewed JSON</button>
         </div>
+      </section>
+      <section id="ws-operational-actions" class="ws-operational-actions" aria-label="Capture result" hidden>
+        <strong id="ws-result-label">No capture result yet</strong>
+        <span id="ws-last-capture">Last capture: none yet</span>
+        <button id="ws-open-conversation" class="ws-secondary-btn" type="button" hidden>Open received conversation</button>
+      </section>
+      <section class="ws-roadmap-preview" aria-label="Planned capture actions">
+        <strong>Coming next</strong>
+        <span>Select individual messages — <b>Soon</b></span>
+        <span>Match participants — <b>Soon</b></span>
       </section>
       <div id="ws-legacy-attention" class="ws-legacy-attention" hidden>
         <strong>Legacy local captures need review</strong>
@@ -471,6 +486,25 @@ async function injectUI(): Promise<void> {
     .getElementById("ws-cancel-capture")
     ?.addEventListener("click", () => {
       if (launcherOperation) void reviewPageCapture(launcherOperation, false);
+    });
+  document
+    .getElementById("ws-export-capture")
+    ?.addEventListener("click", () => {
+      if (!launcherOperation) return;
+      try {
+        const filename = exportCaptureOperationPayload(
+          launcherOperation.operationId,
+        );
+        updateStatus(`Exported ${filename}.`, "success");
+      } catch (error) {
+        updateStatus(normalizeErrorMessage(error), "error");
+      }
+    });
+  document
+    .getElementById("ws-open-conversation")
+    ?.addEventListener("click", () => {
+      const path = currentResultPath();
+      if (path) void openReceivedConversation(path);
     });
   document.getElementById("ws-stop-guided")?.addEventListener("click", () => {
     if (launcherOperation) void stopPageCollection(launcherOperation);
@@ -665,13 +699,72 @@ function updateLegacyQueueState(count: number): void {
   updateLauncherBadge(launcherOperation);
 }
 
+function currentResultPath(): string | undefined {
+  if (
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state) &&
+    launcherOperation.resultPath
+  ) {
+    return launcherOperation.resultPath;
+  }
+  return launcherOperationalState.lastCapture?.resultPath;
+}
+
+function renderOperationalActions(): void {
+  const section = document.getElementById("ws-operational-actions");
+  const result = document.getElementById("ws-result-label");
+  const last = document.getElementById("ws-last-capture");
+  const open = document.getElementById(
+    "ws-open-conversation",
+  ) as HTMLButtonElement | null;
+  if (!section || !result || !last || !open) return;
+  section.hidden = authToken === null;
+  if (section.hidden) return;
+
+  const lastCapture = launcherOperationalState.lastCapture;
+  const terminalOperation =
+    launcherOperation &&
+    ["received", "duplicate"].includes(launcherOperation.state)
+      ? launcherOperation
+      : null;
+  const resultState = terminalOperation?.state || lastCapture?.state;
+  const reconciliationRequired =
+    terminalOperation?.reconciliationRequired ||
+    lastCapture?.reconciliationRequired;
+  result.textContent = reconciliationRequired
+    ? "New conversation stored separately — reconciliation needed"
+    : resultState === "duplicate"
+      ? "Existing conversation found — no duplicate created"
+      : resultState === "received"
+        ? "New conversation received"
+        : "No capture result yet";
+  last.textContent = lastCapture
+    ? `Last capture: ${lastCapture.count} message${lastCapture.count === 1 ? "" : "s"} · ${formatPreviewTimestamp(lastCapture.completedAt)}`
+    : "Last capture: none yet";
+  open.hidden = !currentResultPath();
+}
+
+async function openReceivedConversation(path: string): Promise<void> {
+  try {
+    const response = (await chrome.runtime.sendMessage({
+      action: "OPEN_DASHBOARD",
+      path,
+    })) as ExtensionResponse;
+    if (!response.success) updateStatus(response.error, "error");
+  } catch (error) {
+    updateStatus(normalizeErrorMessage(error), "error");
+  }
+}
+
 function resetLauncherAccountState(authenticated: boolean): void {
   launcherOperationRenderGeneration += 1;
   launcherOperation = null;
+  launcherOperationalState = { preferredMode: "loaded" };
   pageConfirmationOperationId = null;
   const review = document.getElementById("ws-capture-review");
   if (review) review.hidden = true;
   updateLegacyQueueState(0);
+  renderOperationalActions();
   updateProgress(0);
   updateStatus(
     authenticated
@@ -722,14 +815,28 @@ async function refreshLauncherAuthenticationState(
   const operationRenderGeneration = launcherOperationRenderGeneration;
 
   try {
-    const [operationResponse, legacyResponse] = (await Promise.all([
-      chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
-      chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
-    ])) as [
-      ExtensionResponse<CaptureOperationSnapshot>,
-      ExtensionResponse<{ count: number }>,
-    ];
+    const [operationResponse, legacyResponse, operationalResponse] =
+      (await Promise.all([
+        chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATION" }),
+        chrome.runtime.sendMessage({ action: "GET_LEGACY_QUEUE_SUMMARY" }),
+        chrome.runtime.sendMessage({ action: "GET_CAPTURE_OPERATIONAL_STATE" }),
+      ])) as [
+        ExtensionResponse<CaptureOperationSnapshot>,
+        ExtensionResponse<{ count: number }>,
+        ExtensionResponse<CaptureOperationalState>,
+      ];
     if (refreshGeneration !== launcherAuthRefreshGeneration) return;
+    if (operationalResponse.success && operationalResponse.data) {
+      launcherOperationalState = operationalResponse.data;
+      if (!(operationResponse.success && operationResponse.data)) {
+        applyPageCaptureMode(
+          operationalResponse.data.preferredMode === "guided"
+            ? "scroll"
+            : operationalResponse.data.preferredMode,
+        );
+      }
+      renderOperationalActions();
+    }
     if (
       operationRenderGeneration === launcherOperationRenderGeneration &&
       operationResponse.success &&
@@ -902,6 +1009,43 @@ function renderPageCapturePreview(operation: CaptureOperationSnapshot): void {
   review.hidden = false;
 }
 
+function exportCaptureOperationPayload(operationId: string): string {
+  const operation = activeCaptureOperation;
+  if (
+    !operation ||
+    operation.operationId !== operationId ||
+    !operation.payload ||
+    !["ready-for-review", "retry-required"].includes(operation.state) ||
+    operation.chatIdentity !== getCurrentChatIdentity()
+  ) {
+    throw new Error(
+      "The reviewed capture is no longer available in this tab. Recapture before exporting.",
+    );
+  }
+  const safeName =
+    operation.payload.chatName
+      .normalize("NFKD")
+      .replace(/[^a-z0-9]+/gi, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "whatsapp-capture";
+  const filename = `convolens-${safeName}-${new Date()
+    .toISOString()
+    .replace(/[:.]/g, "-")}.json`;
+  const blob = new Blob([JSON.stringify(operation.payload, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.hidden = true;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  return filename;
+}
+
 function applyPageCaptureMode(selectedMode: string): void {
   document
     .querySelectorAll<HTMLElement>(".ws-capture-mode")
@@ -925,6 +1069,19 @@ function handleCaptureModeChange(event: Event): void {
   const selectedMode = (event.target as HTMLInputElement).value;
   const generation = ++launcherModeChangeGeneration;
   applyPageCaptureMode(selectedMode);
+  const preferredMode =
+    selectedMode === "scroll"
+      ? "guided"
+      : selectedMode === "automatic"
+        ? "automatic"
+        : "loaded";
+  launcherOperationalState = {
+    ...launcherOperationalState,
+    preferredMode,
+  };
+  void chrome.runtime
+    .sendMessage({ action: "SET_PREFERRED_CAPTURE_MODE", mode: preferredMode })
+    .catch(() => undefined);
   if (
     launcherOperation &&
     ((launcherOperation.mode === "loaded" && selectedMode !== "loaded") ||
@@ -1151,7 +1308,33 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
   if (operation.authGeneration !== launcherCaptureAuthGeneration) return false;
   launcherOperationRenderGeneration += 1;
   launcherOperation = operation;
-  const modeValue = operation.mode === "guided" ? "scroll" : operation.mode;
+  if (
+    (operation.state === "received" || operation.state === "duplicate") &&
+    operation.completedAt
+  ) {
+    launcherOperationalState = {
+      ...launcherOperationalState,
+      lastCapture: {
+        count: operation.extractedCount,
+        completedAt: operation.completedAt,
+        state: operation.state,
+        resultPath: operation.resultPath,
+        reconciliationRequired: Boolean(operation.reconciliationRequired),
+      },
+    };
+  }
+  const operationOwnsMode = [
+    "inspecting",
+    "collecting",
+    "paused",
+    "ready-for-review",
+    "uploading",
+    "retry-required",
+  ].includes(operation.state);
+  const selectedMode = operationOwnsMode
+    ? operation.mode
+    : launcherOperationalState.preferredMode;
+  const modeValue = selectedMode === "guided" ? "scroll" : selectedMode;
   document
     .querySelectorAll<HTMLInputElement>('input[name="ws-capture-mode"]')
     .forEach((input) => {
@@ -1167,6 +1350,7 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
   const automaticOptions = document.getElementById("ws-automatic-options");
   if (automaticOptions) automaticOptions.hidden = modeValue !== "automatic";
   updateLauncherBadge(operation);
+  renderOperationalActions();
   renderPageCapturePreview(operation);
   renderPageGuidedProgress(operation);
   if (activeCaptureOperation?.operationId === operation.operationId) {
@@ -1182,7 +1366,13 @@ function renderCaptureOperation(operation: CaptureOperationSnapshot): boolean {
       "paused",
       "uploading",
     ].includes(operation.state);
-    button.textContent = getLauncherActionLabel(operation);
+    button.textContent = operationOwnsMode
+      ? getLauncherActionLabel(operation)
+      : selectedMode === "guided"
+        ? "Start guided capture"
+        : selectedMode === "automatic"
+          ? "Load older messages"
+          : "Review loaded messages";
   }
 
   switch (operation.state) {
@@ -3215,6 +3405,15 @@ function handleMessage(
         });
       } else {
         sendResponse({ success: true, data: activeCaptureOperation.payload });
+      }
+      break;
+
+    case "EXPORT_CAPTURE_OPERATION_PAYLOAD":
+      try {
+        const filename = exportCaptureOperationPayload(message.operationId);
+        sendResponse({ success: true, data: { filename } });
+      } catch (error) {
+        sendResponse({ success: false, error: normalizeErrorMessage(error) });
       }
       break;
 

--- a/apps/chrome-extension/tests/phase3-operation-state.test.ts
+++ b/apps/chrome-extension/tests/phase3-operation-state.test.ts
@@ -225,7 +225,14 @@ test("keeps in-flight upload truth across logout and tab closure", () => {
     backgroundSource.indexOf("// Message Handler"),
   );
   assert.doesNotMatch(tabRemoval, /isActiveCaptureState/);
-  assert.doesNotMatch(tabRemoval, /"uploading"/);
+  assert.match(
+    tabRemoval,
+    /operation\.state === "uploading"[\s\S]*closedCaptureTabIds\.add\(tabId\)[\s\S]*return;/,
+  );
+  assert.ok(
+    tabRemoval.indexOf('operation.state === "uploading"') <
+      tabRemoval.indexOf("finishCaptureOperation"),
+  );
 });
 
 test("rejects late collection responses after background cancellation", () => {

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import type { CaptureOperationSnapshot } from "../src/capture-operation";
 import {
+  canRestoreReviewedRetry,
   deriveToolbarBadge,
   normalizeConversationResultPath,
   operationalStateForOwner,
@@ -99,13 +100,14 @@ test("prioritizes retry, legacy migration, then other attention in the toolbar",
 });
 
 test("preserves only retry metadata across worker restart and fails closed without tab payload", () => {
+  const retry = operation("retry-required");
+  assert.equal(canRestoreReviewedRetry(retry, "owner-a", "owner-a"), true);
+  assert.equal(canRestoreReviewedRetry(retry, "owner-a", "owner-b"), false);
+  assert.equal(canRestoreReviewedRetry(retry, undefined, "owner-a"), false);
+  assert.match(backgroundSource, /STORAGE_KEYS\.captureOperationOwners/);
   assert.match(
     backgroundSource,
-    /canRestoreReviewedRetry[\s\S]*operation\.state === "retry-required"/,
-  );
-  assert.match(
-    backgroundSource,
-    /captureOperationOwnerIds\.set\(restored\.operationId, restoredOwnerId\)/,
+    /captureOperationOwnerIds\.set\([\s\S]*persistedOwnerId as string/,
   );
   assert.match(
     contentSource,
@@ -143,7 +145,19 @@ test("shows results, last capture, remembered mode, and exactly two planned acti
     assert.match(source, /SET_PREFERRED_CAPTURE_MODE/);
   }
   assert.match(popupSource, /GET_CAPTURE_OPERATIONAL_STATE/);
+  assert.match(
+    popupSource,
+    /showLoggedIn\(result\.data\?\.user\);\s*await refreshOperationalState\(\)/,
+  );
   assert.match(contentSource, /GET_CAPTURE_OPERATIONAL_STATE/);
   assert.equal((popupHtml.match(/— <b>Soon<\/b>/g) || []).length, 2);
   assert.equal((contentSource.match(/— <b>Soon<\/b>/g) || []).length, 2);
+});
+
+test("removes closed-tab captures without leaving permanent badge attention", () => {
+  assert.equal(deriveToolbarBadge([operation("cancelled")], 0).text, "");
+  assert.match(
+    backgroundSource,
+    /handleCaptureTabRemoved[\s\S]*captureOperations\.delete\(tabId\)[\s\S]*captureOperationOwnerIds\.delete\(operation\.operationId\)/,
+  );
 });

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import type { CaptureOperationSnapshot } from "../src/capture-operation";
+import {
+  deriveToolbarBadge,
+  normalizeConversationResultPath,
+  operationalStateForOwner,
+} from "../src/capture-operational";
+
+const read = (path: string) =>
+  readFileSync(new URL(path, import.meta.url), "utf8");
+const backgroundSource = read("../src/background.ts");
+const contentSource = read("../src/content.ts");
+const popupSource = read("../popup/popup.js");
+const popupHtml = read("../popup/popup.html");
+const manifest = JSON.parse(read("../manifest.json"));
+
+function operation(
+  state: CaptureOperationSnapshot["state"],
+  reconciliationRequired = false,
+): CaptureOperationSnapshot {
+  return {
+    operationId: crypto.randomUUID(),
+    authGeneration: 1,
+    tabId: 1,
+    initiator: "popup",
+    mode: "loaded",
+    state,
+    renderedCount: 12,
+    collectedCount: 12,
+    extractedCount: 12,
+    skippedCount: 0,
+    unreadableCount: 0,
+    participantLabelCount: 2,
+    alignmentWarningCount: 0,
+    mediaCount: 0,
+    reconciliationRequired,
+    startedAt: "2026-07-29T12:00:00.000Z",
+  };
+}
+
+test("accepts only exact persisted conversation result paths", () => {
+  const path = "/dashboard/conversations/1d3e4567-e89b-42d3-a456-426614174000";
+  assert.equal(normalizeConversationResultPath(path), path);
+  assert.equal(
+    normalizeConversationResultPath("https://evil.example/x"),
+    undefined,
+  );
+  assert.equal(normalizeConversationResultPath("/dashboard"), undefined);
+  assert.match(backgroundSource, /normalizeConversationResultPath\(path\)/);
+  assert.match(popupHtml, /id="openConversation"/);
+  assert.match(contentSource, /id="ws-open-conversation"/);
+});
+
+test("keeps preferences and last capture scoped to the authenticated owner", () => {
+  const stored = {
+    ownerId: "owner-a",
+    preferredMode: "automatic",
+    lastCapture: {
+      count: 42,
+      completedAt: "2026-07-29T12:01:00.000Z",
+      state: "received",
+      resultPath:
+        "/dashboard/conversations/1d3e4567-e89b-42d3-a456-426614174000",
+      reconciliationRequired: false,
+    },
+  };
+  assert.equal(
+    operationalStateForOwner(stored, "owner-a").preferredMode,
+    "automatic",
+  );
+  assert.deepEqual(operationalStateForOwner(stored, "owner-b"), {
+    preferredMode: "loaded",
+  });
+  assert.match(backgroundSource, /STORAGE_KEYS\.captureOperationalState/);
+  assert.doesNotMatch(
+    read("../src/capture-operational.ts"),
+    /messages|payload/,
+  );
+});
+
+test("prioritizes retry, legacy migration, then other attention in the toolbar", () => {
+  assert.equal(
+    deriveToolbarBadge([operation("retry-required")], 2).title,
+    "ConvoLens: reviewed capture needs retry",
+  );
+  assert.equal(
+    deriveToolbarBadge([], 2).title,
+    "ConvoLens: legacy captures need export or deletion",
+  );
+  assert.equal(
+    deriveToolbarBadge([operation("ready-for-review")], 0).title,
+    "ConvoLens: capture needs attention",
+  );
+  assert.equal(deriveToolbarBadge([operation("received")], 0).text, "");
+  assert.match(backgroundSource, /chrome\.action\.setBadgeText/);
+  assert.ok(!manifest.permissions.includes("downloads"));
+});
+
+test("preserves only retry metadata across worker restart and fails closed without tab payload", () => {
+  assert.match(
+    backgroundSource,
+    /canRestoreReviewedRetry[\s\S]*operation\.state === "retry-required"/,
+  );
+  assert.match(
+    backgroundSource,
+    /captureOperationOwnerIds\.set\(restored\.operationId, restoredOwnerId\)/,
+  );
+  assert.match(
+    contentSource,
+    /EXPORT_CAPTURE_OPERATION_PAYLOAD[\s\S]*exportCaptureOperationPayload/,
+  );
+  assert.match(
+    contentSource,
+    /The reviewed capture is no longer available in this tab\. Recapture before exporting\./,
+  );
+  assert.match(
+    backgroundSource,
+    /GET_CAPTURE_OPERATION_PAYLOAD[\s\S]*The reviewed capture is no longer available in this tab/,
+  );
+});
+
+test("exports the exact reviewed in-tab payload without a raw background queue", () => {
+  assert.match(contentSource, /JSON\.stringify\(operation\.payload, null, 2\)/);
+  assert.match(contentSource, /URL\.createObjectURL\(blob\)/);
+  assert.match(
+    contentSource,
+    /operation\.chatIdentity !== getCurrentChatIdentity\(\)/,
+  );
+  assert.doesNotMatch(
+    backgroundSource,
+    /queuePendingUpload|retryPendingUploads/,
+  );
+  assert.ok(!manifest.permissions.includes("downloads"));
+});
+
+test("shows results, last capture, remembered mode, and exactly two planned actions", () => {
+  for (const source of [popupSource, contentSource]) {
+    assert.match(source, /Existing conversation found — no duplicate created/);
+    assert.match(source, /New conversation received/);
+    assert.match(source, /Last capture:/);
+    assert.match(source, /SET_PREFERRED_CAPTURE_MODE/);
+  }
+  assert.match(popupSource, /GET_CAPTURE_OPERATIONAL_STATE/);
+  assert.match(contentSource, /GET_CAPTURE_OPERATIONAL_STATE/);
+  assert.equal((popupHtml.match(/— <b>Soon<\/b>/g) || []).length, 2);
+  assert.equal((contentSource.match(/— <b>Soon<\/b>/g) || []).length, 2);
+});

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -215,3 +215,19 @@ test("recalculates the toolbar badge when options refreshes legacy state", () =>
     /case "REFRESH_LAUNCHER_STATE":[\s\S]*await updateToolbarBadge\(\)[\s\S]*await notifyLauncherStateRefresh\(\)/,
   );
 });
+
+test("preserves a newer aggregate result when an older tab operation renders", () => {
+  for (const source of [popupSource, contentSource]) {
+    assert.match(
+      source,
+      /Date\.parse\(operation\.completedAt\) >=\s*Date\.parse\([^)]*lastCapture\.completedAt\)/,
+    );
+  }
+});
+
+test("broadcasts preferred-mode changes to every live launcher", () => {
+  assert.match(
+    backgroundSource,
+    /async function setPreferredCaptureMode[\s\S]*mutateCaptureOperationalState[\s\S]*await notifyLauncherStateRefresh\(\)[\s\S]*return \{ success: true, data: state \}/,
+  );
+});

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -7,6 +7,7 @@ import {
   deriveToolbarBadge,
   normalizeConversationResultPath,
   operationalStateForOwner,
+  withOperationalStateForOwner,
 } from "../src/capture-operational";
 
 const read = (path: string) =>
@@ -56,15 +57,16 @@ test("accepts only exact persisted conversation result paths", () => {
 
 test("keeps preferences and last capture scoped to the authenticated owner", () => {
   const stored = {
-    ownerId: "owner-a",
-    preferredMode: "automatic",
-    lastCapture: {
-      count: 42,
-      completedAt: "2026-07-29T12:01:00.000Z",
-      state: "received",
-      resultPath:
-        "/dashboard/conversations/1d3e4567-e89b-42d3-a456-426614174000",
-      reconciliationRequired: false,
+    "owner-a": {
+      preferredMode: "automatic",
+      lastCapture: {
+        count: 42,
+        completedAt: "2026-07-29T12:01:00.000Z",
+        state: "received",
+        resultPath:
+          "/dashboard/conversations/1d3e4567-e89b-42d3-a456-426614174000",
+        reconciliationRequired: false,
+      },
     },
   };
   assert.equal(
@@ -74,6 +76,17 @@ test("keeps preferences and last capture scoped to the authenticated owner", () 
   assert.deepEqual(operationalStateForOwner(stored, "owner-b"), {
     preferredMode: "loaded",
   });
+  const withOwnerB = withOperationalStateForOwner(stored, "owner-b", {
+    preferredMode: "guided",
+  });
+  assert.equal(
+    operationalStateForOwner(withOwnerB, "owner-a").preferredMode,
+    "automatic",
+  );
+  assert.equal(
+    operationalStateForOwner(withOwnerB, "owner-b").preferredMode,
+    "guided",
+  );
   assert.match(backgroundSource, /STORAGE_KEYS\.captureOperationalState/);
   assert.doesNotMatch(
     read("../src/capture-operational.ts"),

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -232,6 +232,17 @@ test("preserves the newest aggregate result inside the serialized storage mutati
   );
 });
 
+test("does not open an older aggregate link for a terminal result without a path", () => {
+  assert.match(
+    popupSource,
+    /\["received", "duplicate"\]\.includes\(currentOperation\.state\)\s*\) \{\s*return currentOperation\.resultPath;/,
+  );
+  assert.match(
+    contentSource,
+    /\["received", "duplicate"\]\.includes\(launcherOperation\.state\)\s*\) \{\s*return launcherOperation\.resultPath;/,
+  );
+});
+
 test("broadcasts preferred-mode changes to every live launcher", () => {
   assert.match(
     backgroundSource,

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -225,6 +225,13 @@ test("preserves a newer aggregate result when an older tab operation renders", (
   }
 });
 
+test("preserves the newest aggregate result inside the serialized storage mutation", () => {
+  assert.match(
+    backgroundSource,
+    /current\.lastCapture[\s\S]*Date\.parse\(current\.lastCapture\.completedAt\) >= Date\.parse\(completedAt\)[\s\S]*return current/,
+  );
+});
+
 test("broadcasts preferred-mode changes to every live launcher", () => {
   assert.match(
     backgroundSource,

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -201,3 +201,17 @@ test("ties reconciliation state to the same result shown and opened", () => {
     );
   }
 });
+
+test("refreshes every launcher after successful aggregate metadata changes", () => {
+  assert.match(
+    backgroundSource,
+    /async function recordSuccessfulCapture[\s\S]*mutateCaptureOperationalState[\s\S]*await notifyLauncherStateRefresh\(\)/,
+  );
+});
+
+test("recalculates the toolbar badge when options refreshes legacy state", () => {
+  assert.match(
+    backgroundSource,
+    /case "REFRESH_LAUNCHER_STATE":[\s\S]*await updateToolbarBadge\(\)[\s\S]*await notifyLauncherStateRefresh\(\)/,
+  );
+});

--- a/apps/chrome-extension/tests/phase8-operational-actions.test.ts
+++ b/apps/chrome-extension/tests/phase8-operational-actions.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import type { CaptureOperationSnapshot } from "../src/capture-operation";
 import {
   canRestoreReviewedRetry,
+  captureOwnerMatches,
   deriveToolbarBadge,
   normalizeConversationResultPath,
   operationalStateForOwner,
@@ -117,6 +118,8 @@ test("preserves only retry metadata across worker restart and fails closed witho
   assert.equal(canRestoreReviewedRetry(retry, "owner-a", "owner-a"), true);
   assert.equal(canRestoreReviewedRetry(retry, "owner-a", "owner-b"), false);
   assert.equal(canRestoreReviewedRetry(retry, undefined, "owner-a"), false);
+  assert.equal(captureOwnerMatches("owner-a", "owner-a"), true);
+  assert.equal(captureOwnerMatches("owner-a", "owner-b"), false);
   assert.match(backgroundSource, /STORAGE_KEYS\.captureOperationOwners/);
   assert.match(
     backgroundSource,
@@ -171,6 +174,30 @@ test("removes closed-tab captures without leaving permanent badge attention", ()
   assert.equal(deriveToolbarBadge([operation("cancelled")], 0).text, "");
   assert.match(
     backgroundSource,
-    /handleCaptureTabRemoved[\s\S]*captureOperations\.delete\(tabId\)[\s\S]*captureOperationOwnerIds\.delete\(operation\.operationId\)/,
+    /handleCaptureTabRemoved[\s\S]*operation\.state === "uploading"[\s\S]*closedCaptureTabIds\.add\(tabId\)[\s\S]*removeCaptureOperation\(operation\)/,
   );
+  assert.match(
+    backgroundSource,
+    /closedCaptureTabIds\.has\(operation\.tabId\)[\s\S]*operation\.state !== "uploading"[\s\S]*removeCaptureOperation\(operation\)/,
+  );
+});
+
+test("drops every restored snapshot that does not belong to the current owner", () => {
+  assert.match(
+    backgroundSource,
+    /if \(!captureOwnerMatches\(persistedOwnerId, restoredOwnerId\)\) \{\s*discarded\.push\(operation\);\s*continue;/,
+  );
+  assert.match(
+    backgroundSource,
+    /for \(const operation of discarded\) \{\s*await discardCapturePayload\(operation\);/,
+  );
+});
+
+test("ties reconciliation state to the same result shown and opened", () => {
+  for (const source of [popupSource, contentSource]) {
+    assert.match(
+      source,
+      /const reconciliationRequired = terminalOperation\s*\? Boolean\(terminalOperation\.reconciliationRequired\)\s*:/,
+    );
+  }
 });

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.18");
+  assert.equal(manifest.version, "1.0.19");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 129 passed, 0 failed.
+- Chrome extension Node tests: 131 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `D541BD8074329DD3B7B275FDC1B0AE40C1AE03938C60392616A2C8CF0BA6BB7E`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, closed-tab badge cleanup, immediate post-sign-in operational-state refresh, and retaining separate aggregate preferences/results for each owner that uses the browser profile. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `EFD95331F49BA2E11A211B47DA4DDFBDD06EB00D4A24D062FF5DC3AA6211E777`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, and keeping reconciliation truth tied to the result displayed for the active tab. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 135 passed, 0 failed.
+- Chrome extension Node tests: 136 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `E5393DFB29F631861B702DE54254A1843780D84709AD359F02FEF64B7EBD54CF`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture without overwriting a newer aggregate result, recalculating the toolbar badge after Options removes the legacy queue, and broadcasting preferred-mode changes to every live launcher. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `56A4E9BABDD8D00E6271E9DBFB2459207F1782953795182C3F6EDB9D8057F017`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture without overwriting a newer aggregate result, preserving the newest aggregate result inside the serialized storage mutation, recalculating the toolbar badge after Options removes the legacy queue, and broadcasting preferred-mode changes to every live launcher. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -1,0 +1,52 @@
+# ConvoLens extension capture Phase 8 handoff — 2026-07-30
+
+## Outcome
+
+Phase 8 completes the practical post-capture loop while preserving the prior review, ownership, and in-tab raw-data boundaries.
+
+- The popup and WhatsApp launcher can open the exact received dashboard conversation after a successful intake response.
+- Result paths are accepted only when they match `/dashboard/conversations/{uuid}` exactly; arbitrary URLs and broader dashboard paths are rejected.
+- Both surfaces distinguish a newly received conversation, a deterministic duplicate, and a separately stored conversation that requires reconciliation.
+- The last successful capture count and completion time are retained as owner-scoped aggregate metadata.
+- The preferred loaded, guided, or automatic capture mode is remembered for the authenticated owner.
+- A reviewed payload can be exported locally from the active WhatsApp tab while it is still in `ready-for-review` or `retry-required` state and the same chat remains selected.
+- Export serializes the exact reviewed payload with presentation-only JSON whitespace. It does not add the `downloads` permission or pass raw messages through the service worker.
+- The browser-toolbar badge prioritizes retry-required, then legacy export/delete migration, then other capture attention. It adds no extension permission.
+- A retry-required operation can restore only its non-sensitive operation snapshot after a service-worker restart. If the reviewed tab payload is unavailable, retry and export fail closed and require recapture and review.
+- Legacy raw entries remain explicit export-or-confirmed-delete only; Phase 8 introduces no durable raw-message queue or automatic legacy transmission.
+- The expanded popup and launcher show exactly two unavailable roadmap previews: `Select individual messages — Soon` and `Match participants — Soon`.
+- Extension runtime and package metadata are synchronized at `1.0.19`.
+
+## Repository state
+
+- Base: `origin/main` at `5f179f6f884369b3616ffd653636ea4db59cf8d3` (merged PR #155).
+- Branch: `agent/extension-capture-phase8`.
+- Worktree: `C:/tmp/convolens-extension-phase8`.
+- Pull request: pending publication.
+- The primary checkout and its pre-existing untracked handoff remain untouched.
+
+## Validation
+
+- Chrome extension Node tests: 128 passed, 0 failed.
+- Chrome extension TypeScript: passed.
+- Popup JavaScript syntax: passed.
+- Prettier and `git diff --check`: passed.
+- Focused API conversation-intake service tests: 29 passed, 0 failed, supporting deterministic duplicate and authenticated-user isolation behavior.
+- Repository Turbo build: 8 of 8 packages passed.
+- Production extension build and package: passed.
+- Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
+- Packaged ZIP SHA-256: `C0FB47800051336212DD356F98FBF0BBD805C26C74E5B0F08E2B0C4E84DFC686`.
+- No visual or authentic WhatsApp acceptance is claimed.
+
+## Boundaries still open
+
+- No extension, API, web, database, or Azure deployment is included.
+- No authentic WhatsApp connected-send, persistence, duplicate, reconciliation, popup-close, navigation, service-worker restart, cross-user isolation, deletion, or console-attribution evidence is claimed.
+- A browser toolbar badge, popup acknowledgement, automated test, package, CI result, or synthetic fixture is not authentic WhatsApp acceptance.
+- Retry remains possible only while the exact reviewed raw payload survives in the same WhatsApp tab. Tab loss requires recapture and review.
+- Only aggregate result metadata is persisted. Raw message text, raw WhatsApp identifiers, chat names, and participant evidence are not added to extension storage by this phase.
+- The two `Soon` actions are previews only and have no executable behavior.
+
+## Continuation
+
+After Phase 8 is reviewed and merged, create Phase 9 from current `origin/main`. Phase 9 should consolidate the automated release matrix, inspect the packaged ZIP, record exact-head CI/review evidence, and publish a durable closeout that clearly leaves the authorized long-conversation WhatsApp acceptance matrix operator-held until it is genuinely executed.

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `FCA8D4BC01C98AA65A588129455A2523F059E7E296CE55F08862F4D4A047B5ED`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, closed-tab badge cleanup, and immediate post-sign-in operational-state refresh. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `D541BD8074329DD3B7B275FDC1B0AE40C1AE03938C60392616A2C8CF0BA6BB7E`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, closed-tab badge cleanup, immediate post-sign-in operational-state refresh, and retaining separate aggregate preferences/results for each owner that uses the browser profile. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -22,7 +22,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Base: `origin/main` at `5f179f6f884369b3616ffd653636ea4db59cf8d3` (merged PR #155).
 - Branch: `agent/extension-capture-phase8`.
 - Worktree: `C:/tmp/convolens-extension-phase8`.
-- Pull request: pending publication.
+- Pull request: [#156](https://github.com/neuralliquid/convolens/pull/156).
 - The primary checkout and its pre-existing untracked handoff remain untouched.
 
 ## Validation

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 131 passed, 0 failed.
+- Chrome extension Node tests: 133 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `EFD95331F49BA2E11A211B47DA4DDFBDD06EB00D4A24D062FF5DC3AA6211E777`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, and keeping reconciliation truth tied to the result displayed for the active tab. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `01C0ECB13100D90043BC51CB82EC347BB8CC2AE075B18952EB881B02A03FCD9E`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture, and recalculating the toolbar badge after Options removes the legacy queue. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 133 passed, 0 failed.
+- Chrome extension Node tests: 135 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `01C0ECB13100D90043BC51CB82EC347BB8CC2AE075B18952EB881B02A03FCD9E`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture, and recalculating the toolbar badge after Options removes the legacy queue. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `E5393DFB29F631861B702DE54254A1843780D84709AD359F02FEF64B7EBD54CF`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture without overwriting a newer aggregate result, recalculating the toolbar badge after Options removes the legacy queue, and broadcasting preferred-mode changes to every live launcher. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 128 passed, 0 failed.
+- Chrome extension Node tests: 129 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,7 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `C0FB47800051336212DD356F98FBF0BBD805C26C74E5B0F08E2B0C4E84DFC686`.
+- Packaged ZIP SHA-256: `FCA8D4BC01C98AA65A588129455A2523F059E7E296CE55F08862F4D4A047B5ED`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, closed-tab badge cleanup, and immediate post-sign-in operational-state refresh. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open

--- a/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
+++ b/docs/HANDOFF-2026-07-30-EXTENSION-CAPTURE-PHASE8.md
@@ -27,7 +27,7 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 
 ## Validation
 
-- Chrome extension Node tests: 136 passed, 0 failed.
+- Chrome extension Node tests: 137 passed, 0 failed.
 - Chrome extension TypeScript: passed.
 - Popup JavaScript syntax: passed.
 - Prettier and `git diff --check`: passed.
@@ -35,8 +35,8 @@ Phase 8 completes the practical post-capture loop while preserving the prior rev
 - Repository Turbo build: 8 of 8 packages passed.
 - Production extension build and package: passed.
 - Packaged manifest: version `1.0.19`; permissions remain `storage`, `activeTab`, `scripting`, and `notifications`.
-- Packaged ZIP SHA-256: `56A4E9BABDD8D00E6271E9DBFB2459207F1782953795182C3F6EDB9D8057F017`.
-- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, refreshing every open launcher after a successful capture without overwriting a newer aggregate result, preserving the newest aggregate result inside the serialized storage mutation, recalculating the toolbar badge after Options removes the legacy queue, and broadcasting preferred-mode changes to every live launcher. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
+- Packaged ZIP SHA-256: `51A0A34AB44411A039F47E9475EB0432047D3E428E83A40B0511E23B9469BF82`.
+- Exact-head Codex review identified and prompted fixes for restored retry ownership, rejecting every cross-owner restored snapshot, closed-tab and post-upload terminal badge cleanup, immediate post-sign-in operational-state refresh, retaining separate aggregate preferences/results for each owner that uses the browser profile, keeping reconciliation truth tied to the result displayed for the active tab, hiding a terminal result link instead of falling back to an older aggregate conversation, refreshing every open launcher after a successful capture without overwriting a newer aggregate result, preserving the newest aggregate result inside the serialized storage mutation, recalculating the toolbar badge after Options removes the legacy queue, and broadcasting preferred-mode changes to every live launcher. Regression coverage is included; the remediated head requires a fresh exact-head review before merge.
 - No visual or authentic WhatsApp acceptance is claimed.
 
 ## Boundaries still open


### PR DESCRIPTION
## What changed

- add owner-scoped preferred-mode and last-capture aggregate metadata
- expose exact received-conversation links, new/duplicate/reconciliation truth, reviewed-payload export, and toolbar attention badges
- preserve retry metadata across service-worker restart while keeping raw payloads in WhatsApp tab memory only
- add exactly two clearly unavailable roadmap previews
- bump the extension package and manifest to 1.0.19 and add the durable Phase 8 handoff

## Why

Phase 8 completes the practical capture loop after review and upload without introducing automatic synchronization or a durable raw-message queue.

## Validation

- extension tests: 137 passed
- extension TypeScript and popup syntax: passed
- focused API intake tests: 29 passed
- Prettier and `git diff --check`: passed
- production extension package: passed
- monorepo build: 8/8 packages passed
- ZIP SHA-256: `51A0A34AB44411A039F47E9475EB0432047D3E428E83A40B0511E23B9469BF82`

## Review remediation

- persist the original operation owner binding and restore reviewed retries only for an exact current-owner match
- remove closed-tab operations and their owner metadata so cancelled tabs cannot leave a permanent badge
- refresh owner-scoped operational state immediately after in-popup sign-in
- retain separate normalized aggregate preference/result records for every authenticated owner using the browser profile
- discard every restored snapshot whose persisted owner does not match the current owner
- remove closed-tab terminal attention, including uploads that settle after tab closure
- derive reconciliation text and result links from the same active-tab result
- refresh every open launcher after successful aggregate metadata changes
- recalculate the toolbar badge when Options removes the legacy queue
- preserve a newer aggregate capture when an older tab operation renders
- preserve the newest aggregate capture inside the serialized storage mutation
- hide a terminal result link instead of opening an older aggregate conversation
- broadcast preferred-mode changes to every live launcher

## Acceptance boundary

No deployment or authentic WhatsApp acceptance is claimed. Connected send, persistence, deduplication, restart, isolation, deletion, and console attribution remain operator-held.
