### PR TITLE
test(extension): add repeatable Playwright acceptance fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Test extension capture matrix
         run: pnpm --filter @convolens/chrome-extension test
 
+      - name: Install extension fixture browser
+        run: pnpm --filter @convolens/chrome-extension exec playwright install --with-deps chromium
+
+      - name: Test extension browser fixtures
+        run: xvfb-run --auto-servernum pnpm --filter @convolens/chrome-extension test:browser:fixtures
+
       - name: Test API conversation intake
         run: pnpm --filter @convolens/api exec jest --config=jest.config.js --runInBand src/services/__tests__/conversation-intake.service.test.ts
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ yarn-error.log*
 tests/__results__/
 /.playwright-cli/
 /output/playwright/
+/.playwright-auth/
 
 # Local extension package output
 /apps/chrome-extension/convolens-extension/

--- a/apps/chrome-extension/e2e/auth.spec.ts
+++ b/apps/chrome-extension/e2e/auth.spec.ts
@@ -1,0 +1,105 @@
+import { chromium, expect, test } from "@playwright/test";
+import { isAbsolute, relative, resolve } from "node:path";
+
+const enabled = process.env.CONVOLENS_AUTHENTIC_ACCEPTANCE === "1";
+const profileDir = process.env.CONVOLENS_PW_PROFILE_DIR;
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+const relativeProfilePath = profileDir
+  ? relative(repositoryRoot, resolve(profileDir))
+  : "";
+const profileInsideRepository =
+  relativeProfilePath === "" ||
+  (!relativeProfilePath.startsWith("..") && !isAbsolute(relativeProfilePath));
+
+test.describe("operator-held authentic extension acceptance", () => {
+  test.skip(
+    !enabled,
+    "Set CONVOLENS_AUTHENTIC_ACCEPTANCE=1 to authorize an authentic read-only run.",
+  );
+  test.skip(
+    !profileDir || !isAbsolute(profileDir) || profileInsideRepository,
+    "CONVOLENS_PW_PROFILE_DIR must name an absolute, provisioned profile outside the repository.",
+  );
+
+  test("loads the authenticated extension without sending", async () => {
+    const extensionPath = resolve(import.meta.dirname, "..");
+    const context = await chromium.launchPersistentContext(
+      resolve(profileDir!),
+      {
+        channel: "chromium",
+        headless: false,
+        args: [
+          `--disable-extensions-except=${extensionPath}`,
+          `--load-extension=${extensionPath}`,
+        ],
+      },
+    );
+    try {
+      const page = await context.newPage();
+      await page.goto("https://web.whatsapp.com/");
+      await page
+        .locator('[data-testid="chat-list"], #pane-side')
+        .first()
+        .waitFor();
+      await page.locator("#convolens-fab").waitFor();
+      await page.locator("#ws-launcher-toggle").click();
+      await expect(page.locator("#ws-extract-btn")).toBeEnabled();
+      await expect(page.locator("#ws-status-text")).not.toContainText(
+        "Sign in",
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("sends one explicitly allowlisted reviewed capture", async () => {
+    test.skip(
+      process.env.CONVOLENS_ALLOW_SEND !== "1",
+      "Sending is disabled by default.",
+    );
+    test.skip(
+      process.env.CONVOLENS_SEND_CONFIRMATION !==
+        "I authorize one ConvoLens intake",
+      "Set the exact one-intake confirmation phrase.",
+    );
+    const targetChat = process.env.CONVOLENS_TEST_CHAT;
+    test.skip(
+      !targetChat,
+      "CONVOLENS_TEST_CHAT must identify the dedicated test chat.",
+    );
+
+    const extensionPath = resolve(import.meta.dirname, "..");
+    const context = await chromium.launchPersistentContext(
+      resolve(profileDir!),
+      {
+        channel: "chromium",
+        headless: false,
+        args: [
+          `--disable-extensions-except=${extensionPath}`,
+          `--load-extension=${extensionPath}`,
+        ],
+      },
+    );
+    try {
+      const page = await context.newPage();
+      await page.goto("https://web.whatsapp.com/");
+      await page
+        .locator('[data-testid="chat-list"], #pane-side')
+        .first()
+        .waitFor();
+      await page.getByText(targetChat!, { exact: true }).first().click();
+      await page.locator("#convolens-fab").waitFor();
+      await page.locator("#ws-launcher-toggle").click();
+      await page.locator("#ws-extract-btn").click();
+      await expect(page.locator("#ws-status-text")).toContainText(
+        "ready for review",
+      );
+      await page.locator("#ws-confirm-capture").click();
+      await expect(page.locator("#ws-status-text")).toContainText(
+        /received by ConvoLens|already exist in ConvoLens/,
+      );
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/apps/chrome-extension/e2e/auth.spec.ts
+++ b/apps/chrome-extension/e2e/auth.spec.ts
@@ -91,6 +91,11 @@ test.describe("operator-held authentic extension acceptance", () => {
       !targetChat,
       "CONVOLENS_TEST_CHAT must identify the dedicated test chat.",
     );
+    const targetChatJid = process.env.CONVOLENS_TEST_CHAT_JID;
+    test.skip(
+      !targetChatJid,
+      "CONVOLENS_TEST_CHAT_JID must identify the reviewed WhatsApp conversation.",
+    );
 
     const extensionPath = resolve(import.meta.dirname, "..");
     const context = await chromium.launchPersistentContext(
@@ -112,7 +117,8 @@ test.describe("operator-held authentic extension acceptance", () => {
         .locator('[data-testid="chat-list"], #pane-side')
         .first();
       await chatList.waitFor();
-      const target = chatList.getByText(targetChat!, { exact: true }).first();
+      const target = chatList.getByText(targetChat!, { exact: true });
+      await expect(target).toHaveCount(1);
       await expect(target).toBeVisible();
       await target.click();
       const activeTitle = page
@@ -125,14 +131,18 @@ test.describe("operator-held authentic extension acceptance", () => {
       await expect(page.locator("#ws-status-text")).toContainText(
         "ready for review",
       );
+      await page.bringToFront();
       const reviewedChat = await extensionPage.evaluate(async () => {
         const chromeApi = (
           globalThis as typeof globalThis & { chrome: typeof chrome }
         ).chrome;
         const [tab] = await chromeApi.tabs.query({
-          url: "https://web.whatsapp.com/*",
+          active: true,
+          currentWindow: true,
         });
-        if (!tab?.id) return { success: false };
+        if (!tab?.id || !tab.url?.startsWith("https://web.whatsapp.com/")) {
+          return { success: false };
+        }
         const operation = await chromeApi.runtime.sendMessage({
           action: "GET_CAPTURE_OPERATION",
           tabId: tab.id,
@@ -144,12 +154,21 @@ test.describe("operator-held authentic extension acceptance", () => {
           action: "GET_CAPTURE_PREVIEW",
           operationId: operation.data.operationId,
         });
+        const payload = await chromeApi.tabs.sendMessage(tab.id, {
+          action: "GET_CAPTURE_OPERATION_PAYLOAD",
+          operationId: operation.data.operationId,
+        });
         return {
-          success: Boolean(preview?.success),
+          success: Boolean(preview?.success && payload?.success),
           chatName: preview?.data?.chatName,
+          sourceConversationId: payload?.data?.sourceConversationId,
         };
       });
-      expect(reviewedChat).toEqual({ success: true, chatName: targetChat });
+      expect(reviewedChat).toEqual({
+        success: true,
+        chatName: targetChat,
+        sourceConversationId: targetChatJid,
+      });
       await expect(activeTitle).toHaveText(targetChat!);
       await page.locator("#ws-confirm-capture").click();
       await expect(page.locator("#ws-status-text")).toContainText(

--- a/apps/chrome-extension/e2e/auth.spec.ts
+++ b/apps/chrome-extension/e2e/auth.spec.ts
@@ -1,4 +1,10 @@
-import { chromium, expect, test } from "@playwright/test";
+import {
+  chromium,
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
 import { isAbsolute, relative, resolve } from "node:path";
 
 const enabled = process.env.CONVOLENS_AUTHENTIC_ACCEPTANCE === "1";
@@ -10,6 +16,24 @@ const relativeProfilePath = profileDir
 const profileInsideRepository =
   relativeProfilePath === "" ||
   (!relativeProfilePath.startsWith("..") && !isAbsolute(relativeProfilePath));
+
+async function openExtensionControlPage(
+  context: BrowserContext,
+): Promise<Page> {
+  const worker =
+    context
+      .serviceWorkers()
+      .find((candidate) => candidate.url().startsWith("chrome-extension://")) ||
+    (await context.waitForEvent("serviceworker", {
+      predicate: (candidate) =>
+        candidate.url().startsWith("chrome-extension://"),
+    }));
+  const extensionPage = await context.newPage();
+  await extensionPage.goto(
+    `chrome-extension://${new URL(worker.url()).host}/options/options.html`,
+  );
+  return extensionPage;
+}
 
 test.describe("operator-held authentic extension acceptance", () => {
   test.skip(
@@ -37,10 +61,10 @@ test.describe("operator-held authentic extension acceptance", () => {
     try {
       const page = await context.newPage();
       await page.goto("https://web.whatsapp.com/");
-      await page
+      const chatList = page
         .locator('[data-testid="chat-list"], #pane-side')
-        .first()
-        .waitFor();
+        .first();
+      await chatList.waitFor();
       await page.locator("#convolens-fab").waitFor();
       await page.locator("#ws-launcher-toggle").click();
       await expect(page.locator("#ws-extract-btn")).toBeEnabled();
@@ -81,19 +105,52 @@ test.describe("operator-held authentic extension acceptance", () => {
       },
     );
     try {
+      const extensionPage = await openExtensionControlPage(context);
       const page = await context.newPage();
       await page.goto("https://web.whatsapp.com/");
-      await page
+      const chatList = page
         .locator('[data-testid="chat-list"], #pane-side')
-        .first()
-        .waitFor();
-      await page.getByText(targetChat!, { exact: true }).first().click();
+        .first();
+      await chatList.waitFor();
+      const target = chatList.getByText(targetChat!, { exact: true }).first();
+      await expect(target).toBeVisible();
+      await target.click();
+      const activeTitle = page
+        .locator('[data-testid="conversation-info-header-chat-title"]')
+        .first();
+      await expect(activeTitle).toHaveText(targetChat!, { timeout: 30_000 });
       await page.locator("#convolens-fab").waitFor();
       await page.locator("#ws-launcher-toggle").click();
       await page.locator("#ws-extract-btn").click();
       await expect(page.locator("#ws-status-text")).toContainText(
         "ready for review",
       );
+      const reviewedChat = await extensionPage.evaluate(async () => {
+        const chromeApi = (
+          globalThis as typeof globalThis & { chrome: typeof chrome }
+        ).chrome;
+        const [tab] = await chromeApi.tabs.query({
+          url: "https://web.whatsapp.com/*",
+        });
+        if (!tab?.id) return { success: false };
+        const operation = await chromeApi.runtime.sendMessage({
+          action: "GET_CAPTURE_OPERATION",
+          tabId: tab.id,
+        });
+        if (!operation?.success || !operation.data?.operationId) {
+          return { success: false };
+        }
+        const preview = await chromeApi.tabs.sendMessage(tab.id, {
+          action: "GET_CAPTURE_PREVIEW",
+          operationId: operation.data.operationId,
+        });
+        return {
+          success: Boolean(preview?.success),
+          chatName: preview?.data?.chatName,
+        };
+      });
+      expect(reviewedChat).toEqual({ success: true, chatName: targetChat });
+      await expect(activeTitle).toHaveText(targetChat!);
       await page.locator("#ws-confirm-capture").click();
       await expect(page.locator("#ws-status-text")).toContainText(
         /received by ConvoLens|already exist in ConvoLens/,

--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "./support/extension-harness";
+
+async function openCapturePanel(page: import("@playwright/test").Page) {
+  const toggle = page.locator("#ws-launcher-toggle");
+  if ((await toggle.getAttribute("aria-expanded")) !== "true")
+    await toggle.click();
+  await expect(page.locator("#ws-launcher-panel")).toBeVisible();
+}
+
+async function reviewLoadedMessages(page: import("@playwright/test").Page) {
+  await openCapturePanel(page);
+  const review = page.locator("#ws-extract-btn");
+  await expect(review).toBeEnabled();
+  await expect(review).toHaveText("Review loaded messages");
+  await review.click();
+  await expect(page.locator("#ws-status-text")).toHaveText(
+    "3 loaded messages ready for review.",
+  );
+  await expect(page.locator("#ws-preview-loaded")).toHaveText("3");
+}
+
+test("loads the production extension and sends only after explicit review", async ({
+  harness,
+}) => {
+  await reviewLoadedMessages(harness.page);
+  expect(harness.apiRequests).toHaveLength(0);
+
+  await harness.page.locator("#ws-confirm-capture").click();
+  await expect(harness.page.locator("#ws-status-text")).toHaveText(
+    "3 loaded messages received by ConvoLens.",
+  );
+  expect(harness.apiRequests).toHaveLength(1);
+  expect(harness.apiRequests[0]).toMatchObject({
+    authorization: "Bearer fixture-owner-a-token",
+    source: "chrome-extension",
+    body: {
+      chatName: "Fixture Group",
+      isGroup: true,
+      messageCount: 3,
+      source: "chrome-extension",
+      sourceConversationId: "whatsapp:120363000000000000@g.us",
+    },
+  });
+  expect(harness.apiRequests[0].correlationId).toMatch(/^ext_/);
+  const messages = harness.apiRequests[0].body.messages as Array<{
+    text: string;
+    isOutgoing: boolean;
+  }>;
+  expect(messages.map((message) => message.text)).toEqual([
+    "Repeatable fixture message",
+    "Repeatable fixture message",
+    "Synthetic reply",
+  ]);
+  expect(messages.filter((message) => message.isOutgoing)).toHaveLength(1);
+});
+
+test("renders deterministic duplicate evidence on a repeated reviewed capture", async ({
+  harness,
+}) => {
+  await reviewLoadedMessages(harness.page);
+  await harness.page.locator("#ws-confirm-capture").click();
+  await expect(harness.page.locator("#ws-status-text")).toContainText(
+    "received by ConvoLens",
+  );
+
+  await reviewLoadedMessages(harness.page);
+  expect(harness.apiRequests).toHaveLength(1);
+  await harness.page.locator("#ws-confirm-capture").click();
+  await expect(harness.page.locator("#ws-status-text")).toHaveText(
+    "3 loaded messages already exist in ConvoLens.",
+  );
+  expect(harness.apiRequests).toHaveLength(2);
+  const canonicalMessages = (value: unknown) =>
+    (value as Array<Record<string, unknown>>).map(
+      ({ id: _id, ...message }) => message,
+    );
+  expect(canonicalMessages(harness.apiRequests[1].body.messages)).toEqual(
+    canonicalMessages(harness.apiRequests[0].body.messages),
+  );
+});
+
+test("invalidates a reviewed payload when the authenticated owner changes", async ({
+  harness,
+}) => {
+  await reviewLoadedMessages(harness.page);
+  expect(harness.apiRequests).toHaveLength(0);
+
+  const login = await harness.extensionPage.evaluate(async () => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome: typeof chrome }
+    ).chrome;
+    return await chromeApi.runtime.sendMessage({
+      action: "LOGIN",
+      email: "owner-b@example.test",
+      password: "fixture-only",
+    });
+  });
+  expect(login).toMatchObject({ success: true });
+  await expect(harness.page.locator("#ws-status-text")).not.toContainText(
+    "ready for review",
+  );
+  expect(harness.apiRequests).toHaveLength(0);
+});
+
+test("attributes browser console output without leaking credentials", async ({
+  harness,
+}) => {
+  await openCapturePanel(harness.page);
+  expect(
+    harness.consoleMessages.some((message) => message.source === "page"),
+  ).toBe(true);
+  expect(harness.serviceWorker.url()).toBe(
+    `chrome-extension://${harness.extensionId}/dist/background.js`,
+  );
+  expect(
+    harness.consoleMessages.every((message) =>
+      ["page", "service-worker"].includes(message.source),
+    ),
+  ).toBe(true);
+  const serialized = JSON.stringify(harness.consoleMessages);
+  expect(serialized).not.toContain("fixture-owner-a-token");
+  expect(serialized).not.toContain("fixture-only");
+});

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en-ZA">
+  <head>
+    <meta charset="utf-8" />
+    <title>Synthetic WhatsApp fixture</title>
+  </head>
+  <body>
+    <aside id="pane-side" data-testid="chat-list" aria-label="Chat list">
+      <button type="button">Fixture Group</button>
+    </aside>
+    <main id="main" data-testid="conversation-panel-wrapper">
+      <header
+        data-testid="conversation-header"
+        data-chat-id="120363000000000000@g.us"
+      >
+        <span data-testid="conversation-info-header-chat-title"
+          >Fixture Group</span
+        >
+        <span data-testid="conversation-subtitle">3 participants</span>
+      </header>
+      <section data-testid="conversation-panel-body">
+        <section
+          data-testid="conversation-panel-messages"
+          data-jid="120363000000000000@g.us"
+          aria-label="Synthetic messages"
+        >
+          <article
+            class="message-in"
+            data-testid="msg-container"
+            data-id="fixture-001"
+            data-pre-plain-text="[09:55, 30/07/2026] Participant A: "
+          >
+            <span data-testid="msg-sender">Participant A</span>
+            <div data-testid="msg-text">Repeatable fixture message</div>
+            <span data-testid="msg-meta">09:55</span>
+          </article>
+          <article
+            class="message-in"
+            data-testid="msg-container"
+            data-id="fixture-002"
+            data-pre-plain-text="[09:55, 30/07/2026] Participant A: "
+          >
+            <span data-testid="msg-sender">Participant A</span>
+            <div data-testid="msg-text">Repeatable fixture message</div>
+            <span data-testid="msg-meta">09:55</span>
+          </article>
+          <article
+            class="message-out"
+            data-testid="msg-container"
+            data-id="fixture-003"
+            data-pre-plain-text="[10:00, 30/07/2026] You: "
+          >
+            <div data-testid="msg-out">
+              <div data-testid="msg-text">Synthetic reply</div>
+              <span data-testid="msg-meta">10:00</span>
+            </div>
+          </article>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/chrome-extension/e2e/playwright.auth.config.ts
+++ b/apps/chrome-extension/e2e/playwright.auth.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  testDir: import.meta.dirname,
+  testMatch: "auth.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 10 * 60_000,
+  reporter: "line",
+  outputDir: resolve(
+    import.meta.dirname,
+    "../../../test-results/extension-auth",
+  ),
+  use: {
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+});

--- a/apps/chrome-extension/e2e/playwright.fixture.config.ts
+++ b/apps/chrome-extension/e2e/playwright.fixture.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const e2eDir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  testDir: e2eDir,
+  testMatch: "fixture.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 45_000,
+  reporter: [
+    ["line"],
+    [
+      "html",
+      {
+        outputFolder: resolve(
+          e2eDir,
+          "../../../playwright-report/extension-fixture",
+        ),
+        open: "never",
+      },
+    ],
+  ],
+  outputDir: resolve(e2eDir, "../../../test-results/extension-fixture"),
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+});

--- a/apps/chrome-extension/e2e/provision-auth.ts
+++ b/apps/chrome-extension/e2e/provision-auth.ts
@@ -1,0 +1,98 @@
+import { chromium } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, relative, resolve } from "node:path";
+
+const extensionRoot = resolve(import.meta.dirname, "..");
+const extensionPath = extensionRoot;
+const defaultProfile = process.env.LOCALAPPDATA
+  ? resolve(
+      process.env.LOCALAPPDATA,
+      "ConvoLens",
+      "Playwright",
+      "acceptance-profile",
+    )
+  : resolve(homedir(), ".convolens", "playwright", "acceptance-profile");
+const configuredProfile =
+  process.env.CONVOLENS_PW_PROFILE_DIR || defaultProfile;
+if (!isAbsolute(configuredProfile)) {
+  throw new Error("CONVOLENS_PW_PROFILE_DIR must be an absolute path.");
+}
+const profileDir = resolve(configuredProfile);
+const repositoryRoot = resolve(extensionRoot, "../..");
+const relativeToRepo = relative(repositoryRoot, profileDir);
+const profileInsideRepository =
+  relativeToRepo === "" ||
+  (!relativeToRepo.startsWith("..") && !isAbsolute(relativeToRepo));
+
+if (profileInsideRepository) {
+  throw new Error(
+    "CONVOLENS_PW_PROFILE_DIR must be an absolute path outside the repository.",
+  );
+}
+
+await mkdir(profileDir, { recursive: true });
+const context = await chromium.launchPersistentContext(profileDir, {
+  channel: "chromium",
+  headless: false,
+  args: [
+    `--disable-extensions-except=${extensionPath}`,
+    `--load-extension=${extensionPath}`,
+  ],
+});
+
+try {
+  const worker =
+    context
+      .serviceWorkers()
+      .find((candidate) => candidate.url().startsWith("chrome-extension://")) ||
+    (await context.waitForEvent("serviceworker", {
+      predicate: (candidate) =>
+        candidate.url().startsWith("chrome-extension://"),
+    }));
+  const whatsapp = await context.newPage();
+  const convolens = await context.newPage();
+  const extensionPage = await context.newPage();
+  await Promise.all([
+    whatsapp.goto("https://web.whatsapp.com/"),
+    convolens.goto("https://convolens.neuralliquid.ai/login"),
+    extensionPage.goto(
+      `chrome-extension://${new URL(worker.url()).host}/options/options.html`,
+    ),
+  ]);
+  console.log(
+    "Complete WhatsApp QR and ConvoLens/Mystira sign-in in the visible browser. No cookie or token values will be printed.",
+  );
+
+  await whatsapp
+    .locator('[data-testid="chat-list"], #pane-side')
+    .first()
+    .waitFor({ timeout: 10 * 60_000 });
+
+  const deadline = Date.now() + 10 * 60_000;
+  let authenticated = false;
+  while (!authenticated && Date.now() < deadline) {
+    authenticated = await extensionPage.evaluate(async () => {
+      const chromeApi = (
+        globalThis as typeof globalThis & { chrome: typeof chrome }
+      ).chrome;
+      await chromeApi.runtime.sendMessage({ action: "SYNC_MYSTIRA_AUTH" });
+      const result = await chromeApi.runtime.sendMessage({
+        action: "GET_AUTH_STATUS",
+      });
+      return Boolean(result?.success && result?.data?.isAuthenticated);
+    });
+    if (!authenticated)
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+  }
+  if (!authenticated) {
+    throw new Error(
+      "ConvoLens authentication was not established before the provisioning timeout.",
+    );
+  }
+  console.log(
+    `Provisioned a dedicated Playwright acceptance profile at ${profileDir}.`,
+  );
+} finally {
+  await context.close();
+}

--- a/apps/chrome-extension/e2e/support/extension-harness.ts
+++ b/apps/chrome-extension/e2e/support/extension-harness.ts
@@ -1,0 +1,279 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  chromium,
+  test as base,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+  type Worker,
+} from "@playwright/test";
+
+const supportDir = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = resolve(supportDir, "../..");
+const extensionPath = extensionRoot;
+const fixturePath = resolve(supportDir, "../fixtures/whatsapp-web.html");
+const apiOrigin = "http://localhost:3001";
+const conversationId = "1d3e4567-e89b-42d3-a456-426614174000";
+
+export interface CapturedRequest {
+  authorization?: string;
+  body: Record<string, unknown>;
+  correlationId?: string;
+  source?: string;
+}
+
+export interface AttributedConsoleMessage {
+  source: "page" | "service-worker";
+  type: string;
+  text: string;
+}
+
+export interface ExtensionHarness {
+  apiRequests: CapturedRequest[];
+  consoleMessages: AttributedConsoleMessage[];
+  context: BrowserContext;
+  extensionPage: Page;
+  extensionId: string;
+  page: Page;
+  serviceWorker: Worker;
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function json(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function startFixtureApi(apiRequests: CapturedRequest[]) {
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url || "/", apiOrigin);
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/chat-export/extension"
+    ) {
+      const body = JSON.parse(await readBody(request)) as Record<
+        string,
+        unknown
+      >;
+      apiRequests.push({
+        authorization: request.headers.authorization,
+        body,
+        correlationId: request.headers["x-correlation-id"] as
+          | string
+          | undefined,
+        source: request.headers["x-source"] as string | undefined,
+      });
+      const duplicate = apiRequests.length > 1;
+      json(response, 200, {
+        message: duplicate
+          ? "Conversation was already received"
+          : "Chat data received successfully",
+        duplicate,
+        reconciliationRequired: false,
+        data: {
+          chatId: body.chatId,
+          intakeId: conversationId,
+          chatName: "Fixture Group",
+          messageCount: body.messageCount,
+          receivedAt: "2026-07-30T08:00:00.000Z",
+          dashboardUrl: `/dashboard/conversations/${conversationId}`,
+          reconciliationRequired: false,
+        },
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/api/auth/login") {
+      json(response, 200, {
+        token: "fixture-owner-b-token",
+        user: { id: "fixture-owner-b", email: "owner-b@example.test" },
+      });
+      return;
+    }
+    json(response, 404, { error: "Fixture route not found" });
+  });
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(3001, resolvePromise);
+  });
+  return server;
+}
+
+async function waitForExtensionWorker(
+  context: BrowserContext,
+): Promise<Worker> {
+  return (
+    context
+      .serviceWorkers()
+      .find((worker) => worker.url().startsWith("chrome-extension://")) ||
+    (await context.waitForEvent("serviceworker", {
+      predicate: (worker) => worker.url().startsWith("chrome-extension://"),
+    }))
+  );
+}
+
+async function attachConsoleEvidence(
+  context: BrowserContext,
+  messages: AttributedConsoleMessage[],
+): Promise<void> {
+  const observedPages = new WeakSet<Page>();
+  const observedWorkers = new WeakSet<Worker>();
+  const observePage = (page: Page) => {
+    if (observedPages.has(page)) return;
+    observedPages.add(page);
+    page.on("console", (message) =>
+      messages.push({
+        source: "page",
+        type: message.type(),
+        text: message.text(),
+      }),
+    );
+  };
+  const observeWorker = (worker: Worker) => {
+    if (observedWorkers.has(worker)) return;
+    observedWorkers.add(worker);
+    worker.on("console", (message) =>
+      messages.push({
+        source: "service-worker",
+        type: message.type(),
+        text: message.text(),
+      }),
+    );
+  };
+  context.pages().forEach(observePage);
+  context.serviceWorkers().forEach(observeWorker);
+  context.on("page", observePage);
+  context.on("serviceworker", observeWorker);
+}
+
+async function attachEvidence(
+  testInfo: TestInfo,
+  harness: ExtensionHarness,
+): Promise<void> {
+  await testInfo.attach("extension-console-attribution.json", {
+    body: Buffer.from(JSON.stringify(harness.consoleMessages, null, 2)),
+    contentType: "application/json",
+  });
+  await testInfo.attach("fixture-api-requests.json", {
+    body: Buffer.from(
+      JSON.stringify(
+        harness.apiRequests.map(
+          ({ authorization, body, correlationId, source }) => ({
+            body,
+            correlationId,
+            source,
+            authorizationPresent: Boolean(authorization),
+          }),
+        ),
+        null,
+        2,
+      ),
+    ),
+    contentType: "application/json",
+  });
+}
+
+export const test = base.extend<{ harness: ExtensionHarness }>({
+  harness: async ({}, use, testInfo) => {
+    const apiRequests: CapturedRequest[] = [];
+    const consoleMessages: AttributedConsoleMessage[] = [];
+    const profileDir = await mkdtemp(
+      resolve(tmpdir(), "convolens-pw-fixture-"),
+    );
+    const fixtureApi = await startFixtureApi(apiRequests);
+    const fixtureHtml = await readFile(fixturePath, "utf8");
+    const context = await chromium.launchPersistentContext(profileDir, {
+      channel: "chromium",
+      // MV3 service workers must run in the full bundled Chromium process.
+      // Linux CI supplies a virtual display with xvfb-run.
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+        "--host-resolver-rules=MAP convolens.neuralliquid.ai ~NOTFOUND, MAP nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io ~NOTFOUND, MAP api.convolens.com ~NOTFOUND, MAP api.convolens.neuralliquid.ai ~NOTFOUND, EXCLUDE localhost",
+      ],
+    });
+    await attachConsoleEvidence(context, consoleMessages);
+    await context.route("https://web.whatsapp.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: fixtureHtml,
+      }),
+    );
+    await context.route("https://convolens.neuralliquid.ai/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>Fixture dashboard</title>",
+      }),
+    );
+    const serviceWorker = await waitForExtensionWorker(context);
+    const extensionId = new URL(serviceWorker.url()).host;
+    const existingPages = context.pages();
+    const extensionPage = await context.newPage();
+    await extensionPage.goto(
+      `chrome-extension://${extensionId}/options/options.html`,
+    );
+    for (const existingPage of existingPages) await existingPage.close();
+    await extensionPage.evaluate(
+      async ({ endpoint }) => {
+        const chromeApi = (
+          globalThis as typeof globalThis & { chrome: typeof chrome }
+        ).chrome;
+        await chromeApi.storage.local.clear();
+        await chromeApi.storage.session.clear();
+        await chromeApi.storage.local.set({
+          authToken: "fixture-owner-a-token",
+          authTokenExpiresAt: Date.now() + 3_600_000,
+          user: { id: "fixture-owner-a", email: "owner-a@example.test" },
+          settings: { apiEndpoint: endpoint },
+        });
+      },
+      { endpoint: apiOrigin },
+    );
+
+    const page = await context.newPage();
+    await page.goto("https://web.whatsapp.com/");
+    await page.locator("#convolens-fab").waitFor();
+
+    const harness = {
+      apiRequests,
+      consoleMessages,
+      context,
+      extensionPage,
+      extensionId,
+      page,
+      serviceWorker,
+    };
+    try {
+      await use(harness);
+      await attachEvidence(testInfo, harness);
+    } finally {
+      await context.close();
+      await new Promise<void>((resolvePromise) =>
+        fixtureApi.close(() => resolvePromise()),
+      );
+      await rm(profileDir, { force: true, recursive: true });
+    }
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/chrome-extension/e2e/support/extension-harness.ts
+++ b/apps/chrome-extension/e2e/support/extension-harness.ts
@@ -197,81 +197,87 @@ export const test = base.extend<{ harness: ExtensionHarness }>({
     const profileDir = await mkdtemp(
       resolve(tmpdir(), "convolens-pw-fixture-"),
     );
-    const fixtureApi = await startFixtureApi(apiRequests);
-    const fixtureHtml = await readFile(fixturePath, "utf8");
-    const context = await chromium.launchPersistentContext(profileDir, {
-      channel: "chromium",
-      // MV3 service workers must run in the full bundled Chromium process.
-      // Linux CI supplies a virtual display with xvfb-run.
-      headless: false,
-      args: [
-        `--disable-extensions-except=${extensionPath}`,
-        `--load-extension=${extensionPath}`,
-        "--host-resolver-rules=MAP convolens.neuralliquid.ai ~NOTFOUND, MAP nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io ~NOTFOUND, MAP api.convolens.com ~NOTFOUND, MAP api.convolens.neuralliquid.ai ~NOTFOUND, EXCLUDE localhost",
-      ],
-    });
-    await attachConsoleEvidence(context, consoleMessages);
-    await context.route("https://web.whatsapp.com/**", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "text/html",
-        body: fixtureHtml,
-      }),
-    );
-    await context.route("https://convolens.neuralliquid.ai/**", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "text/html",
-        body: "<!doctype html><title>Fixture dashboard</title>",
-      }),
-    );
-    const serviceWorker = await waitForExtensionWorker(context);
-    const extensionId = new URL(serviceWorker.url()).host;
-    const existingPages = context.pages();
-    const extensionPage = await context.newPage();
-    await extensionPage.goto(
-      `chrome-extension://${extensionId}/options/options.html`,
-    );
-    for (const existingPage of existingPages) await existingPage.close();
-    await extensionPage.evaluate(
-      async ({ endpoint }) => {
-        const chromeApi = (
-          globalThis as typeof globalThis & { chrome: typeof chrome }
-        ).chrome;
-        await chromeApi.storage.local.clear();
-        await chromeApi.storage.session.clear();
-        await chromeApi.storage.local.set({
-          authToken: "fixture-owner-a-token",
-          authTokenExpiresAt: Date.now() + 3_600_000,
-          user: { id: "fixture-owner-a", email: "owner-a@example.test" },
-          settings: { apiEndpoint: endpoint },
-        });
-      },
-      { endpoint: apiOrigin },
-    );
-
-    const page = await context.newPage();
-    await page.goto("https://web.whatsapp.com/");
-    await page.locator("#convolens-fab").waitFor();
-
-    const harness = {
-      apiRequests,
-      consoleMessages,
-      context,
-      extensionPage,
-      extensionId,
-      page,
-      serviceWorker,
-    };
+    let fixtureApi: Awaited<ReturnType<typeof startFixtureApi>> | undefined;
+    let context: BrowserContext | undefined;
     try {
+      fixtureApi = await startFixtureApi(apiRequests);
+      const fixtureHtml = await readFile(fixturePath, "utf8");
+      context = await chromium.launchPersistentContext(profileDir, {
+        channel: "chromium",
+        // MV3 service workers must run in the full bundled Chromium process.
+        // Linux CI supplies a virtual display with xvfb-run.
+        headless: false,
+        args: [
+          `--disable-extensions-except=${extensionPath}`,
+          `--load-extension=${extensionPath}`,
+          "--host-resolver-rules=MAP convolens.neuralliquid.ai ~NOTFOUND, MAP nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io ~NOTFOUND, MAP api.convolens.com ~NOTFOUND, MAP api.convolens.neuralliquid.ai ~NOTFOUND, EXCLUDE localhost",
+        ],
+      });
+      await attachConsoleEvidence(context, consoleMessages);
+      await context.route("https://web.whatsapp.com/**", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: fixtureHtml,
+        }),
+      );
+      await context.route("https://convolens.neuralliquid.ai/**", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: "<!doctype html><title>Fixture dashboard</title>",
+        }),
+      );
+      const serviceWorker = await waitForExtensionWorker(context);
+      const extensionId = new URL(serviceWorker.url()).host;
+      const existingPages = context.pages();
+      const extensionPage = await context.newPage();
+      await extensionPage.goto(
+        `chrome-extension://${extensionId}/options/options.html`,
+      );
+      for (const existingPage of existingPages) await existingPage.close();
+      await extensionPage.evaluate(
+        async ({ endpoint }) => {
+          const chromeApi = (
+            globalThis as typeof globalThis & { chrome: typeof chrome }
+          ).chrome;
+          await chromeApi.storage.local.clear();
+          await chromeApi.storage.session.clear();
+          await chromeApi.storage.local.set({
+            authToken: "fixture-owner-a-token",
+            authTokenExpiresAt: Date.now() + 3_600_000,
+            user: { id: "fixture-owner-a", email: "owner-a@example.test" },
+            settings: { apiEndpoint: endpoint },
+          });
+        },
+        { endpoint: apiOrigin },
+      );
+
+      const page = await context.newPage();
+      await page.goto("https://web.whatsapp.com/");
+      await page.locator("#convolens-fab").waitFor();
+
+      const harness = {
+        apiRequests,
+        consoleMessages,
+        context,
+        extensionPage,
+        extensionId,
+        page,
+        serviceWorker,
+      };
       await use(harness);
       await attachEvidence(testInfo, harness);
     } finally {
-      await context.close();
-      await new Promise<void>((resolvePromise) =>
-        fixtureApi.close(() => resolvePromise()),
+      if (context) await context.close().catch(() => undefined);
+      if (fixtureApi) {
+        await new Promise<void>((resolvePromise) =>
+          fixtureApi?.close(() => resolvePromise()),
+        );
+      }
+      await rm(profileDir, { force: true, recursive: true }).catch(
+        () => undefined,
       );
-      await rm(profileDir, { force: true, recursive: true });
     }
   },
 });

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -12,11 +12,15 @@
     "package": "npm run build:prod && node scripts/package-extension.mjs && node scripts/verify-package.mjs",
     "clean": "rm -rf dist",
     "test": "tsx --test tests/*.test.ts",
+    "test:browser:fixtures": "npm run build && playwright test --config=e2e/playwright.fixture.config.ts",
+    "auth:provision": "npm run build && tsx e2e/provision-auth.ts",
+    "test:browser:auth": "npm run build && playwright test --config=e2e/playwright.auth.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.18.0",
     "@anthropic-ai/tokenizer": "^0.0.4",
+    "@playwright/test": "^1.56.1",
     "@types/chrome": "^0.0.260",
     "archiver": "^8.0.0",
     "esbuild": "^0.27.7",

--- a/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
+++ b/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
@@ -34,8 +34,11 @@ Authentic sending is fail-closed and needs all of these values:
 $env:CONVOLENS_ALLOW_SEND="1"
 $env:CONVOLENS_SEND_CONFIRMATION="I authorize one ConvoLens intake"
 $env:CONVOLENS_TEST_CHAT="Dedicated test chat label"
+$env:CONVOLENS_TEST_CHAT_JID="whatsapp:stable-test-chat-jid"
 pnpm --filter @convolens/chrome-extension test:browser:auth
 ```
+
+The chat label must match exactly one chat-list row. Before confirmation, the runner focuses that exact WhatsApp tab and requires both the active header and the reviewed payload's stable conversation ID to match the allowlist.
 
 The profile contains sensitive session material. Keep it outside the repository, never upload it as a CI artifact, and do not use a normal personal Chrome profile. Authentic runs force one worker, zero retries, and disable traces, screenshots, and video.
 

--- a/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
+++ b/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
@@ -1,0 +1,44 @@
+# Extension Playwright acceptance
+
+The extension has two intentionally separate Playwright surfaces. Neither surface silently reuses a normal Chrome profile.
+
+## Credential-free fixture suite
+
+`pnpm --filter @convolens/chrome-extension test:browser:fixtures` builds and loads the production extension in Playwright's bundled Chromium. Navigation to `web.whatsapp.com` is fulfilled from a synthetic, non-PII fixture and the intake API is a local deterministic recorder.
+
+This suite proves browser injection, explicit review before send, request shape and tracing headers, repeated-capture duplicate rendering, account-change invalidation, page console capture, and service-worker target attribution. It does not prove production authentication, persistence, restart durability, cross-user authorization, deletion, or authentic WhatsApp compatibility.
+
+CI installs the pinned Chromium build and runs this headed MV3 suite under `xvfb-run`. Fixture traces and screenshots contain synthetic data only.
+
+## Dedicated operator profile
+
+Install Chromium once with `pnpm exec playwright install chromium`, then choose an absolute profile path outside the repository:
+
+```powershell
+$env:CONVOLENS_PW_PROFILE_DIR="$env:LOCALAPPDATA\ConvoLens\Playwright\acceptance-profile"
+pnpm --filter @convolens/chrome-extension auth:provision
+```
+
+The visible browser opens WhatsApp Web and the ConvoLens login. The operator completes WhatsApp QR and Mystira authentication. The provisioner verifies only authenticated state; it does not print or export cookies or tokens.
+
+Run the read-only authentic check with:
+
+```powershell
+$env:CONVOLENS_AUTHENTIC_ACCEPTANCE="1"
+pnpm --filter @convolens/chrome-extension test:browser:auth
+```
+
+Authentic sending is fail-closed and needs all of these values:
+
+```powershell
+$env:CONVOLENS_ALLOW_SEND="1"
+$env:CONVOLENS_SEND_CONFIRMATION="I authorize one ConvoLens intake"
+$env:CONVOLENS_TEST_CHAT="Dedicated test chat label"
+pnpm --filter @convolens/chrome-extension test:browser:auth
+```
+
+The profile contains sensitive session material. Keep it outside the repository, never upload it as a CI artifact, and do not use a normal personal Chrome profile. Authentic runs force one worker, zero retries, and disable traces, screenshots, and video.
+
+## Evidence boundary
+
+Fixture success is repository evidence only. The read-only authentic test proves session validity and browser injection only. A staffed, explicitly authorized send is required for connected intake, and separate legitimate API/dashboard checks remain required for exact persistence, restart durability, cross-user isolation, and authenticated deletion.

--- a/docs/HANDOFF-2026-07-31-EXTENSION-PLAYWRIGHT-FIXTURES.md
+++ b/docs/HANDOFF-2026-07-31-EXTENSION-PLAYWRIGHT-FIXTURES.md
@@ -1,0 +1,32 @@
+# Extension Playwright fixtures handoff
+
+Date: 2026-07-31
+
+## Outcome
+
+Phase 10 adds a real-browser test layer without turning synthetic evidence into an authentic-acceptance claim.
+
+- Playwright loads the production unpacked MV3 extension in bundled Chromium.
+- `web.whatsapp.com` is fulfilled from a synthetic, non-PII fixture.
+- Production API hosts are DNS-blocked and reviewed uploads go only to a local deterministic recorder.
+- Four browser fixtures cover explicit review before send, payload/tracing shape, repeated-capture duplicate rendering, authenticated-owner invalidation, page console capture, and service-worker target attribution.
+- A dedicated-profile provisioner supports operator-completed WhatsApp QR and Mystira authentication without printing or exporting session values.
+- Authentic checks use one worker, zero retries, and no trace, screenshot, or video capture.
+- Authentic sending is disabled unless the operator supplies the acceptance flag, dedicated chat label, send flag, and exact one-intake confirmation phrase.
+
+The commands and evidence boundary are documented in `docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md`.
+
+## Local validation
+
+- Chrome extension Node tests: 148 passed, 0 failed.
+- Credential-free Playwright extension fixtures: 4 passed, 0 failed.
+- Authentic Playwright profile: 2 tests discovered and safely skipped without operator authorization.
+- Chrome extension TypeScript and production package verification: passed; 13 expected ZIP entries verified.
+- Frozen-lockfile offline install: passed.
+- Clean forced monorepo build: 8/8 packages passed; the web build compiled 24 routes.
+
+## Acceptance boundary
+
+No authentic profile was provisioned in this phase, no production login was performed, and no WhatsApp capture was sent. The fixture API does not prove production persistence, restart durability, cross-user authorization, authenticated deletion, or authentic WhatsApp compatibility.
+
+Those outcomes require the dedicated operator profile and explicit, staffed authorization described in the runbook. Session profile material must stay outside the repository and must never be uploaded as a CI artifact.

--- a/docs/HANDOFF-2026-07-31-EXTENSION-PLAYWRIGHT-FIXTURES.md
+++ b/docs/HANDOFF-2026-07-31-EXTENSION-PLAYWRIGHT-FIXTURES.md
@@ -12,7 +12,7 @@ Phase 10 adds a real-browser test layer without turning synthetic evidence into 
 - Four browser fixtures cover explicit review before send, payload/tracing shape, repeated-capture duplicate rendering, authenticated-owner invalidation, page console capture, and service-worker target attribution.
 - A dedicated-profile provisioner supports operator-completed WhatsApp QR and Mystira authentication without printing or exporting session values.
 - Authentic checks use one worker, zero retries, and no trace, screenshot, or video capture.
-- Authentic sending is disabled unless the operator supplies the acceptance flag, dedicated chat label, send flag, and exact one-intake confirmation phrase.
+- Authentic sending is disabled unless the operator supplies the acceptance flag, unique dedicated chat label, stable reviewed WhatsApp conversation ID, send flag, and exact one-intake confirmation phrase.
 
 The commands and evidence boundary are documented in `docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md`.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@anthropic-ai/tokenizer':
         specifier: ^0.0.4
         version: 0.0.4
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
       '@types/chrome':
         specifier: ^0.0.260
         version: 0.0.260


### PR DESCRIPTION
## Outcome

Adds a repeatable browser layer for the Chrome extension while keeping authentic WhatsApp acceptance explicitly operator-held.

- loads the production unpacked MV3 extension in bundled Chromium
- fulfills web.whatsapp.com from a synthetic non-PII fixture
- DNS-blocks production API hosts and records reviewed uploads locally
- covers explicit review before send, request/tracing shape, duplicate rendering, owner-change invalidation, and runtime attribution
- adds a dedicated persistent-profile provisioner for operator-completed WhatsApp QR and Mystira authentication
- keeps authentic sending fail-closed behind four explicit environment gates
- runs the credential-free fixture suite in CI under xvfb

## Validation

- 4/4 credential-free Playwright extension fixtures
- 148/148 extension Node tests
- authentic Playwright profile: 2 tests safely skipped without operator authorization
- extension typecheck and production package inspection
- frozen-lockfile offline install
- clean forced monorepo build: 8/8 packages, 24 web routes

## Boundary

No authentic profile was provisioned, no production login was performed, and no WhatsApp capture was sent. Fixture success does not prove production persistence, restart durability, cross-user authorization, authenticated deletion, or authentic WhatsApp compatibility.