### PR TITLE
feat(intake): persist raw evidence with browser proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,18 @@ jobs:
       - name: Test extension browser fixtures
         run: xvfb-run --auto-servernum pnpm --filter @convolens/chrome-extension test:browser:fixtures
 
+      - name: Test extension persistence fixtures
+        run: xvfb-run --auto-servernum pnpm --filter @convolens/chrome-extension test:browser:persistence
+
       - name: Test API conversation intake
-        run: pnpm --filter @convolens/api exec jest --config=jest.config.js --runInBand src/services/__tests__/conversation-intake.service.test.ts
+        run: >-
+          pnpm --filter @convolens/api exec jest --config=jest.config.js --runInBand
+          src/services/__tests__/conversation-intake.service.test.ts
+          src/services/__tests__/selector-report.service.test.ts
+          src/services/__tests__/storage-managed-identity.test.ts
+          src/db/migrations/__tests__/conversation-intake.migration.test.ts
+          src/routes/__tests__/chat-export.routes.test.ts
+          src/routes/__tests__/extension.routes.test.ts
 
       - name: Package and inspect extension
         run: pnpm --filter @convolens/chrome-extension package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           src/services/__tests__/conversation-intake.service.test.ts
           src/services/__tests__/selector-report.service.test.ts
           src/services/__tests__/storage-managed-identity.test.ts
+          src/services/__tests__/auth.service.test.ts
+          src/services/__tests__/mystira-auth.service.test.ts
           src/db/migrations/__tests__/conversation-intake.migration.test.ts
           src/routes/__tests__/chat-export.routes.test.ts
           src/routes/__tests__/extension.routes.test.ts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -232,6 +232,8 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
+          TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
         run: |
           terraform -chdir=infra/terraform/env/prod plan \
             -out=base.tfplan \
@@ -298,6 +300,8 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
+          TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
 
       - name: Terraform Apply API Image
         run: terraform -chdir=infra/terraform/env/prod apply api-image.tfplan

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -148,6 +148,8 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
+          TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
         run: |
           set -euo pipefail
           PLAN_ARGS=()

--- a/apps/api/src/config/database.ts
+++ b/apps/api/src/config/database.ts
@@ -4,6 +4,7 @@ import { Group } from '../db/entities/Group';
 import { User } from '../db/entities/User';
 import { ConversationIntake } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
+import { SelectorReport } from '../db/entities/SelectorReport';
 import { postgresNativeUuidOptions } from './postgres-uuid';
 import { CONVERSATION_MIGRATIONS } from './migrations';
 import { logger } from '../utils/logger';
@@ -18,7 +19,7 @@ const migrationsRun =
 const commonOptions = {
   synchronize: !isProduction && process.env.DB_SYNCHRONIZE !== 'false',
   logging: process.env.DB_LOGGING === 'true' || process.env.NODE_ENV === 'development',
-  entities: [Message, Group, User, ConversationIntake, ConversationMessage],
+  entities: [Message, Group, User, ConversationIntake, ConversationMessage, SelectorReport],
   migrations: CONVERSATION_MIGRATIONS,
   migrationsRun,
   subscribers: [],

--- a/apps/api/src/config/datasource.ts
+++ b/apps/api/src/config/datasource.ts
@@ -4,6 +4,7 @@ import { Group } from '../db/entities/Group';
 import { Message } from '../db/entities/Message';
 import { ConversationIntake } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
+import { SelectorReport } from '../db/entities/SelectorReport';
 import { postgresNativeUuidOptions } from './postgres-uuid';
 import { CONVERSATION_MIGRATIONS } from './migrations';
 import { logger } from '../utils/logger';
@@ -26,7 +27,7 @@ const commonOptions = {
       ? 'all'
       : ['error', 'warn'],
   logger: isProduction ? 'file' : 'debug',
-  entities: [User, Group, Message, ConversationIntake, ConversationMessage],
+  entities: [User, Group, Message, ConversationIntake, ConversationMessage, SelectorReport],
   migrations: CONVERSATION_MIGRATIONS,
   migrationsRun,
   migrationsTableName: 'migrations',

--- a/apps/api/src/config/migrations.ts
+++ b/apps/api/src/config/migrations.ts
@@ -1,7 +1,9 @@
 import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
 import { AddConversationFidelity1753660000000 } from '../db/migrations/1753660000000-AddConversationFidelity';
+import { AddIntakeArtifactsAndSelectorReports1754000000000 } from '../db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports';
 
 export const CONVERSATION_MIGRATIONS = [
   CreateConversationIntake1753400000000,
   AddConversationFidelity1753660000000,
+  AddIntakeArtifactsAndSelectorReports1754000000000,
 ];

--- a/apps/api/src/db/entities/ConversationIntake.ts
+++ b/apps/api/src/db/entities/ConversationIntake.ts
@@ -12,7 +12,8 @@ import { ConversationMessage } from './ConversationMessage';
 import { dateColumnType } from '../column-types';
 
 export type ConversationSourceKind = 'extension' | 'upload';
-export type ConversationStatus = 'received';
+export type ConversationStatus = 'received' | 'failed';
+export type RawArtifactStatus = 'pending' | 'stored' | 'failed' | 'not-recorded';
 
 export interface ConversationProvenance {
   connectorVersion?: string;
@@ -97,6 +98,18 @@ export class ConversationIntake {
 
   @Column({ type: 'varchar', length: 100, nullable: true })
   errorCode?: string;
+
+  @Column({ type: 'varchar', length: 1000, nullable: true })
+  rawArtifactKey?: string;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  rawArtifactSha256?: string;
+
+  @Column({ type: 'integer', nullable: true })
+  rawArtifactSize?: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'pending' })
+  rawArtifactStatus!: RawArtifactStatus;
 
   @Column({ type: dateColumnType, nullable: true })
   sourceExtractedAt?: Date;

--- a/apps/api/src/db/entities/ConversationIntake.ts
+++ b/apps/api/src/db/entities/ConversationIntake.ts
@@ -13,7 +13,7 @@ import { dateColumnType } from '../column-types';
 
 export type ConversationSourceKind = 'extension' | 'upload';
 export type ConversationStatus = 'received' | 'failed';
-export type RawArtifactStatus = 'pending' | 'stored' | 'failed' | 'not-recorded';
+export type RawArtifactStatus = 'pending' | 'stored' | 'failed' | 'not-recorded' | 'deleting';
 
 export interface ConversationProvenance {
   connectorVersion?: string;

--- a/apps/api/src/db/entities/ConversationIntake.ts
+++ b/apps/api/src/db/entities/ConversationIntake.ts
@@ -97,7 +97,7 @@ export class ConversationIntake {
   status!: ConversationStatus;
 
   @Column({ type: 'varchar', length: 100, nullable: true })
-  errorCode?: string;
+  errorCode?: string | null;
 
   @Column({ type: 'varchar', length: 1000, nullable: true })
   rawArtifactKey?: string;
@@ -110,6 +110,12 @@ export class ConversationIntake {
 
   @Column({ type: 'varchar', length: 50, default: 'pending' })
   rawArtifactStatus!: RawArtifactStatus;
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  rawArtifactClaimId?: string | null;
+
+  @Column({ type: dateColumnType, nullable: true })
+  rawArtifactClaimedAt?: Date | null;
 
   @Column({ type: dateColumnType, nullable: true })
   sourceExtractedAt?: Date;

--- a/apps/api/src/db/entities/SelectorReport.ts
+++ b/apps/api/src/db/entities/SelectorReport.ts
@@ -1,0 +1,24 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { dateColumnType } from '../column-types';
+
+@Entity({ name: 'extension_selector_reports' })
+@Index('IDX_extension_selector_reports_observed', ['observedAt'])
+export class SelectorReport {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'simple-json' })
+  discovered!: Record<string, string>;
+
+  @Column({ type: 'varchar', length: 500, default: '' })
+  userAgent!: string;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  extensionVersion?: string;
+
+  @Column({ type: dateColumnType })
+  observedAt!: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/apps/api/src/db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports.ts
+++ b/apps/api/src/db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports.ts
@@ -22,6 +22,17 @@ export class AddIntakeArtifactsAndSelectorReports1754000000000 implements Migrat
         length: '50',
         default: "'pending'",
       }),
+      new TableColumn({
+        name: 'rawArtifactClaimId',
+        type: 'varchar',
+        length: '36',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'rawArtifactClaimedAt',
+        type: queryRunner.connection.options.type === 'postgres' ? 'timestamptz' : 'datetime',
+        isNullable: true,
+      }),
     ]);
     // Existing normalized-only intakes must not be presented as if a Blob
     // write is still in progress. New rows retain the pending default.
@@ -64,6 +75,8 @@ export class AddIntakeArtifactsAndSelectorReports1754000000000 implements Migrat
     await queryRunner.dropTable('extension_selector_reports', true);
     for (const column of [
       'rawArtifactStatus',
+      'rawArtifactClaimedAt',
+      'rawArtifactClaimId',
       'rawArtifactSize',
       'rawArtifactSha256',
       'rawArtifactKey',

--- a/apps/api/src/db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports.ts
+++ b/apps/api/src/db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableIndex } from 'typeorm';
+
+export class AddIntakeArtifactsAndSelectorReports1754000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('conversation_intakes', [
+      new TableColumn({
+        name: 'rawArtifactKey',
+        type: 'varchar',
+        length: '1000',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'rawArtifactSha256',
+        type: 'varchar',
+        length: '64',
+        isNullable: true,
+      }),
+      new TableColumn({ name: 'rawArtifactSize', type: 'integer', isNullable: true }),
+      new TableColumn({
+        name: 'rawArtifactStatus',
+        type: 'varchar',
+        length: '50',
+        default: "'pending'",
+      }),
+    ]);
+    // Existing normalized-only intakes must not be presented as if a Blob
+    // write is still in progress. New rows retain the pending default.
+    await queryRunner.query(
+      `UPDATE "conversation_intakes" SET "rawArtifactStatus" = 'not-recorded' WHERE "rawArtifactKey" IS NULL`
+    );
+
+    const dateType =
+      queryRunner.connection.options.type === 'postgres' ? 'timestamptz' : 'datetime';
+    await queryRunner.createTable(
+      new Table({
+        name: 'extension_selector_reports',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          { name: 'discovered', type: 'text' },
+          { name: 'userAgent', type: 'varchar', length: '500', default: "''" },
+          { name: 'extensionVersion', type: 'varchar', length: '50', isNullable: true },
+          { name: 'observedAt', type: dateType },
+          { name: 'createdAt', type: dateType, default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true
+    );
+    await queryRunner.createIndex(
+      'extension_selector_reports',
+      new TableIndex({
+        name: 'IDX_extension_selector_reports_observed',
+        columnNames: ['observedAt'],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('extension_selector_reports', true);
+    for (const column of [
+      'rawArtifactStatus',
+      'rawArtifactSize',
+      'rawArtifactSha256',
+      'rawArtifactKey',
+    ]) {
+      await queryRunner.dropColumn('conversation_intakes', column);
+    }
+  }
+}

--- a/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
+++ b/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { DataSource } from 'typeorm';
 import { CreateConversationIntake1753400000000 } from '../1753400000000-CreateConversationIntake';
 import { AddConversationFidelity1753660000000 } from '../1753660000000-AddConversationFidelity';
+import { AddIntakeArtifactsAndSelectorReports1754000000000 } from '../1754000000000-AddIntakeArtifactsAndSelectorReports';
 import { CONVERSATION_MIGRATIONS } from '../../../config/migrations';
 
 describe('CreateConversationIntake migration', () => {
@@ -14,7 +15,11 @@ describe('CreateConversationIntake migration', () => {
       synchronize: false,
       migrationsRun: false,
       entities: [],
-      migrations: [CreateConversationIntake1753400000000, AddConversationFidelity1753660000000],
+      migrations: [
+        CreateConversationIntake1753400000000,
+        AddConversationFidelity1753660000000,
+        AddIntakeArtifactsAndSelectorReports1754000000000,
+      ],
     });
     await dataSource.initialize();
     await dataSource.runMigrations();
@@ -28,14 +33,18 @@ describe('CreateConversationIntake migration', () => {
     expect(CONVERSATION_MIGRATIONS).toEqual([
       CreateConversationIntake1753400000000,
       AddConversationFidelity1753660000000,
+      AddIntakeArtifactsAndSelectorReports1754000000000,
     ]);
     const queryRunner = dataSource.createQueryRunner();
     const intakeTable = await queryRunner.getTable('conversation_intakes');
     const messageTable = await queryRunner.getTable('conversation_messages');
+    const selectorReportTable = await queryRunner.getTable('extension_selector_reports');
     await queryRunner.release();
 
     expect(intakeTable).toBeDefined();
     expect(messageTable).toBeDefined();
+    expect(selectorReportTable).toBeDefined();
+    expect(intakeTable?.findColumnByName('rawArtifactStatus')).toBeDefined();
     expect(
       intakeTable?.indices.some(
         (index) => index.name === 'UQ_conversation_intakes_user_content_hash' && index.isUnique

--- a/apps/api/src/middleware/admin.ts
+++ b/apps/api/src/middleware/admin.ts
@@ -1,0 +1,9 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  if (req.user?.role !== 'admin') {
+    res.status(403).json({ error: 'Admin access required' });
+    return;
+  }
+  next();
+}

--- a/apps/api/src/routes/__tests__/extension.routes.test.ts
+++ b/apps/api/src/routes/__tests__/extension.routes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { NextFunction, Request, Response } from 'express';
+import { requireAdmin } from '../../middleware/admin';
+
+function responseDouble() {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as Response;
+}
+
+describe('extension admin authorization', () => {
+  it('rejects non-admin selector evidence reads', () => {
+    const request = { user: { id: 'user-1', email: 'user@example.test', role: 'user' } } as Request;
+    const response = responseDouble();
+    const next = jest.fn() as NextFunction;
+
+    requireAdmin(request, response, next);
+
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({ error: 'Admin access required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows an authenticated admin to continue', () => {
+    const request = {
+      user: { id: 'admin-1', email: 'admin@example.test', role: 'admin' },
+    } as Request;
+    const response = responseDouble();
+    const next = jest.fn() as NextFunction;
+
+    requireAdmin(request, response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(response.status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/chat-export.routes.ts
+++ b/apps/api/src/routes/chat-export.routes.ts
@@ -308,6 +308,11 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
         isMedia: message.isMedia,
       })),
     });
+    const persisted = await conversationIntakeService.ensureRawArtifact(
+      saved.conversation,
+      userId,
+      { body: req.file.buffer, contentType: 'text/plain' }
+    );
 
     return res.status(200).json({
       message: saved.duplicate
@@ -320,6 +325,11 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
         messageCount: chatData.messages.length,
         participants: chatData.participants,
         receivedAt: saved.conversation.receivedAt,
+        persistence: {
+          rawArtifact: persisted.rawArtifactStatus,
+          normalizedMessages: 'stored',
+          status: persisted.status,
+        },
         dashboardUrl: `/dashboard/conversations/${saved.conversation.id}`,
         dateRange: {
           start: chatData.messages[0]?.timestamp,
@@ -415,6 +425,11 @@ router.post('/extension', authenticateToken, async (req, res) => {
         replyToSourceMessageId: message.replyTo,
       })),
     });
+    const persisted = await conversationIntakeService.ensureRawArtifact(
+      saved.conversation,
+      userId,
+      { body: JSON.stringify(chatData), contentType: 'application/json' }
+    );
 
     const result = {
       chatId: chatData.chatId,
@@ -424,6 +439,11 @@ router.post('/extension', authenticateToken, async (req, res) => {
       receivedAt: saved.conversation.receivedAt,
       dashboardUrl: `/dashboard/conversations/${saved.conversation.id}`,
       reconciliationRequired: saved.reconciliationRequired,
+      persistence: {
+        rawArtifact: persisted.rawArtifactStatus,
+        normalizedMessages: 'stored',
+        status: persisted.status,
+      },
     };
 
     metrics.trackExtraction(true, 'chrome-extension', chatData.messages.length);
@@ -500,6 +520,11 @@ router.get('/:id', authenticateToken, async (req, res) => {
           reconciliationCandidateIds: conversation.reconciliationCandidateIds || [],
           status: conversation.status,
           errorCode: conversation.errorCode,
+          rawArtifact: {
+            status: conversation.rawArtifactStatus,
+            sha256: conversation.rawArtifactSha256,
+            size: conversation.rawArtifactSize,
+          },
           sourceExtractedAt: conversation.sourceExtractedAt,
           provenance: conversation.provenance,
           receivedAt: conversation.receivedAt,

--- a/apps/api/src/routes/extension.routes.ts
+++ b/apps/api/src/routes/extension.routes.ts
@@ -10,6 +10,9 @@ import { logger } from '../utils/logger.js';
 import { cacheService } from '../services/cache.service.js';
 import { CACHE_TTL } from '../config/constants.js';
 import { extensionRateLimit, selectorReportRateLimit } from '../middleware/rate-limit.js';
+import { authenticateToken } from '../middleware/auth.middleware.js';
+import { requireAdmin } from '../middleware/admin.js';
+import { selectorReportService } from '../services/selector-report.service.js';
 
 // =============================================================================
 // Input Validation
@@ -25,6 +28,17 @@ function validateSelectorReport(body: any): ValidationError[] {
 
   if (body.discovered !== undefined && typeof body.discovered !== 'object') {
     errors.push({ field: 'discovered', message: 'must be an object' });
+  }
+  if (body.discovered && typeof body.discovered === 'object') {
+    for (const [key, value] of Object.entries(body.discovered)) {
+      if (key.length > 100 || typeof value !== 'string' || value.length > 500) {
+        errors.push({
+          field: `discovered.${key.slice(0, 100)}`,
+          message:
+            'selector names must be at most 100 characters and values at most 500 characters',
+        });
+      }
+    }
   }
 
   if (body.userAgent !== undefined && typeof body.userAgent !== 'string') {
@@ -120,7 +134,7 @@ interface SelectorConfig {
   fallback: SelectorSet;
 }
 
-interface SelectorReport {
+interface SelectorReportPayload {
   discovered: Partial<SelectorSet>;
   userAgent: string;
   timestamp: string;
@@ -159,10 +173,6 @@ let selectorConfig: SelectorConfig = {
     scrollableMessageList: '._asmz',
   },
 };
-
-// Selector reports for analysis (kept in memory, would be database in production)
-const selectorReports: SelectorReport[] = [];
-const MAX_REPORTS = 100;
 
 // =============================================================================
 // Routes
@@ -206,61 +216,65 @@ router.post(
   selectorReportRateLimit,
   validationMiddleware(validateSelectorReport),
   async (req: Request, res: Response) => {
-  try {
-    const report: SelectorReport = {
-      discovered: req.body.discovered || {},
-      userAgent: req.body.userAgent || '',
-      timestamp: req.body.timestamp || new Date().toISOString(),
-      extensionVersion: req.headers['x-extension-version'] as string,
-    };
+    try {
+      const report: SelectorReportPayload = {
+        discovered: req.body.discovered || {},
+        userAgent: (req.body.userAgent || '').replace(/[\u0000-\u001f\u007f]/g, ' ').trim(),
+        timestamp: req.body.timestamp || new Date().toISOString(),
+        extensionVersion: req.headers['x-extension-version'] as string,
+      };
 
-    // Store report (limited to MAX_REPORTS)
-    selectorReports.push(report);
-    if (selectorReports.length > MAX_REPORTS) {
-      selectorReports.shift();
+      await selectorReportService.save(report);
+
+      logger.info('Selector report received', {
+        discovered: Object.keys(report.discovered),
+        extensionVersion: report.extensionVersion,
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('Error processing selector report:', error);
+      res.status(500).json({ error: 'Failed to process report' });
     }
-
-    logger.info('Selector report received', {
-      discovered: Object.keys(report.discovered),
-      extensionVersion: report.extensionVersion,
-    });
-
-    res.json({ success: true });
-  } catch (error) {
-    logger.error('Error processing selector report:', error);
-    res.status(500).json({ error: 'Failed to process report' });
   }
-});
+);
 
 /**
  * @route GET /api/extension/selectors/reports
  * @description Get selector reports (admin only)
- * @access Private (would need admin auth)
+ * @access Private (admin only)
  */
-router.get('/selectors/reports', extensionRateLimit, async (_req: Request, res: Response) => {
-  // In production, this would require admin authentication
-  try {
-    res.json({
-      reports: selectorReports,
-      count: selectorReports.length,
-    });
-  } catch (error) {
-    logger.error('Error fetching selector reports:', error);
-    res.status(500).json({ error: 'Failed to fetch reports' });
+router.get(
+  '/selectors/reports',
+  extensionRateLimit,
+  authenticateToken,
+  requireAdmin,
+  async (_req: Request, res: Response) => {
+    try {
+      const selectorReports = await selectorReportService.list();
+      res.json({
+        reports: selectorReports,
+        count: selectorReports.length,
+      });
+    } catch (error) {
+      logger.error('Error fetching selector reports:', error);
+      res.status(500).json({ error: 'Failed to fetch reports' });
+    }
   }
-});
+);
 
 /**
  * @route PUT /api/extension/selectors
  * @description Update selectors (admin only)
- * @access Private (would need admin auth)
+ * @access Private (admin only)
  */
 router.put(
   '/selectors',
   extensionRateLimit,
+  authenticateToken,
+  requireAdmin,
   validationMiddleware(validateSelectorUpdate),
   async (req: Request, res: Response) => {
-    // In production, this would require admin authentication
     try {
       const { primary, fallback, version } = req.body;
 

--- a/apps/api/src/services/__tests__/auth.service.test.ts
+++ b/apps/api/src/services/__tests__/auth.service.test.ts
@@ -1,0 +1,22 @@
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../../config/constants';
+import { UserRole } from '../../db/entities/User';
+import { issueApiToken } from '../auth.service';
+
+describe('local API authentication', () => {
+  it('issues middleware-compatible claims while preserving the stored admin role', () => {
+    const token = issueApiToken({
+      id: 'local-admin-123',
+      email: 'admin@example.com',
+      role: UserRole.ADMIN,
+    });
+
+    expect(jwt.verify(token, JWT_SECRET)).toMatchObject({
+      id: 'local-admin-123',
+      userId: 'local-admin-123',
+      email: 'admin@example.com',
+      role: 'admin',
+      sub: 'local-admin-123',
+    });
+  });
+});

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -135,7 +135,7 @@ describe('ConversationIntakeService', () => {
       expect(persisted.rawArtifactStatus).toBe('stored');
       expect(persisted.rawArtifactSha256).toMatch(/^[a-f0-9]{64}$/);
       expect(persisted.rawArtifactKey).toMatch(
-        /^raw-intakes\/[a-f0-9]{32}\/[a-f0-9-]+\/[a-f0-9]{64}\.json$/
+        /^raw-intakes\/[a-f0-9]{32}\/[a-f0-9-]+\/[a-f0-9-]{36}\/[a-f0-9]{64}\.json$/
       );
       expect(await readFile(resolve(artifactRoot, persisted.rawArtifactKey!), 'utf8')).toBe(
         '{"fixture":true}'
@@ -193,6 +193,69 @@ describe('ConversationIntakeService', () => {
     expect(uploads[0].body).toBe('{"capture":1}');
     expect(second.rawArtifactKey).toBe(first.rawArtifactKey);
     expect(second.rawArtifactStatus).toBe('stored');
+  });
+
+  it('reclaims an expired pending raw-artifact lease without reusing its key', async () => {
+    const uploads: string[] = [];
+    const storage = {
+      uploadFile: jest.fn(async (key: string) => {
+        uploads.push(key);
+      }),
+    } as unknown as StorageService;
+    const artifactService = new ConversationIntakeService(dataSource, storage);
+    const saved = await artifactService.save(baseInput);
+    const repository = dataSource.getRepository(ConversationIntake);
+    await repository.update(saved.conversation.id, {
+      rawArtifactKey: `raw-intakes/stale/${saved.conversation.id}/stale/artifact.json`,
+      rawArtifactSha256: 'a'.repeat(64),
+      rawArtifactSize: 8,
+      rawArtifactStatus: 'pending',
+      rawArtifactClaimId: '00000000-0000-4000-8000-000000000000',
+      rawArtifactClaimedAt: new Date(Date.now() - 120_000),
+      errorCode: 'raw_artifact_write_failed',
+    });
+
+    const persisted = await artifactService.ensureRawArtifact(
+      saved.conversation,
+      baseInput.userId,
+      { body: '{"replacement":true}', contentType: 'application/json' }
+    );
+
+    expect(uploads).toEqual([persisted.rawArtifactKey]);
+    expect(persisted.rawArtifactKey).not.toContain('/stale/');
+    expect(persisted.rawArtifactStatus).toBe('stored');
+    expect(persisted.rawArtifactClaimId).toBeNull();
+    expect(persisted.rawArtifactClaimedAt).toBeNull();
+    expect(persisted.errorCode).toBeNull();
+  });
+
+  it('clears the persisted write error after a successful same-artifact retry', async () => {
+    const uploadFile = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const artifactService = new ConversationIntakeService(dataSource, {
+      uploadFile,
+    } as unknown as StorageService);
+    const saved = await artifactService.save(baseInput);
+    const artifact = { body: '{"retry":true}', contentType: 'application/json' as const };
+
+    await expect(
+      artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, artifact)
+    ).rejects.toThrow('storage unavailable');
+    const failed = await dataSource
+      .getRepository(ConversationIntake)
+      .findOneByOrFail({ id: saved.conversation.id });
+    expect(failed.errorCode).toBe('raw_artifact_write_failed');
+
+    const retried = await artifactService.ensureRawArtifact(
+      saved.conversation,
+      baseInput.userId,
+      artifact
+    );
+    expect(retried.rawArtifactStatus).toBe('stored');
+    expect(retried.errorCode).toBeNull();
+    expect(uploadFile).toHaveBeenCalledTimes(2);
   });
 
   it('can retry deletion when the artifact is already absent after a database error', async () => {

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -355,6 +355,45 @@ describe('ConversationIntakeService', () => {
     }
   });
 
+  it('tombstones deletion so a concurrent late upload cleans itself up', async () => {
+    let releaseUpload!: () => void;
+    let reportUploadStarted!: () => void;
+    const uploadGate = new Promise<void>((resolvePromise) => {
+      releaseUpload = resolvePromise;
+    });
+    const uploadStarted = new Promise<void>((resolvePromise) => {
+      reportUploadStarted = resolvePromise;
+    });
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    const storage = {
+      uploadFile: jest.fn(async () => {
+        reportUploadStarted();
+        await uploadGate;
+      }),
+      deleteFile,
+    } as unknown as StorageService;
+    const artifactService = new ConversationIntakeService(dataSource, storage);
+    const saved = await artifactService.save(baseInput);
+
+    const persistence = artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+      body: '{"late":true}',
+      contentType: 'application/json',
+    });
+    const persistenceAssertion = expect(persistence).rejects.toThrow(
+      /deletion started|Could not find any entity/
+    );
+    await uploadStarted;
+    const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+    releaseUpload();
+
+    expect(await deletion).toBe(true);
+    await persistenceAssertion;
+    expect(deleteFile).toHaveBeenCalledTimes(2);
+    expect(deleteFile.mock.calls[1][0]).toBe(deleteFile.mock.calls[0][0]);
+    expect(await artifactService.getForUser(baseInput.userId, saved.conversation.id)).toBeNull();
+  });
+
   it('deduplicates stable content even when connector IDs change', async () => {
     const first = await service.save(baseInput);
     const second = await service.save({

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -201,6 +201,7 @@ describe('ConversationIntakeService', () => {
       uploadFile: jest.fn(async (key: string) => {
         uploads.push(key);
       }),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
     } as unknown as StorageService;
     const artifactService = new ConversationIntakeService(dataSource, storage);
     const saved = await artifactService.save(baseInput);
@@ -229,6 +230,32 @@ describe('ConversationIntakeService', () => {
     expect(persisted.errorCode).toBeNull();
   });
 
+  it('reclaims a pending claim when its lease expires during the wait', async () => {
+    const storage = {
+      uploadFile: jest.fn().mockResolvedValue(undefined),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+    } as unknown as StorageService;
+    const artifactService = new ConversationIntakeService(dataSource, storage);
+    const saved = await artifactService.save(baseInput);
+    await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
+      rawArtifactKey: `raw-intakes/pending/${saved.conversation.id}/pending/artifact.json`,
+      rawArtifactSha256: 'b'.repeat(64),
+      rawArtifactSize: 8,
+      rawArtifactStatus: 'pending',
+      rawArtifactClaimId: '00000000-0000-4000-8000-000000000001',
+      rawArtifactClaimedAt: new Date(Date.now() - 59_900),
+    });
+
+    const persisted = await artifactService.ensureRawArtifact(
+      saved.conversation,
+      baseInput.userId,
+      { body: '{"after-wait":true}', contentType: 'application/json' }
+    );
+
+    expect(persisted.rawArtifactStatus).toBe('stored');
+    expect(storage.uploadFile).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the persisted write error after a successful same-artifact retry', async () => {
     const uploadFile = jest
       .fn()
@@ -236,6 +263,7 @@ describe('ConversationIntakeService', () => {
       .mockResolvedValueOnce(undefined);
     const artifactService = new ConversationIntakeService(dataSource, {
       uploadFile,
+      deleteFile: jest.fn().mockResolvedValue(undefined),
     } as unknown as StorageService);
     const saved = await artifactService.save(baseInput);
     const artifact = { body: '{"retry":true}', contentType: 'application/json' as const };
@@ -247,6 +275,7 @@ describe('ConversationIntakeService', () => {
       .getRepository(ConversationIntake)
       .findOneByOrFail({ id: saved.conversation.id });
     expect(failed.errorCode).toBe('raw_artifact_write_failed');
+    const failedKey = failed.rawArtifactKey;
 
     const retried = await artifactService.ensureRawArtifact(
       saved.conversation,
@@ -256,6 +285,8 @@ describe('ConversationIntakeService', () => {
     expect(retried.rawArtifactStatus).toBe('stored');
     expect(retried.errorCode).toBeNull();
     expect(uploadFile).toHaveBeenCalledTimes(2);
+    expect(retried.rawArtifactKey).not.toBe(failedKey);
+    expect(uploadFile.mock.calls[1][0]).toBe(retried.rawArtifactKey);
   });
 
   it('can retry deletion when the artifact is already absent after a database error', async () => {

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -8,12 +8,13 @@ import { ConversationIntake } from '../../db/entities/ConversationIntake';
 import { ConversationMessage } from '../../db/entities/ConversationMessage';
 import {
   ConversationIntakeService,
+  RAW_ARTIFACT_CLAIM_LEASE_MS,
   createConversationCompatibilityHash,
   createConversationContentHash,
   createConversationContentHashV2,
   type ConversationIntakeInput,
 } from '../conversation-intake.service';
-import { StorageService } from '../storage/storage.service';
+import { AZURE_UPLOAD_TOTAL_TIMEOUT_MS, StorageService } from '../storage/storage.service';
 
 const baseInput: ConversationIntakeInput = {
   userId: 'mystira-user-1',
@@ -89,6 +90,11 @@ describe('ConversationIntakeService', () => {
   beforeEach(async () => {
     await dataSource.getRepository(ConversationMessage).clear();
     await dataSource.getRepository(ConversationIntake).clear();
+  });
+
+  it('bounds crash recovery plus a replacement upload below caller timeouts', () => {
+    expect(RAW_ARTIFACT_CLAIM_LEASE_MS).toBeGreaterThan(AZURE_UPLOAD_TOTAL_TIMEOUT_MS);
+    expect(RAW_ARTIFACT_CLAIM_LEASE_MS + AZURE_UPLOAD_TOTAL_TIMEOUT_MS).toBeLessThan(60_000);
   });
 
   afterAll(async () => {
@@ -275,7 +281,7 @@ describe('ConversationIntakeService', () => {
       rawArtifactSize: 8,
       rawArtifactStatus: 'pending',
       rawArtifactClaimId: '00000000-0000-4000-8000-000000000001',
-      rawArtifactClaimedAt: new Date(Date.now() - 179_900),
+      rawArtifactClaimedAt: new Date(Date.now() - (RAW_ARTIFACT_CLAIM_LEASE_MS - 100)),
     });
 
     const persisted = await artifactService.ensureRawArtifact(

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -167,6 +167,62 @@ describe('ConversationIntakeService', () => {
     }
   });
 
+  it('serializes concurrent raw-artifact claims and retains the first evidence', async () => {
+    const uploads: Array<{ key: string; body: string }> = [];
+    const storage = {
+      uploadFile: jest.fn(async (key: string, body: Buffer) => {
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+        uploads.push({ key, body: body.toString('utf8') });
+      }),
+    } as unknown as StorageService;
+    const artifactService = new ConversationIntakeService(dataSource, storage);
+    const saved = await artifactService.save(baseInput);
+
+    const [first, second] = await Promise.all([
+      artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+        body: '{"capture":1}',
+        contentType: 'application/json',
+      }),
+      artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+        body: '{"capture":2}',
+        contentType: 'application/json',
+      }),
+    ]);
+
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].body).toBe('{"capture":1}');
+    expect(second.rawArtifactKey).toBe(first.rawArtifactKey);
+    expect(second.rawArtifactStatus).toBe('stored');
+  });
+
+  it('can retry deletion when the artifact is already absent after a database error', async () => {
+    const artifactRoot = await mkdtemp(resolve(tmpdir(), 'convolens-delete-retry-test-'));
+    try {
+      const artifactService = new ConversationIntakeService(
+        dataSource,
+        new StorageService({ provider: 'local', localBasePath: artifactRoot })
+      );
+      const saved = await artifactService.save(baseInput);
+      const persisted = await artifactService.ensureRawArtifact(
+        saved.conversation,
+        baseInput.userId,
+        { body: 'deletion retry', contentType: 'text/plain' }
+      );
+      const repository = dataSource.getRepository(ConversationIntake);
+      const deleteSpy = jest
+        .spyOn(repository, 'delete')
+        .mockRejectedValueOnce(new Error('db down'));
+
+      await expect(artifactService.deleteForUser(baseInput.userId, persisted.id)).rejects.toThrow(
+        'db down'
+      );
+      expect(await artifactService.deleteForUser(baseInput.userId, persisted.id)).toBe(true);
+      expect(deleteSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(artifactRoot, { recursive: true, force: true });
+    }
+  });
+
   it('deduplicates stable content even when connector IDs change', async () => {
     const first = await service.save(baseInput);
     const second = await service.save({

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -9,6 +9,7 @@ import { ConversationMessage } from '../../db/entities/ConversationMessage';
 import {
   ConversationIntakeService,
   RAW_ARTIFACT_CLAIM_LEASE_MS,
+  RAW_ARTIFACT_DELETE_GRACE_MS,
   createConversationCompatibilityHash,
   createConversationContentHash,
   createConversationContentHashV2,
@@ -95,6 +96,9 @@ describe('ConversationIntakeService', () => {
   it('bounds crash recovery plus a replacement upload below caller timeouts', () => {
     expect(RAW_ARTIFACT_CLAIM_LEASE_MS).toBeGreaterThan(AZURE_UPLOAD_TOTAL_TIMEOUT_MS);
     expect(RAW_ARTIFACT_CLAIM_LEASE_MS + AZURE_UPLOAD_TOTAL_TIMEOUT_MS).toBeLessThan(60_000);
+    expect(AZURE_UPLOAD_TOTAL_TIMEOUT_MS + RAW_ARTIFACT_DELETE_GRACE_MS + 15_000).toBeLessThan(
+      60_000
+    );
   });
 
   afterAll(async () => {
@@ -383,6 +387,11 @@ describe('ConversationIntakeService', () => {
       /deletion started|Could not find any entity/
     );
     await uploadStarted;
+    await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
+      rawArtifactClaimedAt: new Date(
+        Date.now() - AZURE_UPLOAD_TOTAL_TIMEOUT_MS - RAW_ARTIFACT_DELETE_GRACE_MS
+      ),
+    });
     const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
     releaseUpload();
@@ -392,6 +401,53 @@ describe('ConversationIntakeService', () => {
     expect(deleteFile).toHaveBeenCalledTimes(2);
     expect(deleteFile.mock.calls[1][0]).toBe(deleteFile.mock.calls[0][0]);
     expect(await artifactService.getForUser(baseInput.userId, saved.conversation.id)).toBeNull();
+  });
+
+  it('never claims a null-key intake after deletion is tombstoned', async () => {
+    const uploadFile = jest.fn().mockResolvedValue(undefined);
+    const artifactService = new ConversationIntakeService(dataSource, {
+      uploadFile,
+    } as unknown as StorageService);
+    const saved = await artifactService.save(baseInput);
+    await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
+      rawArtifactStatus: 'deleting',
+      rawArtifactKey: undefined,
+    });
+
+    await expect(
+      artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+        body: '{"tooLate":true}',
+        contentType: 'application/json',
+      })
+    ).rejects.toThrow('cannot be replaced');
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('retains the tombstoned row until Blob cleanup succeeds', async () => {
+    const deleteFile = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('blob delete unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const artifactService = new ConversationIntakeService(dataSource, {
+      uploadFile: jest.fn().mockResolvedValue(undefined),
+      deleteFile,
+    } as unknown as StorageService);
+    const saved = await artifactService.save(baseInput);
+    await artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+      body: '{"durableCleanup":true}',
+      contentType: 'application/json',
+    });
+
+    await expect(
+      artifactService.deleteForUser(baseInput.userId, saved.conversation.id)
+    ).rejects.toThrow('blob delete unavailable');
+    const retained = await dataSource
+      .getRepository(ConversationIntake)
+      .findOneByOrFail({ id: saved.conversation.id });
+    expect(retained.rawArtifactStatus).toBe('deleting');
+
+    expect(await artifactService.deleteForUser(baseInput.userId, saved.conversation.id)).toBe(true);
+    expect(deleteFile).toHaveBeenCalledTimes(2);
   });
 
   it('deduplicates stable content even when connector IDs change', async () => {

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { DataSource, IsNull } from 'typeorm';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
 import { ConversationIntake } from '../../db/entities/ConversationIntake';
 import { ConversationMessage } from '../../db/entities/ConversationMessage';
 import {
@@ -9,6 +12,7 @@ import {
   createConversationContentHashV2,
   type ConversationIntakeInput,
 } from '../conversation-intake.service';
+import { StorageService } from '../storage/storage.service';
 
 const baseInput: ConversationIntakeInput = {
   userId: 'mystira-user-1',
@@ -112,6 +116,55 @@ describe('ConversationIntakeService', () => {
       'Ready for alpha.',
     ]);
     expect(await service.getForUser('other-user', saved.conversation.id)).toBeNull();
+  });
+
+  it('stores an integrity-addressed raw artifact and deletes it with the intake', async () => {
+    const artifactRoot = await mkdtemp(resolve(tmpdir(), 'convolens-artifact-test-'));
+    try {
+      const artifactService = new ConversationIntakeService(
+        dataSource,
+        new StorageService({ provider: 'local', localBasePath: artifactRoot })
+      );
+      const saved = await artifactService.save(baseInput);
+      const persisted = await artifactService.ensureRawArtifact(
+        saved.conversation,
+        baseInput.userId,
+        { body: '{"fixture":true}', contentType: 'application/json' }
+      );
+
+      expect(persisted.rawArtifactStatus).toBe('stored');
+      expect(persisted.rawArtifactSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(persisted.rawArtifactKey).toMatch(
+        /^raw-intakes\/[a-f0-9]{32}\/[a-f0-9-]+\/[a-f0-9]{64}\.json$/
+      );
+      expect(await readFile(resolve(artifactRoot, persisted.rawArtifactKey!), 'utf8')).toBe(
+        '{"fixture":true}'
+      );
+
+      const duplicate = await artifactService.save({
+        ...baseInput,
+        messages: baseInput.messages.map((message, index) => ({
+          ...message,
+          sourceMessageId: `retry-${index}`,
+        })),
+      });
+      const retained = await artifactService.ensureRawArtifact(
+        duplicate.conversation,
+        baseInput.userId,
+        { body: '{"fixture":"retry"}', contentType: 'application/json' }
+      );
+      expect(retained.rawArtifactKey).toBe(persisted.rawArtifactKey);
+      expect(await readFile(resolve(artifactRoot, retained.rawArtifactKey!), 'utf8')).toBe(
+        '{"fixture":true}'
+      );
+
+      expect(await artifactService.deleteForUser(baseInput.userId, persisted.id)).toBe(true);
+      await expect(
+        readFile(resolve(artifactRoot, persisted.rawArtifactKey!))
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(artifactRoot, { recursive: true, force: true });
+    }
   });
 
   it('deduplicates stable content even when connector IDs change', async () => {

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -3,6 +3,7 @@ import { DataSource, IsNull } from 'typeorm';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
 import { ConversationIntake } from '../../db/entities/ConversationIntake';
 import { ConversationMessage } from '../../db/entities/ConversationMessage';
 import {
@@ -206,20 +207,21 @@ describe('ConversationIntakeService', () => {
     const artifactService = new ConversationIntakeService(dataSource, storage);
     const saved = await artifactService.save(baseInput);
     const repository = dataSource.getRepository(ConversationIntake);
+    const replacement = '{"replacement":true}';
     await repository.update(saved.conversation.id, {
       rawArtifactKey: `raw-intakes/stale/${saved.conversation.id}/stale/artifact.json`,
-      rawArtifactSha256: 'a'.repeat(64),
+      rawArtifactSha256: createHash('sha256').update(replacement).digest('hex'),
       rawArtifactSize: 8,
       rawArtifactStatus: 'pending',
       rawArtifactClaimId: '00000000-0000-4000-8000-000000000000',
-      rawArtifactClaimedAt: new Date(Date.now() - 120_000),
+      rawArtifactClaimedAt: new Date(Date.now() - 240_000),
       errorCode: 'raw_artifact_write_failed',
     });
 
     const persisted = await artifactService.ensureRawArtifact(
       saved.conversation,
       baseInput.userId,
-      { body: '{"replacement":true}', contentType: 'application/json' }
+      { body: replacement, contentType: 'application/json' }
     );
 
     expect(uploads).toEqual([persisted.rawArtifactKey]);
@@ -230,6 +232,35 @@ describe('ConversationIntakeService', () => {
     expect(persisted.errorCode).toBeNull();
   });
 
+  it('fails closed rather than replacing an expired claim with different raw bytes', async () => {
+    const storage = {
+      uploadFile: jest.fn().mockResolvedValue(undefined),
+    } as unknown as StorageService;
+    const artifactService = new ConversationIntakeService(dataSource, storage);
+    const saved = await artifactService.save(baseInput);
+    const originalKey = `raw-intakes/original/${saved.conversation.id}/claim/artifact.json`;
+    await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
+      rawArtifactKey: originalKey,
+      rawArtifactSha256: createHash('sha256').update('original').digest('hex'),
+      rawArtifactSize: 8,
+      rawArtifactStatus: 'pending',
+      rawArtifactClaimId: '00000000-0000-4000-8000-000000000002',
+      rawArtifactClaimedAt: new Date(Date.now() - 240_000),
+    });
+
+    await expect(
+      artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
+        body: 'different',
+        contentType: 'text/plain',
+      })
+    ).rejects.toThrow('recovery requires the exact original raw payload');
+    const retained = await dataSource
+      .getRepository(ConversationIntake)
+      .findOneByOrFail({ id: saved.conversation.id });
+    expect(retained.rawArtifactKey).toBe(originalKey);
+    expect(storage.uploadFile).not.toHaveBeenCalled();
+  });
+
   it('reclaims a pending claim when its lease expires during the wait', async () => {
     const storage = {
       uploadFile: jest.fn().mockResolvedValue(undefined),
@@ -237,19 +268,20 @@ describe('ConversationIntakeService', () => {
     } as unknown as StorageService;
     const artifactService = new ConversationIntakeService(dataSource, storage);
     const saved = await artifactService.save(baseInput);
+    const afterWait = '{"after-wait":true}';
     await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
       rawArtifactKey: `raw-intakes/pending/${saved.conversation.id}/pending/artifact.json`,
-      rawArtifactSha256: 'b'.repeat(64),
+      rawArtifactSha256: createHash('sha256').update(afterWait).digest('hex'),
       rawArtifactSize: 8,
       rawArtifactStatus: 'pending',
       rawArtifactClaimId: '00000000-0000-4000-8000-000000000001',
-      rawArtifactClaimedAt: new Date(Date.now() - 59_900),
+      rawArtifactClaimedAt: new Date(Date.now() - 179_900),
     });
 
     const persisted = await artifactService.ensureRawArtifact(
       saved.conversation,
       baseInput.userId,
-      { body: '{"after-wait":true}', contentType: 'application/json' }
+      { body: afterWait, contentType: 'application/json' }
     );
 
     expect(persisted.rawArtifactStatus).toBe('stored');

--- a/apps/api/src/services/__tests__/mystira-auth.service.test.ts
+++ b/apps/api/src/services/__tests__/mystira-auth.service.test.ts
@@ -51,7 +51,7 @@ describe('Mystira extension authentication', () => {
     process.env.MYSTIRA_ADMIN_EMAILS = 'other@example.com, operator@example.com';
     mockDiscoveryAndKeys();
 
-    const result = await exchangeMystiraIdToken(createIdToken());
+    const result = await exchangeMystiraIdToken(createIdToken({ email_verified: true }));
     const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
 
     expect(claims.role).toBe('admin');
@@ -62,6 +62,16 @@ describe('Mystira extension authentication', () => {
     mockDiscoveryAndKeys();
 
     const result = await exchangeMystiraIdToken(createIdToken());
+    const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(claims.role).toBe('user');
+  });
+
+  it('does not elevate an allow-listed email unless Mystira verified it', async () => {
+    process.env.MYSTIRA_ADMIN_EMAILS = 'operator@example.com';
+    mockDiscoveryAndKeys();
+
+    const result = await exchangeMystiraIdToken(createIdToken({ email_verified: false }));
     const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
 
     expect(claims.role).toBe('user');

--- a/apps/api/src/services/__tests__/mystira-auth.service.test.ts
+++ b/apps/api/src/services/__tests__/mystira-auth.service.test.ts
@@ -6,6 +6,8 @@ import { exchangeMystiraIdToken, resetMystiraDiscoveryCache } from '../mystira-a
 describe('Mystira extension authentication', () => {
   const originalWellKnown = process.env.MYSTIRA_IDENTITY_WELL_KNOWN;
   const originalClientId = process.env.MYSTIRA_IDENTITY_CLIENT_ID;
+  const originalAdminEmails = process.env.MYSTIRA_ADMIN_EMAILS;
+  const originalAdminSubjects = process.env.MYSTIRA_ADMIN_SUBJECTS;
   const issuer = 'https://identity.example';
   const clientId = 'convolens-client';
   const keyId = 'mystira-signing-key';
@@ -23,14 +25,46 @@ describe('Mystira extension authentication', () => {
     process.env.MYSTIRA_IDENTITY_WELL_KNOWN =
       'https://identity.example/.well-known/openid-configuration';
     process.env.MYSTIRA_IDENTITY_CLIENT_ID = clientId;
+    delete process.env.MYSTIRA_ADMIN_EMAILS;
+    delete process.env.MYSTIRA_ADMIN_SUBJECTS;
     resetMystiraDiscoveryCache();
     global.fetch = jest.fn();
   });
 
   afterEach(() => {
-    process.env.MYSTIRA_IDENTITY_WELL_KNOWN = originalWellKnown;
-    process.env.MYSTIRA_IDENTITY_CLIENT_ID = originalClientId;
+    restoreEnvironment('MYSTIRA_IDENTITY_WELL_KNOWN', originalWellKnown);
+    restoreEnvironment('MYSTIRA_IDENTITY_CLIENT_ID', originalClientId);
+    restoreEnvironment('MYSTIRA_ADMIN_EMAILS', originalAdminEmails);
+    restoreEnvironment('MYSTIRA_ADMIN_SUBJECTS', originalAdminSubjects);
     jest.restoreAllMocks();
+  });
+
+  function restoreEnvironment(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+
+  it('issues an admin API token only for an explicitly configured verified identity', async () => {
+    process.env.MYSTIRA_ADMIN_EMAILS = 'other@example.com, operator@example.com';
+    mockDiscoveryAndKeys();
+
+    const result = await exchangeMystiraIdToken(createIdToken());
+    const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(claims.role).toBe('admin');
+  });
+
+  it('does not elevate an unconfigured verified identity', async () => {
+    process.env.MYSTIRA_ADMIN_EMAILS = 'other@example.com';
+    mockDiscoveryAndKeys();
+
+    const result = await exchangeMystiraIdToken(createIdToken());
+    const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(claims.role).toBe('user');
   });
 
   function createIdToken(overrides: Record<string, unknown> = {}): string {

--- a/apps/api/src/services/__tests__/mystira-auth.service.test.ts
+++ b/apps/api/src/services/__tests__/mystira-auth.service.test.ts
@@ -77,6 +77,16 @@ describe('Mystira extension authentication', () => {
     expect(claims.role).toBe('user');
   });
 
+  it('matches opaque Mystira subjects case-sensitively', async () => {
+    process.env.MYSTIRA_ADMIN_SUBJECTS = 'Mystira-User-123';
+    mockDiscoveryAndKeys();
+
+    const result = await exchangeMystiraIdToken(createIdToken());
+    const claims = jwt.verify(result.token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(claims.role).toBe('user');
+  });
+
   function createIdToken(overrides: Record<string, unknown> = {}): string {
     return jwt.sign(
       {

--- a/apps/api/src/services/__tests__/selector-report.service.test.ts
+++ b/apps/api/src/services/__tests__/selector-report.service.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { DataSource } from 'typeorm';
+import { SelectorReport } from '../../db/entities/SelectorReport';
+import { SelectorReportService } from '../selector-report.service';
+
+describe('SelectorReportService', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      synchronize: true,
+      entities: [SelectorReport],
+    });
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  it('persists reports across service instances and bounds retained evidence', async () => {
+    const writer = new SelectorReportService(dataSource, 2);
+    for (let index = 0; index < 3; index += 1) {
+      await writer.save({
+        discovered: { messageList: `[data-fixture="${index}"]` },
+        userAgent: 'Synthetic fixture browser',
+        timestamp: new Date(Date.UTC(2026, 6, 31, 8, index)).toISOString(),
+        extensionVersion: '1.0.20',
+      });
+    }
+
+    const readerAfterRestart = new SelectorReportService(dataSource, 2);
+    const reports = await readerAfterRestart.list();
+    expect(reports).toHaveLength(2);
+    expect(reports.map((report) => report.discovered.messageList)).toEqual([
+      '[data-fixture="2"]',
+      '[data-fixture="1"]',
+    ]);
+    expect(await dataSource.getRepository(SelectorReport).count()).toBe(2);
+  });
+});

--- a/apps/api/src/services/__tests__/selector-report.service.test.ts
+++ b/apps/api/src/services/__tests__/selector-report.service.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { DataSource } from 'typeorm';
 import { SelectorReport } from '../../db/entities/SelectorReport';
 import { SelectorReportService } from '../selector-report.service';
@@ -20,6 +20,10 @@ describe('SelectorReportService', () => {
     await dataSource.destroy();
   });
 
+  beforeEach(async () => {
+    await dataSource.getRepository(SelectorReport).clear();
+  });
+
   it('persists reports across service instances and bounds retained evidence', async () => {
     const writer = new SelectorReportService(dataSource, 2);
     for (let index = 0; index < 3; index += 1) {
@@ -29,6 +33,7 @@ describe('SelectorReportService', () => {
         timestamp: new Date(Date.UTC(2026, 6, 31, 8, index)).toISOString(),
         extensionVersion: '1.0.20',
       });
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
     }
 
     const readerAfterRestart = new SelectorReportService(dataSource, 2);
@@ -39,5 +44,29 @@ describe('SelectorReportService', () => {
       '[data-fixture="1"]',
     ]);
     expect(await dataSource.getRepository(SelectorReport).count()).toBe(2);
+  });
+
+  it('bounds retention by server receipt rather than the client observation clock', async () => {
+    const writer = new SelectorReportService(dataSource, 2);
+    for (const [label, timestamp] of [
+      ['future-first', '2126-07-31T08:00:00.000Z'],
+      ['current-second', '2026-07-31T08:00:00.000Z'],
+      ['past-last', '1926-07-31T08:00:00.000Z'],
+    ] as const) {
+      await writer.save({
+        discovered: { messageList: label },
+        userAgent: 'Synthetic skew fixture',
+        timestamp,
+      });
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+    }
+
+    const retained = await dataSource.getRepository(SelectorReport).find({
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    expect(retained.map((report) => report.discovered.messageList)).toEqual([
+      'past-last',
+      'current-second',
+    ]);
   });
 });

--- a/apps/api/src/services/__tests__/storage-managed-identity.test.ts
+++ b/apps/api/src/services/__tests__/storage-managed-identity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import {
   AZURE_MANAGED_IDENTITY_TIMEOUT_MS,
+  AZURE_DELETE_REQUEST_TIMEOUT_MS,
   AZURE_UPLOAD_MAX_RETRIES,
   AZURE_UPLOAD_REQUEST_TIMEOUT_MS,
   AZURE_UPLOAD_TOTAL_TIMEOUT_MS,
@@ -10,15 +11,18 @@ import {
 const originalEnvironment = {
   account: process.env.AZURE_STORAGE_ACCOUNT_NAME,
   container: process.env.AZURE_STORAGE_CONTAINER,
+  sasToken: process.env.AZURE_STORAGE_SAS_TOKEN,
   endpoint: process.env.IDENTITY_ENDPOINT,
   header: process.env.IDENTITY_HEADER,
 };
 
 afterEach(() => {
+  jest.useRealTimers();
   jest.restoreAllMocks();
   for (const [name, value] of Object.entries({
     AZURE_STORAGE_ACCOUNT_NAME: originalEnvironment.account,
     AZURE_STORAGE_CONTAINER: originalEnvironment.container,
+    AZURE_STORAGE_SAS_TOKEN: originalEnvironment.sasToken,
     IDENTITY_ENDPOINT: originalEnvironment.endpoint,
     IDENTITY_HEADER: originalEnvironment.header,
   })) {
@@ -36,6 +40,7 @@ describe('StorageService managed identity', () => {
 
     expect(worstCaseConfiguredDuration).toBeLessThan(AZURE_UPLOAD_TOTAL_TIMEOUT_MS);
     expect(AZURE_UPLOAD_TOTAL_TIMEOUT_MS).toBeLessThan(60_000);
+    expect(AZURE_DELETE_REQUEST_TIMEOUT_MS).toBeLessThan(60_000);
   });
 
   it('uses and caches a Container Apps identity token for private Blob writes', async () => {
@@ -78,5 +83,28 @@ describe('StorageService managed identity', () => {
         }),
       });
     }
+  });
+
+  it('aborts a stalled Blob deletion inside the caller window', async () => {
+    jest.useFakeTimers();
+    process.env.AZURE_STORAGE_ACCOUNT_NAME = 'fixturestorage';
+    process.env.AZURE_STORAGE_CONTAINER = 'chat-exports';
+    process.env.AZURE_STORAGE_SAS_TOKEN = 'fixture-sas';
+    jest.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          });
+        })
+    );
+    const storage = new StorageService({ provider: 'azure-blob' });
+
+    const assertion = expect(
+      storage.deleteFile('raw-intakes/a/stalled.json')
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    await jest.advanceTimersByTimeAsync(AZURE_DELETE_REQUEST_TIMEOUT_MS);
+
+    await assertion;
   });
 });

--- a/apps/api/src/services/__tests__/storage-managed-identity.test.ts
+++ b/apps/api/src/services/__tests__/storage-managed-identity.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import { StorageService } from '../storage/storage.service';
+import {
+  AZURE_MANAGED_IDENTITY_TIMEOUT_MS,
+  AZURE_UPLOAD_MAX_RETRIES,
+  AZURE_UPLOAD_REQUEST_TIMEOUT_MS,
+  AZURE_UPLOAD_TOTAL_TIMEOUT_MS,
+  StorageService,
+} from '../storage/storage.service';
 
 const originalEnvironment = {
   account: process.env.AZURE_STORAGE_ACCOUNT_NAME,
@@ -22,6 +28,16 @@ afterEach(() => {
 });
 
 describe('StorageService managed identity', () => {
+  it('bounds identity lookup and Blob retries below the 60-second caller timeout', () => {
+    const worstCaseConfiguredDuration =
+      AZURE_MANAGED_IDENTITY_TIMEOUT_MS +
+      AZURE_UPLOAD_REQUEST_TIMEOUT_MS * (AZURE_UPLOAD_MAX_RETRIES + 1) +
+      1_000;
+
+    expect(worstCaseConfiguredDuration).toBeLessThan(AZURE_UPLOAD_TOTAL_TIMEOUT_MS);
+    expect(AZURE_UPLOAD_TOTAL_TIMEOUT_MS).toBeLessThan(60_000);
+  });
+
   it('uses and caches a Container Apps identity token for private Blob writes', async () => {
     process.env.AZURE_STORAGE_ACCOUNT_NAME = 'fixturestorage';
     process.env.AZURE_STORAGE_CONTAINER = 'chat-exports';

--- a/apps/api/src/services/__tests__/storage-managed-identity.test.ts
+++ b/apps/api/src/services/__tests__/storage-managed-identity.test.ts
@@ -12,6 +12,7 @@ const originalEnvironment = {
   account: process.env.AZURE_STORAGE_ACCOUNT_NAME,
   container: process.env.AZURE_STORAGE_CONTAINER,
   sasToken: process.env.AZURE_STORAGE_SAS_TOKEN,
+  accountKey: process.env.AZURE_STORAGE_ACCOUNT_KEY,
   endpoint: process.env.IDENTITY_ENDPOINT,
   header: process.env.IDENTITY_HEADER,
 };
@@ -23,6 +24,7 @@ afterEach(() => {
     AZURE_STORAGE_ACCOUNT_NAME: originalEnvironment.account,
     AZURE_STORAGE_CONTAINER: originalEnvironment.container,
     AZURE_STORAGE_SAS_TOKEN: originalEnvironment.sasToken,
+    AZURE_STORAGE_ACCOUNT_KEY: originalEnvironment.accountKey,
     IDENTITY_ENDPOINT: originalEnvironment.endpoint,
     IDENTITY_HEADER: originalEnvironment.header,
   })) {
@@ -106,5 +108,27 @@ describe('StorageService managed identity', () => {
     await jest.advanceTimersByTimeAsync(AZURE_DELETE_REQUEST_TIMEOUT_MS);
 
     await assertion;
+  });
+
+  it('uses SharedKey authentication for Blob deletion when an account key is configured', async () => {
+    process.env.AZURE_STORAGE_ACCOUNT_NAME = 'fixturestorage';
+    process.env.AZURE_STORAGE_CONTAINER = 'chat-exports';
+    process.env.AZURE_STORAGE_ACCOUNT_KEY = Buffer.from('fixture-account-key').toString('base64');
+    delete process.env.AZURE_STORAGE_SAS_TOKEN;
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 202 }));
+    const storage = new StorageService({ provider: 'azure-blob' });
+
+    await storage.deleteFile('raw-intakes/a/account-key.json');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      method: 'DELETE',
+      headers: expect.objectContaining({
+        Authorization: expect.stringMatching(/^SharedKey fixturestorage:/),
+        'x-ms-date': expect.any(String),
+      }),
+    });
   });
 });

--- a/apps/api/src/services/__tests__/storage-managed-identity.test.ts
+++ b/apps/api/src/services/__tests__/storage-managed-identity.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { StorageService } from '../storage/storage.service';
+
+const originalEnvironment = {
+  account: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+  container: process.env.AZURE_STORAGE_CONTAINER,
+  endpoint: process.env.IDENTITY_ENDPOINT,
+  header: process.env.IDENTITY_HEADER,
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  for (const [name, value] of Object.entries({
+    AZURE_STORAGE_ACCOUNT_NAME: originalEnvironment.account,
+    AZURE_STORAGE_CONTAINER: originalEnvironment.container,
+    IDENTITY_ENDPOINT: originalEnvironment.endpoint,
+    IDENTITY_HEADER: originalEnvironment.header,
+  })) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe('StorageService managed identity', () => {
+  it('uses and caches a Container Apps identity token for private Blob writes', async () => {
+    process.env.AZURE_STORAGE_ACCOUNT_NAME = 'fixturestorage';
+    process.env.AZURE_STORAGE_CONTAINER = 'chat-exports';
+    process.env.IDENTITY_ENDPOINT = 'http://localhost/identity/token';
+    process.env.IDENTITY_HEADER = 'fixture-identity-header';
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'fixture-managed-identity-token',
+            expires_on: Math.floor(Date.now() / 1000) + 3_600,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    const storage = new StorageService({ provider: 'azure-blob' });
+
+    await storage.uploadFile('raw-intakes/a/first.json', '{}', {
+      contentType: 'application/json',
+    });
+    await storage.uploadFile('raw-intakes/a/second.json', '{}', {
+      contentType: 'application/json',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [tokenUrl, tokenRequest] = fetchMock.mock.calls[0];
+    expect(String(tokenUrl)).toContain('resource=https%3A%2F%2Fstorage.azure.com%2F');
+    expect(tokenRequest).toMatchObject({
+      headers: { 'X-IDENTITY-HEADER': 'fixture-identity-header' },
+    });
+    for (const call of fetchMock.mock.calls.slice(1)) {
+      expect(call[1]).toMatchObject({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer fixture-managed-identity-token',
+        }),
+      });
+    }
+  });
+});

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -4,12 +4,20 @@ import { AppDataSource } from '../config/database';
 import { User } from '../db/entities/User';
 import { UserRole } from '../db/entities/User';
 
+export function issueApiToken(user: Pick<User, 'id' | 'email' | 'role'>): string {
+  return jwt.sign(
+    { id: user.id, userId: user.id, email: user.email, role: user.role },
+    JWT_SECRET,
+    { expiresIn: '24h', subject: user.id }
+  );
+}
+
 export class AuthService {
   private userRepository = AppDataSource.getRepository(User);
 
   async register(email: string, password: string, name?: string): Promise<User> {
     const existingUser = await this.userRepository.findOne({ where: { email } });
-    
+
     if (existingUser) {
       throw new Error('User already exists');
     }
@@ -26,7 +34,7 @@ export class AuthService {
 
   async login(email: string, password: string): Promise<{ user: User; token: string }> {
     const user = await this.userRepository.findOne({ where: { email } });
-    
+
     if (!user || !(await user.validatePassword(password))) {
       throw new Error('Invalid credentials');
     }
@@ -40,11 +48,7 @@ export class AuthService {
     await this.userRepository.save(user);
 
     // Generate JWT token
-    const token = jwt.sign(
-      { userId: user.id, email: user.email, role: user.role },
-      JWT_SECRET,
-      { expiresIn: '24h' }
-    );
+    const token = issueApiToken(user);
 
     return { user, token };
   }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -466,6 +466,7 @@ export class ConversationIntakeService {
     // overwriting the artifact selected by a newer lease for the same payload.
     const key = `raw-intakes/${ownerScope}/${conversation.id}/${claimId}/${sha256}.${extension}`;
     const claimedAt = new Date();
+    let supersededKey: string | undefined;
     let claim = await repository.update(
       { id: conversation.id, rawArtifactKey: IsNull() },
       {
@@ -493,6 +494,9 @@ export class ConversationIntakeService {
             rawArtifactSha256: sha256,
           },
           {
+            rawArtifactKey: key,
+            rawArtifactSha256: sha256,
+            rawArtifactSize: buffer.length,
             rawArtifactStatus: 'pending',
             rawArtifactClaimId: claimId,
             rawArtifactClaimedAt: claimedAt,
@@ -500,6 +504,7 @@ export class ConversationIntakeService {
             errorCode: null,
           }
         );
+        if (claim.affected === 1) supersededKey = claimed.rawArtifactKey;
       }
 
       const claimExpired =
@@ -523,11 +528,14 @@ export class ConversationIntakeService {
             errorCode: null,
           }
         );
+        if (claim.affected === 1) supersededKey = claimed.rawArtifactKey;
       }
 
       if (claim.affected !== 1) {
         if (claimed.rawArtifactStatus === 'pending' && claimed.rawArtifactKey) {
-          return this.waitForRawArtifact(conversation.id);
+          const resolved = await this.waitForRawArtifact(conversation.id);
+          if (resolved) return resolved;
+          return this.ensureRawArtifactLocked(conversation, userId, artifact);
         }
         throw new Error(
           'The first raw artifact failed and cannot be replaced by a different duplicate payload'
@@ -552,7 +560,15 @@ export class ConversationIntakeService {
       );
       if (finalized.affected !== 1) {
         await this.storage.deleteFile(key);
-        return this.waitForRawArtifact(conversation.id);
+        const resolved = await this.waitForRawArtifact(conversation.id);
+        if (resolved) return resolved;
+        return this.ensureRawArtifactLocked(conversation, userId, artifact);
+      }
+      if (supersededKey && supersededKey !== key) {
+        // Cleanup is best-effort after the durable row points at the winning
+        // artifact; a cleanup outage must not turn a stored intake back into a
+        // failed one.
+        await this.storage.deleteFile(supersededKey).catch(() => undefined);
       }
     } catch (error) {
       await repository.update(
@@ -571,14 +587,21 @@ export class ConversationIntakeService {
     return (await repository.findOneByOrFail({ id: conversation.id })) as ConversationIntake;
   }
 
-  private async waitForRawArtifact(id: string): Promise<ConversationIntake> {
+  private async waitForRawArtifact(id: string): Promise<ConversationIntake | null> {
     const repository = this.dataSource.getRepository(ConversationIntake);
-    const deadline = Date.now() + 45_000;
+    const deadline = Date.now() + RAW_ARTIFACT_CLAIM_LEASE_MS * 2;
     while (Date.now() < deadline) {
       const current = await repository.findOneByOrFail({ id });
       if (current.rawArtifactStatus === 'stored') return current;
       if (current.rawArtifactStatus === 'failed') {
         throw new Error('The first raw artifact write failed');
+      }
+      if (
+        current.rawArtifactStatus === 'pending' &&
+        (!current.rawArtifactClaimedAt ||
+          current.rawArtifactClaimedAt.getTime() <= Date.now() - RAW_ARTIFACT_CLAIM_LEASE_MS)
+      ) {
+        return null;
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
     }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -8,6 +8,7 @@ import {
   type ConversationSourceKind,
 } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
+import { StorageService } from './storage/storage.service';
 
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
@@ -67,6 +68,7 @@ export interface ConversationIntakeSummary {
   isGroup: boolean;
   participants: string[];
   status: string;
+  rawArtifactStatus: string;
   messageCount: number;
   sourceExtractedAt?: Date;
   receivedAt: Date;
@@ -76,6 +78,11 @@ export interface SaveConversationResult {
   conversation: ConversationIntake;
   duplicate: boolean;
   reconciliationRequired: boolean;
+}
+
+export interface RawConversationArtifact {
+  body: Buffer | string;
+  contentType: 'application/json' | 'text/plain';
 }
 
 function normalizeHashValue(value: string): string {
@@ -400,7 +407,58 @@ function isContentHashUniqueConstraintError(error: unknown): boolean {
 }
 
 export class ConversationIntakeService {
-  constructor(private readonly dataSource: DataSource = AppDataSource) {}
+  constructor(
+    private readonly dataSource: DataSource = AppDataSource,
+    private readonly storage: StorageService = new StorageService()
+  ) {}
+
+  async ensureRawArtifact(
+    conversation: ConversationIntake,
+    userId: string,
+    artifact: RawConversationArtifact
+  ): Promise<ConversationIntake> {
+    const buffer = Buffer.isBuffer(artifact.body) ? artifact.body : Buffer.from(artifact.body);
+    const sha256 = createHash('sha256').update(buffer).digest('hex');
+    // A duplicate normalized intake retains the exact first accepted raw evidence.
+    // Connector-generated ids and extraction timestamps may differ on a retry,
+    // so replacing the artifact would create unowned blobs and weaken provenance.
+    if (conversation.rawArtifactStatus === 'stored' && conversation.rawArtifactKey) {
+      return conversation;
+    }
+
+    const ownerScope = createHash('sha256').update(userId).digest('hex').slice(0, 32);
+    const extension = artifact.contentType === 'application/json' ? 'json' : 'txt';
+    const key = `raw-intakes/${ownerScope}/${conversation.id}/${sha256}.${extension}`;
+    const repository = this.dataSource.getRepository(ConversationIntake);
+    await repository.update(conversation.id, {
+      rawArtifactKey: key,
+      rawArtifactSha256: sha256,
+      rawArtifactSize: buffer.length,
+      rawArtifactStatus: 'pending',
+      errorCode: undefined,
+    });
+
+    try {
+      await this.storage.uploadFile(key, buffer, {
+        contentType: artifact.contentType,
+        metadata: { intakeId: conversation.id },
+      });
+      await repository.update(conversation.id, {
+        rawArtifactStatus: 'stored',
+        status: 'received',
+        errorCode: undefined,
+      });
+    } catch (error) {
+      await repository.update(conversation.id, {
+        rawArtifactStatus: 'failed',
+        status: 'failed',
+        errorCode: 'raw_artifact_write_failed',
+      });
+      throw error;
+    }
+
+    return (await repository.findOneByOrFail({ id: conversation.id })) as ConversationIntake;
+  }
 
   private async updateDuplicate(
     conversation: ConversationIntake,
@@ -713,6 +771,7 @@ export class ConversationIntakeService {
       isGroup: conversation.isGroup,
       participants: conversation.participants || [],
       status: conversation.status,
+      rawArtifactStatus: conversation.rawArtifactStatus,
       messageCount: conversation.messageCount,
       sourceExtractedAt: conversation.sourceExtractedAt,
       receivedAt: conversation.receivedAt,
@@ -728,7 +787,13 @@ export class ConversationIntakeService {
   }
 
   async deleteForUser(userId: string, id: string): Promise<boolean> {
-    const result = await this.dataSource.getRepository(ConversationIntake).delete({ id, userId });
+    const repository = this.dataSource.getRepository(ConversationIntake);
+    const conversation = await repository.findOneBy({ id, userId });
+    if (!conversation) return false;
+    if (conversation.rawArtifactKey) {
+      await this.storage.deleteFile(conversation.rawArtifactKey);
+    }
+    const result = await repository.delete({ id, userId });
     return result.affected === 1;
   }
 }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { In, IsNull, QueryFailedError, type DataSource, type EntityManager } from 'typeorm';
 import { AppDataSource } from '../config/database';
 import {
@@ -12,6 +12,7 @@ import { StorageService } from './storage/storage.service';
 
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
+const RAW_ARTIFACT_CLAIM_LEASE_MS = 60_000;
 const compatibilityQueues = new Map<string, Promise<void>>();
 const rawArtifactQueues = new Map<string, Promise<void>>();
 
@@ -460,7 +461,11 @@ export class ConversationIntakeService {
 
     const ownerScope = createHash('sha256').update(userId).digest('hex').slice(0, 32);
     const extension = artifact.contentType === 'application/json' ? 'json' : 'txt';
-    const key = `raw-intakes/${ownerScope}/${conversation.id}/${sha256}.${extension}`;
+    const claimId = randomUUID();
+    // A claim-specific segment prevents a late, expired writer from deleting or
+    // overwriting the artifact selected by a newer lease for the same payload.
+    const key = `raw-intakes/${ownerScope}/${conversation.id}/${claimId}/${sha256}.${extension}`;
+    const claimedAt = new Date();
     let claim = await repository.update(
       { id: conversation.id, rawArtifactKey: IsNull() },
       {
@@ -468,7 +473,9 @@ export class ConversationIntakeService {
         rawArtifactSha256: sha256,
         rawArtifactSize: buffer.length,
         rawArtifactStatus: 'pending',
-        errorCode: undefined,
+        rawArtifactClaimId: claimId,
+        rawArtifactClaimedAt: claimedAt,
+        errorCode: null,
       }
     );
 
@@ -485,7 +492,36 @@ export class ConversationIntakeService {
             rawArtifactStatus: 'failed',
             rawArtifactSha256: sha256,
           },
-          { rawArtifactStatus: 'pending', status: 'received', errorCode: undefined }
+          {
+            rawArtifactStatus: 'pending',
+            rawArtifactClaimId: claimId,
+            rawArtifactClaimedAt: claimedAt,
+            status: 'received',
+            errorCode: null,
+          }
+        );
+      }
+
+      const claimExpired =
+        claimed.rawArtifactStatus === 'pending' &&
+        (!claimed.rawArtifactClaimedAt ||
+          claimed.rawArtifactClaimedAt.getTime() <= Date.now() - RAW_ARTIFACT_CLAIM_LEASE_MS);
+      if (claim.affected !== 1 && claimExpired) {
+        claim = await repository.update(
+          {
+            id: conversation.id,
+            rawArtifactStatus: 'pending',
+            rawArtifactClaimId: claimed.rawArtifactClaimId || IsNull(),
+          },
+          {
+            rawArtifactKey: key,
+            rawArtifactSha256: sha256,
+            rawArtifactSize: buffer.length,
+            rawArtifactClaimId: claimId,
+            rawArtifactClaimedAt: claimedAt,
+            status: 'received',
+            errorCode: null,
+          }
         );
       }
 
@@ -504,17 +540,31 @@ export class ConversationIntakeService {
         contentType: artifact.contentType,
         metadata: { intakeId: conversation.id },
       });
-      await repository.update(conversation.id, {
-        rawArtifactStatus: 'stored',
-        status: 'received',
-        errorCode: undefined,
-      });
+      const finalized = await repository.update(
+        { id: conversation.id, rawArtifactStatus: 'pending', rawArtifactClaimId: claimId },
+        {
+          rawArtifactStatus: 'stored',
+          rawArtifactClaimId: null,
+          rawArtifactClaimedAt: null,
+          status: 'received',
+          errorCode: null,
+        }
+      );
+      if (finalized.affected !== 1) {
+        await this.storage.deleteFile(key);
+        return this.waitForRawArtifact(conversation.id);
+      }
     } catch (error) {
-      await repository.update(conversation.id, {
-        rawArtifactStatus: 'failed',
-        status: 'failed',
-        errorCode: 'raw_artifact_write_failed',
-      });
+      await repository.update(
+        { id: conversation.id, rawArtifactStatus: 'pending', rawArtifactClaimId: claimId },
+        {
+          rawArtifactStatus: 'failed',
+          rawArtifactClaimId: null,
+          rawArtifactClaimedAt: null,
+          status: 'failed',
+          errorCode: 'raw_artifact_write_failed',
+        }
+      );
       throw error;
     }
 

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -12,7 +12,10 @@ import { StorageService } from './storage/storage.service';
 
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
-const RAW_ARTIFACT_CLAIM_LEASE_MS = 60_000;
+// Azure upload retries can consume about 127 seconds (four 30-second attempts
+// plus backoff), so an active first writer must not be reclaimed inside that
+// window.
+const RAW_ARTIFACT_CLAIM_LEASE_MS = 180_000;
 const compatibilityQueues = new Map<string, Promise<void>>();
 const rawArtifactQueues = new Map<string, Promise<void>>();
 
@@ -511,7 +514,7 @@ export class ConversationIntakeService {
         claimed.rawArtifactStatus === 'pending' &&
         (!claimed.rawArtifactClaimedAt ||
           claimed.rawArtifactClaimedAt.getTime() <= Date.now() - RAW_ARTIFACT_CLAIM_LEASE_MS);
-      if (claim.affected !== 1 && claimExpired) {
+      if (claim.affected !== 1 && claimExpired && claimed.rawArtifactSha256 === sha256) {
         claim = await repository.update(
           {
             id: conversation.id,
@@ -533,6 +536,11 @@ export class ConversationIntakeService {
 
       if (claim.affected !== 1) {
         if (claimed.rawArtifactStatus === 'pending' && claimed.rawArtifactKey) {
+          if (claimExpired && claimed.rawArtifactSha256 !== sha256) {
+            throw new Error(
+              'The first raw artifact claim expired; recovery requires the exact original raw payload'
+            );
+          }
           const resolved = await this.waitForRawArtifact(conversation.id);
           if (resolved) return resolved;
           return this.ensureRawArtifactLocked(conversation, userId, artifact);

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -13,6 +13,7 @@ import { StorageService } from './storage/storage.service';
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
 const compatibilityQueues = new Map<string, Promise<void>>();
+const rawArtifactQueues = new Map<string, Promise<void>>();
 
 async function withLocalCompatibilityLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
   const previous = compatibilityQueues.get(key) || Promise.resolve();
@@ -29,6 +30,25 @@ async function withLocalCompatibilityLock<T>(key: string, operation: () => Promi
     release();
     if (compatibilityQueues.get(key) === queued) {
       compatibilityQueues.delete(key);
+    }
+  }
+}
+
+async function withLocalRawArtifactLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+  const previous = rawArtifactQueues.get(key) || Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => gate);
+  rawArtifactQueues.set(key, queued);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (rawArtifactQueues.get(key) === queued) {
+      rawArtifactQueues.delete(key);
     }
   }
 }
@@ -417,26 +437,67 @@ export class ConversationIntakeService {
     userId: string,
     artifact: RawConversationArtifact
   ): Promise<ConversationIntake> {
+    return withLocalRawArtifactLock(conversation.id, () =>
+      this.ensureRawArtifactLocked(conversation, userId, artifact)
+    );
+  }
+
+  private async ensureRawArtifactLocked(
+    conversation: ConversationIntake,
+    userId: string,
+    artifact: RawConversationArtifact
+  ): Promise<ConversationIntake> {
     const buffer = Buffer.isBuffer(artifact.body) ? artifact.body : Buffer.from(artifact.body);
     const sha256 = createHash('sha256').update(buffer).digest('hex');
+    const repository = this.dataSource.getRepository(ConversationIntake);
+    const current = await repository.findOneByOrFail({ id: conversation.id });
     // A duplicate normalized intake retains the exact first accepted raw evidence.
     // Connector-generated ids and extraction timestamps may differ on a retry,
     // so replacing the artifact would create unowned blobs and weaken provenance.
-    if (conversation.rawArtifactStatus === 'stored' && conversation.rawArtifactKey) {
-      return conversation;
+    if (current.rawArtifactStatus === 'stored' && current.rawArtifactKey) {
+      return current;
     }
 
     const ownerScope = createHash('sha256').update(userId).digest('hex').slice(0, 32);
     const extension = artifact.contentType === 'application/json' ? 'json' : 'txt';
     const key = `raw-intakes/${ownerScope}/${conversation.id}/${sha256}.${extension}`;
-    const repository = this.dataSource.getRepository(ConversationIntake);
-    await repository.update(conversation.id, {
-      rawArtifactKey: key,
-      rawArtifactSha256: sha256,
-      rawArtifactSize: buffer.length,
-      rawArtifactStatus: 'pending',
-      errorCode: undefined,
-    });
+    let claim = await repository.update(
+      { id: conversation.id, rawArtifactKey: IsNull() },
+      {
+        rawArtifactKey: key,
+        rawArtifactSha256: sha256,
+        rawArtifactSize: buffer.length,
+        rawArtifactStatus: 'pending',
+        errorCode: undefined,
+      }
+    );
+
+    if (claim.affected !== 1) {
+      const claimed = await repository.findOneByOrFail({ id: conversation.id });
+      if (claimed.rawArtifactStatus === 'stored' && claimed.rawArtifactKey) return claimed;
+
+      // A retry may resume the same first artifact after a failed write, but a
+      // different duplicate payload must never replace its provenance.
+      if (claimed.rawArtifactStatus === 'failed' && claimed.rawArtifactSha256 === sha256) {
+        claim = await repository.update(
+          {
+            id: conversation.id,
+            rawArtifactStatus: 'failed',
+            rawArtifactSha256: sha256,
+          },
+          { rawArtifactStatus: 'pending', status: 'received', errorCode: undefined }
+        );
+      }
+
+      if (claim.affected !== 1) {
+        if (claimed.rawArtifactStatus === 'pending' && claimed.rawArtifactKey) {
+          return this.waitForRawArtifact(conversation.id);
+        }
+        throw new Error(
+          'The first raw artifact failed and cannot be replaced by a different duplicate payload'
+        );
+      }
+    }
 
     try {
       await this.storage.uploadFile(key, buffer, {
@@ -458,6 +519,20 @@ export class ConversationIntakeService {
     }
 
     return (await repository.findOneByOrFail({ id: conversation.id })) as ConversationIntake;
+  }
+
+  private async waitForRawArtifact(id: string): Promise<ConversationIntake> {
+    const repository = this.dataSource.getRepository(ConversationIntake);
+    const deadline = Date.now() + 45_000;
+    while (Date.now() < deadline) {
+      const current = await repository.findOneByOrFail({ id });
+      if (current.rawArtifactStatus === 'stored') return current;
+      if (current.rawArtifactStatus === 'failed') {
+        throw new Error('The first raw artifact write failed');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error('Timed out waiting for the first raw artifact write');
   }
 
   private async updateDuplicate(

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -12,9 +12,6 @@ import { StorageService } from './storage/storage.service';
 
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
-// Azure upload retries can consume about 127 seconds (four 30-second attempts
-// plus backoff), so an active first writer must not be reclaimed inside that
-// window.
 // Longer than the bounded 24-second Blob write, but short enough that a crashed
 // claim can be reclaimed and persisted inside the callers' 60-second window.
 export const RAW_ARTIFACT_CLAIM_LEASE_MS = 30_000;
@@ -606,6 +603,9 @@ export class ConversationIntakeService {
       if (current.rawArtifactStatus === 'failed') {
         throw new Error('The first raw artifact write failed');
       }
+      if (current.rawArtifactStatus === 'deleting') {
+        throw new Error('Conversation deletion started during the raw artifact write');
+      }
       if (
         current.rawArtifactStatus === 'pending' &&
         (!current.rawArtifactClaimedAt ||
@@ -948,6 +948,12 @@ export class ConversationIntakeService {
     const repository = this.dataSource.getRepository(ConversationIntake);
     const conversation = await repository.findOneBy({ id, userId });
     if (!conversation) return false;
+
+    // Tombstone the claim before touching Blob storage. A concurrent writer's
+    // claim-conditional finalization then fails and that writer cleans up its
+    // own late upload; new retries cannot claim a deleting row.
+    const marked = await repository.update({ id, userId }, { rawArtifactStatus: 'deleting' });
+    if (marked.affected !== 1) return false;
     if (conversation.rawArtifactKey) {
       await this.storage.deleteFile(conversation.rawArtifactKey);
     }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -8,13 +8,14 @@ import {
   type ConversationSourceKind,
 } from '../db/entities/ConversationIntake';
 import { ConversationMessage } from '../db/entities/ConversationMessage';
-import { StorageService } from './storage/storage.service';
+import { AZURE_UPLOAD_TOTAL_TIMEOUT_MS, StorageService } from './storage/storage.service';
 
 const COMPATIBILITY_BACKFILL_BATCH_SIZE = 100;
 const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
 // Longer than the bounded 24-second Blob write, but short enough that a crashed
 // claim can be reclaimed and persisted inside the callers' 60-second window.
 export const RAW_ARTIFACT_CLAIM_LEASE_MS = 30_000;
+export const RAW_ARTIFACT_DELETE_GRACE_MS = 2_000;
 const compatibilityQueues = new Map<string, Promise<void>>();
 const rawArtifactQueues = new Map<string, Promise<void>>();
 
@@ -470,7 +471,11 @@ export class ConversationIntakeService {
     const claimedAt = new Date();
     let supersededKey: string | undefined;
     let claim = await repository.update(
-      { id: conversation.id, rawArtifactKey: IsNull() },
+      {
+        id: conversation.id,
+        rawArtifactKey: IsNull(),
+        rawArtifactStatus: In(['pending', 'failed', 'not-recorded']),
+      },
       {
         rawArtifactKey: key,
         rawArtifactSha256: sha256,
@@ -954,6 +959,16 @@ export class ConversationIntakeService {
     // own late upload; new retries cannot claim a deleting row.
     const marked = await repository.update({ id, userId }, { rawArtifactStatus: 'deleting' });
     if (marked.affected !== 1) return false;
+    if (conversation.rawArtifactClaimId && conversation.rawArtifactClaimedAt) {
+      const cleanupSafeAt =
+        conversation.rawArtifactClaimedAt.getTime() +
+        AZURE_UPLOAD_TOTAL_TIMEOUT_MS +
+        RAW_ARTIFACT_DELETE_GRACE_MS;
+      const remainingUploadWindow = cleanupSafeAt - Date.now();
+      if (remainingUploadWindow > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remainingUploadWindow));
+      }
+    }
     if (conversation.rawArtifactKey) {
       await this.storage.deleteFile(conversation.rawArtifactKey);
     }

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -15,7 +15,9 @@ const VISUAL_MEDIA_FIX_VERSION = '1.0.13';
 // Azure upload retries can consume about 127 seconds (four 30-second attempts
 // plus backoff), so an active first writer must not be reclaimed inside that
 // window.
-const RAW_ARTIFACT_CLAIM_LEASE_MS = 180_000;
+// Longer than the bounded 24-second Blob write, but short enough that a crashed
+// claim can be reclaimed and persisted inside the callers' 60-second window.
+export const RAW_ARTIFACT_CLAIM_LEASE_MS = 30_000;
 const compatibilityQueues = new Map<string, Promise<void>>();
 const rawArtifactQueues = new Map<string, Promise<void>>();
 

--- a/apps/api/src/services/mystira-auth.service.ts
+++ b/apps/api/src/services/mystira-auth.service.ts
@@ -12,6 +12,8 @@ type MystiraIdTokenClaims = jwt.JwtPayload & {
   email?: string;
   name?: string;
   preferred_username?: string;
+  role?: string;
+  roles?: string[];
 };
 
 type JsonWebKeySet = {
@@ -26,6 +28,32 @@ export type ExtensionIdentity = {
 
 const DISCOVERY_CACHE_TTL_MS = 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
+
+function configuredValues(name: string): Set<string> {
+  return new Set(
+    (process.env[name] || '')
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function resolveMystiraApiRole(profile: MystiraIdTokenClaims): 'admin' | 'user' {
+  const roles = [profile.role, ...(Array.isArray(profile.roles) ? profile.roles : [])]
+    .filter((role): role is string => typeof role === 'string')
+    .map((role) => role.toLowerCase());
+  const email = profile.email || profile.preferred_username;
+
+  if (
+    roles.includes('admin') ||
+    (profile.sub && configuredValues('MYSTIRA_ADMIN_SUBJECTS').has(profile.sub.toLowerCase())) ||
+    (email && configuredValues('MYSTIRA_ADMIN_EMAILS').has(email.toLowerCase()))
+  ) {
+    return 'admin';
+  }
+
+  return 'user';
+}
 
 let cachedDiscovery:
   | {
@@ -121,13 +149,14 @@ export async function exchangeMystiraIdToken(
     email,
     name: profile.name,
   };
+  const role = resolveMystiraApiRole(profile);
   const expiresIn = 15 * 60;
   const token = jwt.sign(
     {
       id: user.id,
       userId: user.id,
       email: user.email,
-      role: 'user',
+      role,
       authProvider: 'mystira',
     },
     JWT_SECRET,

--- a/apps/api/src/services/mystira-auth.service.ts
+++ b/apps/api/src/services/mystira-auth.service.ts
@@ -12,6 +12,7 @@ type MystiraIdTokenClaims = jwt.JwtPayload & {
   email?: string;
   name?: string;
   preferred_username?: string;
+  email_verified?: boolean;
   role?: string;
   roles?: string[];
 };
@@ -42,12 +43,12 @@ export function resolveMystiraApiRole(profile: MystiraIdTokenClaims): 'admin' | 
   const roles = [profile.role, ...(Array.isArray(profile.roles) ? profile.roles : [])]
     .filter((role): role is string => typeof role === 'string')
     .map((role) => role.toLowerCase());
-  const email = profile.email || profile.preferred_username;
+  const verifiedEmail = profile.email_verified === true ? profile.email : undefined;
 
   if (
     roles.includes('admin') ||
     (profile.sub && configuredValues('MYSTIRA_ADMIN_SUBJECTS').has(profile.sub.toLowerCase())) ||
-    (email && configuredValues('MYSTIRA_ADMIN_EMAILS').has(email.toLowerCase()))
+    (verifiedEmail && configuredValues('MYSTIRA_ADMIN_EMAILS').has(verifiedEmail.toLowerCase()))
   ) {
     return 'admin';
   }

--- a/apps/api/src/services/mystira-auth.service.ts
+++ b/apps/api/src/services/mystira-auth.service.ts
@@ -30,11 +30,14 @@ export type ExtensionIdentity = {
 const DISCOVERY_CACHE_TTL_MS = 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
 
-function configuredValues(name: string): Set<string> {
+function configuredValues(
+  name: string,
+  normalize: (value: string) => string = (value) => value.toLowerCase()
+): Set<string> {
   return new Set(
     (process.env[name] || '')
       .split(',')
-      .map((value) => value.trim().toLowerCase())
+      .map((value) => normalize(value.trim()))
       .filter(Boolean)
   );
 }
@@ -47,7 +50,8 @@ export function resolveMystiraApiRole(profile: MystiraIdTokenClaims): 'admin' | 
 
   if (
     roles.includes('admin') ||
-    (profile.sub && configuredValues('MYSTIRA_ADMIN_SUBJECTS').has(profile.sub.toLowerCase())) ||
+    (profile.sub &&
+      configuredValues('MYSTIRA_ADMIN_SUBJECTS', (value) => value).has(profile.sub)) ||
     (verifiedEmail && configuredValues('MYSTIRA_ADMIN_EMAILS').has(verifiedEmail.toLowerCase()))
   ) {
     return 'admin';

--- a/apps/api/src/services/selector-report.service.ts
+++ b/apps/api/src/services/selector-report.service.ts
@@ -1,0 +1,50 @@
+import { type DataSource } from 'typeorm';
+import { AppDataSource } from '../config/database';
+import { SelectorReport } from '../db/entities/SelectorReport';
+
+export interface SelectorReportInput {
+  discovered: Record<string, string>;
+  userAgent: string;
+  timestamp: string;
+  extensionVersion?: string;
+}
+
+export class SelectorReportService {
+  constructor(
+    private readonly dataSource: DataSource = AppDataSource,
+    private readonly maximumReports = 100
+  ) {}
+
+  async save(input: SelectorReportInput): Promise<void> {
+    const repository = this.dataSource.getRepository(SelectorReport);
+    await repository.save(
+      repository.create({
+        discovered: input.discovered,
+        userAgent: input.userAgent,
+        extensionVersion: input.extensionVersion?.slice(0, 50),
+        observedAt: new Date(input.timestamp),
+      })
+    );
+    const expired = await repository.find({
+      select: { id: true },
+      order: { observedAt: 'DESC', id: 'DESC' },
+      skip: this.maximumReports,
+    });
+    if (expired.length > 0) await repository.delete(expired.map(({ id }) => id));
+  }
+
+  async list(): Promise<SelectorReportInput[]> {
+    const reports = await this.dataSource.getRepository(SelectorReport).find({
+      order: { observedAt: 'DESC', id: 'DESC' },
+      take: this.maximumReports,
+    });
+    return reports.map((report) => ({
+      discovered: report.discovered,
+      userAgent: report.userAgent,
+      timestamp: report.observedAt.toISOString(),
+      extensionVersion: report.extensionVersion,
+    }));
+  }
+}
+
+export const selectorReportService = new SelectorReportService();

--- a/apps/api/src/services/selector-report.service.ts
+++ b/apps/api/src/services/selector-report.service.ts
@@ -23,11 +23,15 @@ export class SelectorReportService {
         userAgent: input.userAgent,
         extensionVersion: input.extensionVersion?.slice(0, 50),
         observedAt: new Date(input.timestamp),
+        // Supply the server timestamp explicitly so SQLite fixtures retain
+        // millisecond receipt order instead of its second-precision default.
+        createdAt: new Date(),
       })
     );
     const expired = await repository.find({
       select: { id: true },
-      order: { observedAt: 'DESC', id: 'DESC' },
+      // Retention is based on server receipt, never the untrusted browser clock.
+      order: { createdAt: 'DESC', id: 'DESC' },
       skip: this.maximumReports,
     });
     if (expired.length > 0) await repository.delete(expired.map(({ id }) => id));

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -497,8 +497,22 @@ export class StorageService {
       url = `${url}?${config.sasToken}`;
     }
 
-    const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
-    if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
+    const headers: Record<string, string> = {
+      'x-ms-version': AZURE_API_VERSION,
+      'x-ms-date': new Date().toUTCString(),
+    };
+    if (!config.sasToken) {
+      headers.Authorization = config.accountKey
+        ? this.createAzureAuthHeader(
+            'DELETE',
+            config.accountName,
+            config.containerName,
+            key,
+            config.accountKey,
+            headers
+          )
+        : await this.getAzureBearerAuthorization();
+    }
     const response = await fetchWithTimeout(
       url,
       { method: 'DELETE', headers },

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -35,10 +35,10 @@ const AZURE_API_VERSION = '2023-11-03';
 const REQUEST_TIMEOUT_MS = 30000;
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
-export const AZURE_MANAGED_IDENTITY_TIMEOUT_MS = 10_000;
-export const AZURE_UPLOAD_REQUEST_TIMEOUT_MS = 15_000;
+export const AZURE_MANAGED_IDENTITY_TIMEOUT_MS = 5_000;
+export const AZURE_UPLOAD_REQUEST_TIMEOUT_MS = 8_000;
 export const AZURE_UPLOAD_MAX_RETRIES = 1;
-export const AZURE_UPLOAD_TOTAL_TIMEOUT_MS = 45_000;
+export const AZURE_UPLOAD_TOTAL_TIMEOUT_MS = 24_000;
 
 // =============================================================================
 // Types

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -35,6 +35,10 @@ const AZURE_API_VERSION = '2023-11-03';
 const REQUEST_TIMEOUT_MS = 30000;
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
+export const AZURE_MANAGED_IDENTITY_TIMEOUT_MS = 10_000;
+export const AZURE_UPLOAD_REQUEST_TIMEOUT_MS = 15_000;
+export const AZURE_UPLOAD_MAX_RETRIES = 1;
+export const AZURE_UPLOAD_TOTAL_TIMEOUT_MS = 45_000;
 
 // =============================================================================
 // Types
@@ -104,6 +108,10 @@ async function fetchWithTimeout(
   timeoutMs: number = REQUEST_TIMEOUT_MS
 ): Promise<Response> {
   const controller = new AbortController();
+  const parentSignal = options.signal;
+  const abortFromParent = () => controller.abort();
+  if (parentSignal?.aborted) controller.abort();
+  else parentSignal?.addEventListener('abort', abortFromParent, { once: true });
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
@@ -114,6 +122,7 @@ async function fetchWithTimeout(
     return response;
   } finally {
     clearTimeout(timeoutId);
+    parentSignal?.removeEventListener('abort', abortFromParent);
   }
 }
 
@@ -356,9 +365,11 @@ export class StorageService {
     const tokenUrl = new URL(endpoint);
     tokenUrl.searchParams.set('api-version', '2019-08-01');
     tokenUrl.searchParams.set('resource', 'https://storage.azure.com/');
-    const response = await fetchWithTimeout(tokenUrl.toString(), {
-      headers: { 'X-IDENTITY-HEADER': identityHeader },
-    });
+    const response = await fetchWithTimeout(
+      tokenUrl.toString(),
+      { headers: { 'X-IDENTITY-HEADER': identityHeader } },
+      AZURE_MANAGED_IDENTITY_TIMEOUT_MS
+    );
     if (!response.ok) {
       throw new Error(`Managed identity token request failed: ${response.status}`);
     }
@@ -398,39 +409,50 @@ export class StorageService {
       'x-ms-date': new Date().toUTCString(),
     };
 
-    // Add SAS token or account key authentication
-    let authUrl = url;
-    if (config.sasToken) {
-      authUrl = `${url}?${config.sasToken}`;
-    } else if (config.accountKey) {
-      // For production, use Azure SDK or proper HMAC signing
-      // This is a simplified version for POC
-      headers['Authorization'] = this.createAzureAuthHeader(
-        'PUT',
-        config.accountName,
-        config.containerName,
-        key,
-        config.accountKey,
-        headers
-      );
-    } else {
-      headers['Authorization'] = await this.getAzureBearerAuthorization();
-    }
+    const uploadController = new AbortController();
+    const totalTimeout = setTimeout(() => uploadController.abort(), AZURE_UPLOAD_TOTAL_TIMEOUT_MS);
 
-    const response = await withRetry(async () => {
-      const res = await fetchWithTimeout(authUrl, {
-        method: 'PUT',
-        headers,
-        body: buffer,
-      });
-
-      if (!res.ok) {
-        const errorText = await res.text();
-        throw new Error(`Azure Blob upload failed: ${res.status} - ${errorText}`);
+    try {
+      // Add SAS token or account key authentication
+      let authUrl = url;
+      if (config.sasToken) {
+        authUrl = `${url}?${config.sasToken}`;
+      } else if (config.accountKey) {
+        // For production, use Azure SDK or proper HMAC signing
+        // This is a simplified version for POC
+        headers['Authorization'] = this.createAzureAuthHeader(
+          'PUT',
+          config.accountName,
+          config.containerName,
+          key,
+          config.accountKey,
+          headers
+        );
+      } else {
+        headers['Authorization'] = await this.getAzureBearerAuthorization();
       }
 
-      return res;
-    });
+      await withRetry(async () => {
+        const res = await fetchWithTimeout(
+          authUrl,
+          {
+            method: 'PUT',
+            headers,
+            body: buffer,
+            signal: uploadController.signal,
+          },
+          AZURE_UPLOAD_REQUEST_TIMEOUT_MS
+        );
+
+        if (!res.ok) {
+          throw Object.assign(new Error(`Azure Blob upload failed: ${res.status}`), {
+            status: res.status,
+          });
+        }
+      }, AZURE_UPLOAD_MAX_RETRIES);
+    } finally {
+      clearTimeout(totalTimeout);
+    }
 
     logger.info(`[StorageService] Uploaded to Azure: ${key}`);
 

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -289,7 +289,11 @@ export class StorageService {
 
   private async deleteFromLocal(key: string): Promise<void> {
     const filePath = join(this.localBasePath, key);
-    await fs.unlink(filePath);
+    try {
+      await fs.unlink(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
   }
 
   private getLocalUrl(key: string): string {

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -39,6 +39,7 @@ export const AZURE_MANAGED_IDENTITY_TIMEOUT_MS = 5_000;
 export const AZURE_UPLOAD_REQUEST_TIMEOUT_MS = 8_000;
 export const AZURE_UPLOAD_MAX_RETRIES = 1;
 export const AZURE_UPLOAD_TOTAL_TIMEOUT_MS = 24_000;
+export const AZURE_DELETE_REQUEST_TIMEOUT_MS = 15_000;
 
 // =============================================================================
 // Types
@@ -498,7 +499,11 @@ export class StorageService {
 
     const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
     if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
-    const response = await fetch(url, { method: 'DELETE', headers });
+    const response = await fetchWithTimeout(
+      url,
+      { method: 'DELETE', headers },
+      AZURE_DELETE_REQUEST_TIMEOUT_MS
+    );
 
     if (!response.ok && response.status !== 404) {
       throw new Error(`Azure Blob delete failed: ${response.status}`);

--- a/apps/api/src/services/storage/storage.service.ts
+++ b/apps/api/src/services/storage/storage.service.ts
@@ -21,7 +21,11 @@ import { promises as fs } from 'fs';
 import { join, dirname } from 'path';
 import { createHmac } from 'crypto';
 import { logger } from '../../utils/logger.js';
-import { getStorageProvider, getAzureBlobStorageConfig, type StorageProvider } from '../../config/azure/index.js';
+import {
+  getStorageProvider,
+  getAzureBlobStorageConfig,
+  type StorageProvider,
+} from '../../config/azure/index.js';
 
 // =============================================================================
 // Constants
@@ -153,6 +157,7 @@ async function withRetry<T>(
 export class StorageService {
   private provider: StorageProvider;
   private localBasePath: string;
+  private azureAccessToken?: { value: string; expiresAt: number };
 
   constructor(config: StorageServiceConfig = {}) {
     this.provider = config.provider || getStorageProvider();
@@ -253,7 +258,11 @@ export class StorageService {
   // Local Storage Implementation
   // ===========================================================================
 
-  private async uploadToLocal(key: string, data: Buffer | string, options: UploadOptions): Promise<StorageFile> {
+  private async uploadToLocal(
+    key: string,
+    data: Buffer | string,
+    options: UploadOptions
+  ): Promise<StorageFile> {
     const filePath = join(this.localBasePath, key);
     const dirPath = dirname(filePath);
 
@@ -327,7 +336,48 @@ export class StorageService {
   // Azure Blob Storage Implementation
   // ===========================================================================
 
-  private async uploadToAzure(key: string, data: Buffer | string, options: UploadOptions): Promise<StorageFile> {
+  private async getAzureBearerAuthorization(): Promise<string> {
+    if (this.azureAccessToken && this.azureAccessToken.expiresAt > Date.now() + 300_000) {
+      return `Bearer ${this.azureAccessToken.value}`;
+    }
+
+    const endpoint = process.env.IDENTITY_ENDPOINT;
+    const identityHeader = process.env.IDENTITY_HEADER;
+    if (!endpoint || !identityHeader) {
+      throw new Error(
+        'Azure Blob Storage requires a SAS token, account key, or Container Apps managed identity'
+      );
+    }
+
+    const tokenUrl = new URL(endpoint);
+    tokenUrl.searchParams.set('api-version', '2019-08-01');
+    tokenUrl.searchParams.set('resource', 'https://storage.azure.com/');
+    const response = await fetchWithTimeout(tokenUrl.toString(), {
+      headers: { 'X-IDENTITY-HEADER': identityHeader },
+    });
+    if (!response.ok) {
+      throw new Error(`Managed identity token request failed: ${response.status}`);
+    }
+    const payload = (await response.json()) as {
+      access_token?: string;
+      expires_on?: string | number;
+    };
+    if (!payload.access_token) {
+      throw new Error('Managed identity token response did not contain an access token');
+    }
+    const parsedExpiry = Number(payload.expires_on);
+    this.azureAccessToken = {
+      value: payload.access_token,
+      expiresAt: Number.isFinite(parsedExpiry) ? parsedExpiry * 1000 : Date.now() + 3_600_000,
+    };
+    return `Bearer ${payload.access_token}`;
+  }
+
+  private async uploadToAzure(
+    key: string,
+    data: Buffer | string,
+    options: UploadOptions
+  ): Promise<StorageFile> {
     const config = getAzureBlobStorageConfig();
     if (!config) throw new Error('Azure Blob Storage not configured');
 
@@ -359,6 +409,8 @@ export class StorageService {
         config.accountKey,
         headers
       );
+    } else {
+      headers['Authorization'] = await this.getAzureBearerAuthorization();
     }
 
     const response = await withRetry(async () => {
@@ -397,11 +449,9 @@ export class StorageService {
       url = `${url}?${config.sasToken}`;
     }
 
-    const response = await fetch(url, {
-      headers: {
-        'x-ms-version': '2023-11-03',
-      },
-    });
+    const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
+    if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
+    const response = await fetch(url, { headers });
 
     if (!response.ok) {
       throw new Error(`Azure Blob download failed: ${response.status}`);
@@ -420,12 +470,9 @@ export class StorageService {
       url = `${url}?${config.sasToken}`;
     }
 
-    const response = await fetch(url, {
-      method: 'DELETE',
-      headers: {
-        'x-ms-version': '2023-11-03',
-      },
-    });
+    const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
+    if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
+    const response = await fetch(url, { method: 'DELETE', headers });
 
     if (!response.ok && response.status !== 404) {
       throw new Error(`Azure Blob delete failed: ${response.status}`);
@@ -455,12 +502,9 @@ export class StorageService {
       url = `${url}?${config.sasToken}`;
     }
 
-    const response = await fetch(url, {
-      method: 'HEAD',
-      headers: {
-        'x-ms-version': '2023-11-03',
-      },
-    });
+    const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
+    if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
+    const response = await fetch(url, { method: 'HEAD', headers });
 
     return response.ok;
   }
@@ -476,11 +520,9 @@ export class StorageService {
       url = `${url}&${config.sasToken}`;
     }
 
-    const response = await fetch(url, {
-      headers: {
-        'x-ms-version': '2023-11-03',
-      },
-    });
+    const headers: Record<string, string> = { 'x-ms-version': AZURE_API_VERSION };
+    if (!config.sasToken) headers.Authorization = await this.getAzureBearerAuthorization();
+    const response = await fetch(url, { headers });
 
     if (!response.ok) {
       throw new Error(`Azure Blob list failed: ${response.status}`);
@@ -525,7 +567,8 @@ export class StorageService {
       const lastModified = this.extractXmlElement(blobContent, 'Last-Modified');
 
       // Extract Content-Type if available
-      const contentType = this.extractXmlElement(blobContent, 'Content-Type') || 'application/octet-stream';
+      const contentType =
+        this.extractXmlElement(blobContent, 'Content-Type') || 'application/octet-stream';
 
       files.push({
         key: this.decodeXmlEntities(name),
@@ -588,9 +631,9 @@ export class StorageService {
   ): string {
     // Build canonicalized headers (x-ms-* headers, sorted alphabetically)
     const canonicalizedHeaders = Object.keys(headers)
-      .filter(key => key.toLowerCase().startsWith('x-ms-'))
+      .filter((key) => key.toLowerCase().startsWith('x-ms-'))
       .sort()
-      .map(key => `${key.toLowerCase()}:${headers[key].trim()}`)
+      .map((key) => `${key.toLowerCase()}:${headers[key].trim()}`)
       .join('\n');
 
     // Build canonicalized resource
@@ -602,24 +645,23 @@ export class StorageService {
     const contentType = headers['Content-Type'] || '';
 
     const stringToSign = [
-      method,                              // HTTP Verb
-      '',                                  // Content-Encoding
-      '',                                  // Content-Language
-      contentLength,                       // Content-Length
-      '',                                  // Content-MD5
-      contentType,                         // Content-Type
-      '',                                  // Date (empty when x-ms-date is used)
-      '',                                  // If-Modified-Since
-      '',                                  // If-Match
-      '',                                  // If-None-Match
-      '',                                  // If-Unmodified-Since
-      '',                                  // Range
-      canonicalizedHeaders,                // Canonicalized headers
-      canonicalizedResource,               // Canonicalized resource
+      method, // HTTP Verb
+      '', // Content-Encoding
+      '', // Content-Language
+      contentLength, // Content-Length
+      '', // Content-MD5
+      contentType, // Content-Type
+      '', // Date (empty when x-ms-date is used)
+      '', // If-Modified-Since
+      '', // If-Match
+      '', // If-None-Match
+      '', // If-Unmodified-Since
+      '', // Range
+      canonicalizedHeaders, // Canonicalized headers
+      canonicalizedResource, // Canonicalized resource
     ].join('\n');
 
     // Create HMAC-SHA256 signature
-    const { createHmac } = require('crypto');
     const decodedKey = Buffer.from(accountKey, 'base64');
     const signature = createHmac('sha256', decodedKey)
       .update(stringToSign, 'utf8')
@@ -644,7 +686,11 @@ export class StorageService {
     throw new Error(message);
   }
 
-  private async uploadToS3(key: string, data: Buffer | string, options: UploadOptions): Promise<StorageFile> {
+  private async uploadToS3(
+    key: string,
+    data: Buffer | string,
+    options: UploadOptions
+  ): Promise<StorageFile> {
     this.assertS3NotImplemented();
   }
 

--- a/apps/chrome-extension/e2e/persistence.spec.ts
+++ b/apps/chrome-extension/e2e/persistence.spec.ts
@@ -75,8 +75,13 @@ async function startApi(
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  await waitForReady(child);
-  return child;
+  try {
+    await waitForReady(child);
+    return child;
+  } catch (error) {
+    await stopApi(child);
+    throw error;
+  }
 }
 
 async function stopApi(child: ChildProcess | undefined): Promise<void> {

--- a/apps/chrome-extension/e2e/persistence.spec.ts
+++ b/apps/chrome-extension/e2e/persistence.spec.ts
@@ -1,0 +1,298 @@
+import { createHmac } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
+  chromium,
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+const extensionPath = resolve(import.meta.dirname, "..");
+const apiEntry = resolve(repositoryRoot, "apps/api/dist/index.js");
+const fixturePath = resolve(import.meta.dirname, "fixtures/whatsapp-web.html");
+const apiOrigin = "http://localhost:3001";
+const jwtSecret = "fixture-secret-that-is-at-least-thirty-two-characters";
+
+function base64url(value: string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function fixtureToken(id: string, email: string): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({
+      id,
+      email,
+      role: "user",
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+    }),
+  );
+  const signature = createHmac("sha256", jwtSecret)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+async function waitForReady(child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null)
+      throw new Error(`Fixture API exited with ${child.exitCode}`);
+    try {
+      const response = await fetch(`${apiOrigin}/ready`);
+      if (response.ok) return;
+    } catch {
+      // The process is still starting.
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+  }
+  throw new Error("Fixture API did not become ready");
+}
+
+async function startApi(
+  databasePath: string,
+  artifactRoot: string,
+): Promise<ChildProcess> {
+  const child = spawn(process.execPath, [apiEntry], {
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      PORT: "3001",
+      JWT_SECRET: jwtSecret,
+      DB_TYPE: "sqlite",
+      DATABASE_PATH: databasePath,
+      DB_SYNCHRONIZE: "true",
+      DB_MIGRATIONS_RUN: "false",
+      STORAGE_PROVIDER: "local",
+      UPLOAD_DIR: artifactRoot,
+      FRONTEND_URL: "https://convolens.neuralliquid.ai",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitForReady(child);
+  return child;
+}
+
+async function stopApi(child: ChildProcess | undefined): Promise<void> {
+  if (!child || child.exitCode !== null) return;
+  const exited = new Promise<void>((resolvePromise) =>
+    child.once("exit", () => resolvePromise()),
+  );
+  child.kill("SIGTERM");
+  await Promise.race([
+    exited,
+    new Promise<void>((resolvePromise) =>
+      setTimeout(() => {
+        if (child.exitCode === null) child.kill("SIGKILL");
+        resolvePromise();
+      }, 5_000),
+    ),
+  ]);
+}
+
+async function reviewLoadedMessages(page: Page): Promise<void> {
+  const toggle = page.locator("#ws-launcher-toggle");
+  if ((await toggle.getAttribute("aria-expanded")) !== "true")
+    await toggle.click();
+  await page.locator("#ws-extract-btn").click();
+  await expect(page.locator("#ws-status-text")).toHaveText(
+    "3 loaded messages ready for review.",
+  );
+}
+
+test("persists a reviewed extension capture across duplicate, restart, isolation, and deletion", async ({}, testInfo) => {
+  const root = await mkdtemp(
+    resolve(tmpdir(), "convolens-persistence-fixture-"),
+  );
+  const profileDir = resolve(root, "profile");
+  const databasePath = resolve(root, "intake.sqlite");
+  const artifactRoot = resolve(root, "artifacts");
+  const ownerToken = fixtureToken("fixture-owner-a", "owner-a@example.test");
+  const otherToken = fixtureToken("fixture-owner-b", "owner-b@example.test");
+  let api: ChildProcess | undefined;
+  let context: BrowserContext | undefined;
+  try {
+    api = await startApi(databasePath, artifactRoot);
+    const fixtureHtml = await readFile(fixturePath, "utf8");
+    context = await chromium.launchPersistentContext(profileDir, {
+      channel: "chromium",
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+        "--host-resolver-rules=MAP convolens.neuralliquid.ai ~NOTFOUND, MAP nl-prod-convolens-api.calmmoss-612abacc.southafricanorth.azurecontainerapps.io ~NOTFOUND, EXCLUDE localhost",
+      ],
+    });
+    await context.route("https://web.whatsapp.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: fixtureHtml,
+      }),
+    );
+    const worker =
+      context
+        .serviceWorkers()
+        .find((candidate) =>
+          candidate.url().startsWith("chrome-extension://"),
+        ) ||
+      (await context.waitForEvent("serviceworker", {
+        predicate: (candidate) =>
+          candidate.url().startsWith("chrome-extension://"),
+      }));
+    const extensionPage = await context.newPage();
+    await extensionPage.goto(
+      `chrome-extension://${new URL(worker.url()).host}/options/options.html`,
+    );
+    await extensionPage.evaluate(
+      async ({ endpoint, token }) => {
+        await chrome.storage.local.clear();
+        await chrome.storage.session.clear();
+        await chrome.storage.local.set({
+          authToken: token,
+          authTokenExpiresAt: Date.now() + 3_600_000,
+          user: { id: "fixture-owner-a", email: "owner-a@example.test" },
+          settings: { apiEndpoint: endpoint },
+        });
+      },
+      { endpoint: apiOrigin, token: ownerToken },
+    );
+    const page = await context.newPage();
+    await page.goto("https://web.whatsapp.com/");
+    await page.locator("#convolens-fab").waitFor();
+
+    await reviewLoadedMessages(page);
+    await page.locator("#ws-confirm-capture").click();
+    await expect(page.locator("#ws-status-text")).toContainText(
+      "received by ConvoLens",
+    );
+
+    const ownerHeaders = { Authorization: `Bearer ${ownerToken}` };
+    const listResponse = await context.request.get(
+      `${apiOrigin}/api/chat-export`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(listResponse.ok()).toBe(true);
+    const list = (await listResponse.json()) as {
+      data: {
+        conversations: Array<{
+          id: string;
+          messageCount: number;
+          rawArtifactStatus: string;
+        }>;
+      };
+    };
+    expect(list.data.conversations).toHaveLength(1);
+    expect(list.data.conversations[0]).toMatchObject({
+      messageCount: 3,
+      rawArtifactStatus: "stored",
+    });
+    const intakeId = list.data.conversations[0].id;
+
+    const detailResponse = await context.request.get(
+      `${apiOrigin}/api/chat-export/${intakeId}`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    const detail = (await detailResponse.json()) as {
+      data: {
+        conversation: {
+          messages: unknown[];
+          rawArtifact: { status: string; sha256: string; size: number };
+        };
+      };
+    };
+    expect(detail.data.conversation.messages).toHaveLength(3);
+    expect(detail.data.conversation.rawArtifact).toMatchObject({
+      status: "stored",
+    });
+    expect(detail.data.conversation.rawArtifact.sha256).toMatch(
+      /^[a-f0-9]{64}$/,
+    );
+    expect(detail.data.conversation.rawArtifact.size).toBeGreaterThan(0);
+
+    await reviewLoadedMessages(page);
+    await page.locator("#ws-confirm-capture").click();
+    await expect(page.locator("#ws-status-text")).toContainText(
+      "already exist in ConvoLens",
+    );
+    const duplicateList = await context.request.get(
+      `${apiOrigin}/api/chat-export`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(
+      ((await duplicateList.json()) as typeof list).data.conversations,
+    ).toHaveLength(1);
+
+    await stopApi(api);
+    api = await startApi(databasePath, artifactRoot);
+    const afterRestart = await context.request.get(
+      `${apiOrigin}/api/chat-export/${intakeId}`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(afterRestart.ok()).toBe(true);
+
+    const isolated = await context.request.get(
+      `${apiOrigin}/api/chat-export/${intakeId}`,
+      {
+        headers: { Authorization: `Bearer ${otherToken}` },
+      },
+    );
+    expect(isolated.status()).toBe(404);
+
+    const deleted = await context.request.delete(
+      `${apiOrigin}/api/chat-export/${intakeId}`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(deleted.ok()).toBe(true);
+    const finalList = await context.request.get(
+      `${apiOrigin}/api/chat-export`,
+      {
+        headers: ownerHeaders,
+      },
+    );
+    expect(
+      ((await finalList.json()) as typeof list).data.conversations,
+    ).toHaveLength(0);
+    const remainingArtifacts = await readdir(artifactRoot, {
+      recursive: true,
+    }).catch(() => []);
+    expect(
+      remainingArtifacts.filter((entry) => entry.endsWith(".json")),
+    ).toHaveLength(0);
+
+    await testInfo.attach("phase4-persistence-evidence.json", {
+      body: Buffer.from(
+        JSON.stringify({
+          intakeId,
+          messageCount: 3,
+          rawArtifactStatus: "stored",
+          duplicateCount: 1,
+          restartStatus: afterRestart.status(),
+          isolatedStatus: isolated.status(),
+          deletionStatus: deleted.status(),
+        }),
+      ),
+      contentType: "application/json",
+    });
+  } finally {
+    await context?.close().catch(() => undefined);
+    await stopApi(api);
+    await rm(root, { recursive: true, force: true }).catch(() => undefined);
+  }
+});

--- a/apps/chrome-extension/e2e/persistence.spec.ts
+++ b/apps/chrome-extension/e2e/persistence.spec.ts
@@ -108,6 +108,7 @@ async function reviewLoadedMessages(page: Page): Promise<void> {
   await page.locator("#ws-extract-btn").click();
   await expect(page.locator("#ws-status-text")).toHaveText(
     "3 loaded messages ready for review.",
+    { timeout: 15_000 },
   );
 }
 

--- a/apps/chrome-extension/e2e/playwright.persistence.config.ts
+++ b/apps/chrome-extension/e2e/playwright.persistence.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  testDir: import.meta.dirname,
+  testMatch: "persistence.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 2 * 60_000,
+  reporter: "line",
+  outputDir: resolve(
+    import.meta.dirname,
+    "../../../test-results/extension-persistence",
+  ),
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+});

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist",
     "test": "tsx --test tests/*.test.ts",
     "test:browser:fixtures": "npm run build && playwright test --config=e2e/playwright.fixture.config.ts",
+    "test:browser:persistence": "pnpm --filter @convolens/api build && npm run build && playwright test --config=e2e/playwright.persistence.config.ts",
     "auth:provision": "npm run build && tsx e2e/provision-auth.ts",
     "test:browser:auth": "npm run build && playwright test --config=e2e/playwright.auth.config.ts",
     "typecheck": "tsc --noEmit"

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -33,8 +33,9 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   assert.match(workflow, /@convolens\/chrome-extension test/);
   assert.match(
     workflow,
-    /jest --config=jest\.config\.js --runInBand src\/services\/__tests__\/conversation-intake\.service\.test\.ts/,
+    /jest --config=jest\.config\.js --runInBand[\s\S]*src\/services\/__tests__\/conversation-intake\.service\.test\.ts/,
   );
+  assert.match(workflow, /test:browser:persistence/);
   assert.match(workflow, /@convolens\/chrome-extension package/);
 });
 
@@ -249,7 +250,8 @@ test("rejects Unicode path overrides and malformed ZIP extra fields", () => {
   unicodePath.writeUInt16LE(0x7075, 0);
   unicodePath.writeUInt16LE(5, 2);
   assert.throws(
-    () => verifyExtraFields(unicodePath, 0, unicodePath.length, "manifest.json"),
+    () =>
+      verifyExtraFields(unicodePath, 0, unicodePath.length, "manifest.json"),
     /entry uses a filename override/,
   );
   assert.throws(
@@ -257,7 +259,8 @@ test("rejects Unicode path overrides and malformed ZIP extra fields", () => {
     /extra fields are malformed/,
   );
   assert.throws(
-    () => verifyExtraFields(timestamp, 0, timestamp.length - 1, "manifest.json"),
+    () =>
+      verifyExtraFields(timestamp, 0, timestamp.length - 1, "manifest.json"),
     /extra fields are malformed/,
   );
   assert.throws(

--- a/apps/web/src/app/dashboard/conversations/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/conversations/[id]/page.tsx
@@ -40,6 +40,11 @@ interface Conversation {
   reconciliationStatus?: "none" | "required";
   reconciliationCandidateIds?: string[];
   status: string;
+  rawArtifact?: {
+    status: "pending" | "stored" | "failed" | "not-recorded";
+    sha256?: string;
+    size?: number;
+  };
   receivedAt: string;
   messages: ConversationMessage[];
 }
@@ -187,6 +192,15 @@ export default function ConversationPage() {
                 {conversation.sourceKind === "extension"
                   ? "browser extension"
                   : "chat export"}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {conversation.rawArtifact?.status === "stored"
+                  ? "Raw source stored with integrity metadata"
+                  : conversation.rawArtifact?.status === "not-recorded"
+                    ? "Legacy intake · raw source was not recorded"
+                    : conversation.rawArtifact?.status === "failed"
+                      ? "Raw source storage failed"
+                      : "Raw source storage pending"}
               </p>
             </StyledCard>
             <StyledCard

--- a/apps/web/src/app/dashboard/conversations/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/conversations/[id]/page.tsx
@@ -41,7 +41,7 @@ interface Conversation {
   reconciliationCandidateIds?: string[];
   status: string;
   rawArtifact?: {
-    status: "pending" | "stored" | "failed" | "not-recorded";
+    status: "pending" | "stored" | "failed" | "not-recorded" | "deleting";
     sha256?: string;
     size?: number;
   };
@@ -196,11 +196,13 @@ export default function ConversationPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 {conversation.rawArtifact?.status === "stored"
                   ? "Raw source stored with integrity metadata"
-                  : conversation.rawArtifact?.status === "not-recorded"
-                    ? "Legacy intake · raw source was not recorded"
-                    : conversation.rawArtifact?.status === "failed"
-                      ? "Raw source storage failed"
-                      : "Raw source storage pending"}
+                  : conversation.rawArtifact?.status === "deleting"
+                    ? "Deletion in progress"
+                    : conversation.rawArtifact?.status === "not-recorded"
+                      ? "Legacy intake · raw source was not recorded"
+                      : conversation.rawArtifact?.status === "failed"
+                        ? "Raw source storage failed"
+                        : "Raw source storage pending"}
               </p>
             </StyledCard>
             <StyledCard

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -47,7 +47,12 @@ interface ConversationSummary {
   isGroup: boolean;
   participants: string[];
   status: string;
-  rawArtifactStatus: "pending" | "stored" | "failed" | "not-recorded";
+  rawArtifactStatus:
+    | "pending"
+    | "stored"
+    | "failed"
+    | "not-recorded"
+    | "deleting";
   messageCount: number;
   receivedAt: string;
 }
@@ -227,11 +232,13 @@ export default function DashboardPage() {
               <p className="mt-2 text-xs font-medium text-muted-foreground">
                 {conversation.rawArtifactStatus === "stored"
                   ? "Raw source stored"
-                  : conversation.rawArtifactStatus === "not-recorded"
-                    ? "Legacy intake · raw source not recorded"
-                    : conversation.rawArtifactStatus === "failed"
-                      ? "Raw source storage failed"
-                      : "Raw source storage pending"}
+                  : conversation.rawArtifactStatus === "deleting"
+                    ? "Deletion in progress"
+                    : conversation.rawArtifactStatus === "not-recorded"
+                      ? "Legacy intake · raw source not recorded"
+                      : conversation.rawArtifactStatus === "failed"
+                        ? "Raw source storage failed"
+                        : "Raw source storage pending"}
               </p>
             </StyledCard>
           ))

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -47,6 +47,7 @@ interface ConversationSummary {
   isGroup: boolean;
   participants: string[];
   status: string;
+  rawArtifactStatus: "pending" | "stored" | "failed" | "not-recorded";
   messageCount: number;
   receivedAt: string;
 }
@@ -222,6 +223,15 @@ export default function DashboardPage() {
               </p>
               <p className="mt-2 text-xs text-muted-foreground">
                 Received {new Date(conversation.receivedAt).toLocaleString()}
+              </p>
+              <p className="mt-2 text-xs font-medium text-muted-foreground">
+                {conversation.rawArtifactStatus === "stored"
+                  ? "Raw source stored"
+                  : conversation.rawArtifactStatus === "not-recorded"
+                    ? "Legacy intake · raw source not recorded"
+                    : conversation.rawArtifactStatus === "failed"
+                      ? "Raw source storage failed"
+                      : "Raw source storage pending"}
               </p>
             </StyledCard>
           ))

--- a/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
+++ b/docs/EXTENSION-PLAYWRIGHT-ACCEPTANCE.md
@@ -10,6 +10,12 @@ This suite proves browser injection, explicit review before send, request shape 
 
 CI installs the pinned Chromium build and runs this headed MV3 suite under `xvfb-run`. Fixture traces and screenshots contain synthetic data only.
 
+## Durable persistence fixture
+
+`pnpm --filter @convolens/chrome-extension test:browser:persistence` runs the real built API with a temporary SQLite database and local artifact store, then drives the production extension in bundled Chromium. It proves reviewed send, normalized-message and integrity-addressed raw-artifact persistence, deterministic duplicate handling, API-process restart durability, owner isolation, and authenticated deletion of both the database row and raw artifact.
+
+The fixture uses synthetic JWTs and WhatsApp content inside a temporary directory. It does not contact production and cannot replace the staffed authentic run.
+
 ## Dedicated operator profile
 
 Install Chromium once with `pnpm exec playwright install chromium`, then choose an absolute profile path outside the repository:

--- a/docs/HANDOFF-2026-07-31-PHASE4-PERSISTENCE-PLAYWRIGHT.md
+++ b/docs/HANDOFF-2026-07-31-PHASE4-PERSISTENCE-PLAYWRIGHT.md
@@ -1,0 +1,32 @@
+# Phase 4 persistence and Playwright handoff
+
+Date: 2026-07-31
+
+## Outcome
+
+This slice closes the repository implementation gaps found during the Phase 4/9 live audit:
+
+- extension and manual-upload intakes retain their first accepted raw source in the configured private artifact store alongside normalized PostgreSQL messages;
+- artifact keys are owner-scoped without exposing the Mystira user id, and the database records SHA-256, size, and storage status;
+- production Blob requests use the Container Apps managed identity already granted `Storage Blob Data Contributor` rather than a disabled shared key;
+- duplicate submissions retain the original immutable raw evidence instead of creating orphan artifacts;
+- authenticated deletion removes the raw artifact before deleting the owner-scoped database record;
+- legacy normalized-only rows are explicitly marked `not-recorded` rather than appearing indefinitely pending;
+- selector reports are bounded and persisted in PostgreSQL, while report reads and selector updates require an authenticated admin;
+- the dashboard and conversation detail expose raw-source persistence state;
+- a headed Playwright fixture runs the actual built API and production extension through send, raw/normalized persistence, duplicate submission, API restart, cross-owner denial, and deletion.
+
+## Commands
+
+```powershell
+pnpm --filter @convolens/api run test -- --runInBand --runTestsByPath src/services/__tests__/conversation-intake.service.test.ts src/services/__tests__/selector-report.service.test.ts src/services/__tests__/storage-managed-identity.test.ts src/db/migrations/__tests__/conversation-intake.migration.test.ts src/routes/__tests__/chat-export.routes.test.ts src/routes/__tests__/extension.routes.test.ts
+pnpm --filter @convolens/chrome-extension test:browser:persistence
+pnpm --filter @convolens/chrome-extension test:browser:fixtures
+pnpm run build
+```
+
+## Acceptance boundary
+
+This repository fixture is synthetic and credential-free. Until the merged code is deployed and the dedicated operator profile completes the staffed acceptance matrix, it does not prove production Blob persistence, authentic WhatsApp compatibility, production restart durability, or legitimate cross-user behavior.
+
+Phase 9 remains dependent on the unimplemented candidate-review and approval-gated idempotent Baton publication path represented by the open Phase 5/6 tasks. No Baton write, production deployment, or authentic WhatsApp send is performed by this slice.

--- a/docs/HANDOFF-2026-07-31-PHASE4-PERSISTENCE-PLAYWRIGHT.md
+++ b/docs/HANDOFF-2026-07-31-PHASE4-PERSISTENCE-PLAYWRIGHT.md
@@ -9,7 +9,7 @@ This slice closes the repository implementation gaps found during the Phase 4/9 
 - extension and manual-upload intakes retain their first accepted raw source in the configured private artifact store alongside normalized PostgreSQL messages;
 - artifact keys are owner-scoped without exposing the Mystira user id, and the database records SHA-256, size, and storage status;
 - production Blob requests use the Container Apps managed identity already granted `Storage Blob Data Contributor` rather than a disabled shared key;
-- duplicate submissions retain the original immutable raw evidence instead of creating orphan artifacts;
+- duplicate submissions use a database-conditional claim and lease so concurrent replicas retain one immutable raw artifact, while a crashed writer can be recovered safely;
 - authenticated deletion removes the raw artifact before deleting the owner-scoped database record;
 - legacy normalized-only rows are explicitly marked `not-recorded` rather than appearing indefinitely pending;
 - selector reports are bounded and persisted in PostgreSQL, while report reads and selector updates require an authenticated admin;
@@ -19,7 +19,7 @@ This slice closes the repository implementation gaps found during the Phase 4/9 
 ## Commands
 
 ```powershell
-pnpm --filter @convolens/api run test -- --runInBand --runTestsByPath src/services/__tests__/conversation-intake.service.test.ts src/services/__tests__/selector-report.service.test.ts src/services/__tests__/storage-managed-identity.test.ts src/db/migrations/__tests__/conversation-intake.migration.test.ts src/routes/__tests__/chat-export.routes.test.ts src/routes/__tests__/extension.routes.test.ts
+pnpm --filter @convolens/api test:ci -- src/services/__tests__/conversation-intake.service.test.ts src/services/__tests__/selector-report.service.test.ts src/services/__tests__/storage-managed-identity.test.ts src/db/migrations/__tests__/conversation-intake.migration.test.ts src/routes/__tests__/chat-export.routes.test.ts src/routes/__tests__/extension.routes.test.ts
 pnpm --filter @convolens/chrome-extension test:browser:persistence
 pnpm --filter @convolens/chrome-extension test:browser:fixtures
 pnpm run build

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -362,6 +362,10 @@ resource "azurerm_container_app" "api" {
         value = azurerm_storage_account.st.name
       }
       env {
+        name  = "AZURE_PROVIDER_ENABLED"
+        value = "true"
+      }
+      env {
         name  = "AZURE_STORAGE_CONTAINER"
         value = "chat-exports"
       }

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -314,6 +314,14 @@ resource "azurerm_container_app" "api" {
         value = var.mystira_identity_client_id
       }
       env {
+        name  = "MYSTIRA_ADMIN_EMAILS"
+        value = var.mystira_admin_emails
+      }
+      env {
+        name  = "MYSTIRA_ADMIN_SUBJECTS"
+        value = var.mystira_admin_subjects
+      }
+      env {
         name  = "DB_TYPE"
         value = var.enable_postgres ? "postgres" : "sqlite"
       }

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -133,6 +133,18 @@ variable "mystira_identity_scope" {
   default     = "openid profile email offline_access"
 }
 
+variable "mystira_admin_emails" {
+  type        = string
+  description = "Comma-separated verified Mystira email identities allowed to administer Convolens. Empty denies all Mystira admin access."
+  default     = ""
+}
+
+variable "mystira_admin_subjects" {
+  type        = string
+  description = "Comma-separated verified Mystira subject identifiers allowed to administer Convolens. Empty denies all subject-based admin access."
+  default     = ""
+}
+
 variable "admin_email" {
   type        = string
   description = "Email address that receives budget alerts. Empty disables budget alerts."


### PR DESCRIPTION
## Summary

- persist the first accepted extension/manual raw intake artifact with SHA-256, size, and visible status
- support private Azure Blob storage through the Container Apps managed identity and persist bounded selector diagnostics behind admin authorization
- add a repeatable Playwright fixture that runs the real API and MV3 extension and proves persistence, deduplication, restart survival, owner isolation, and authenticated deletion

## Validation

- focused API tests: 42 tests across 6 suites
- extension Node tests: 148 passed
- Playwright: 4 credential-free fixtures plus 1 real API/MV3 persistence fixture
- forced monorepo build: 8/8 packages; web generated 24 routes
- extension package: 13 entries verified
- formatting/diff checks passed
- full API no-emit typecheck remains blocked by unrelated pre-existing baseline errors; no errors were attributable to changed files

## Acceptance boundary

This PR is not deployment evidence and does not claim an authentic WhatsApp login or send. It does not yet implement the reviewed candidate-to-Baton publication path required for Phase 9; that remains the Phase 5/6 successor slice.