### PR TITLE
fix(intake): refresh tombstoned claim cleanup

### DIFF
--- a/apps/api/src/config/migrations.ts
+++ b/apps/api/src/config/migrations.ts
@@ -1,9 +1,11 @@
 import { CreateConversationIntake1753400000000 } from '../db/migrations/1753400000000-CreateConversationIntake';
 import { AddConversationFidelity1753660000000 } from '../db/migrations/1753660000000-AddConversationFidelity';
 import { AddIntakeArtifactsAndSelectorReports1754000000000 } from '../db/migrations/1754000000000-AddIntakeArtifactsAndSelectorReports';
+import { AddRawArtifactCleanupKeys1754100000000 } from '../db/migrations/1754100000000-AddRawArtifactCleanupKeys';
 
 export const CONVERSATION_MIGRATIONS = [
   CreateConversationIntake1753400000000,
   AddConversationFidelity1753660000000,
   AddIntakeArtifactsAndSelectorReports1754000000000,
+  AddRawArtifactCleanupKeys1754100000000,
 ];

--- a/apps/api/src/db/entities/ConversationIntake.ts
+++ b/apps/api/src/db/entities/ConversationIntake.ts
@@ -102,6 +102,9 @@ export class ConversationIntake {
   @Column({ type: 'varchar', length: 1000, nullable: true })
   rawArtifactKey?: string;
 
+  @Column({ type: 'simple-json', nullable: true })
+  rawArtifactCleanupKeys?: string[] | null;
+
   @Column({ type: 'varchar', length: 64, nullable: true })
   rawArtifactSha256?: string;
 

--- a/apps/api/src/db/migrations/1754100000000-AddRawArtifactCleanupKeys.ts
+++ b/apps/api/src/db/migrations/1754100000000-AddRawArtifactCleanupKeys.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddRawArtifactCleanupKeys1754100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'conversation_intakes',
+      new TableColumn({
+        name: 'rawArtifactCleanupKeys',
+        type: 'text',
+        isNullable: true,
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('conversation_intakes', 'rawArtifactCleanupKeys');
+  }
+}

--- a/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
+++ b/apps/api/src/db/migrations/__tests__/conversation-intake.migration.test.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import { CreateConversationIntake1753400000000 } from '../1753400000000-CreateConversationIntake';
 import { AddConversationFidelity1753660000000 } from '../1753660000000-AddConversationFidelity';
 import { AddIntakeArtifactsAndSelectorReports1754000000000 } from '../1754000000000-AddIntakeArtifactsAndSelectorReports';
+import { AddRawArtifactCleanupKeys1754100000000 } from '../1754100000000-AddRawArtifactCleanupKeys';
 import { CONVERSATION_MIGRATIONS } from '../../../config/migrations';
 
 describe('CreateConversationIntake migration', () => {
@@ -19,6 +20,7 @@ describe('CreateConversationIntake migration', () => {
         CreateConversationIntake1753400000000,
         AddConversationFidelity1753660000000,
         AddIntakeArtifactsAndSelectorReports1754000000000,
+        AddRawArtifactCleanupKeys1754100000000,
       ],
     });
     await dataSource.initialize();
@@ -34,6 +36,7 @@ describe('CreateConversationIntake migration', () => {
       CreateConversationIntake1753400000000,
       AddConversationFidelity1753660000000,
       AddIntakeArtifactsAndSelectorReports1754000000000,
+      AddRawArtifactCleanupKeys1754100000000,
     ]);
     const queryRunner = dataSource.createQueryRunner();
     const intakeTable = await queryRunner.getTable('conversation_intakes');
@@ -45,6 +48,7 @@ describe('CreateConversationIntake migration', () => {
     expect(messageTable).toBeDefined();
     expect(selectorReportTable).toBeDefined();
     expect(intakeTable?.findColumnByName('rawArtifactStatus')).toBeDefined();
+    expect(intakeTable?.findColumnByName('rawArtifactCleanupKeys')).toBeDefined();
     expect(
       intakeTable?.indices.some(
         (index) => index.name === 'UQ_conversation_intakes_user_content_hash' && index.isUnique

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -450,6 +450,34 @@ describe('ConversationIntakeService', () => {
     expect(deleteFile).toHaveBeenCalledTimes(2);
   });
 
+  it('reloads a claim won by another replica immediately before tombstoning', async () => {
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    const artifactService = new ConversationIntakeService(dataSource, {
+      deleteFile,
+    } as unknown as StorageService);
+    const saved = await artifactService.save(baseInput);
+    const repository = dataSource.getRepository(ConversationIntake);
+    const update = repository.update.bind(repository);
+    const racedKey = `raw-intakes/raced/${saved.conversation.id}/claim/artifact.json`;
+    jest.spyOn(repository, 'update').mockImplementationOnce(async (criteria, partialEntity) => {
+      await update(saved.conversation.id, {
+        rawArtifactKey: racedKey,
+        rawArtifactSha256: createHash('sha256').update('raced').digest('hex'),
+        rawArtifactSize: 5,
+        rawArtifactStatus: 'pending',
+        rawArtifactClaimId: '00000000-0000-4000-8000-000000000099',
+        rawArtifactClaimedAt: new Date(
+          Date.now() - AZURE_UPLOAD_TOTAL_TIMEOUT_MS - RAW_ARTIFACT_DELETE_GRACE_MS
+        ),
+      });
+      return update(criteria, partialEntity);
+    });
+
+    expect(await artifactService.deleteForUser(baseInput.userId, saved.conversation.id)).toBe(true);
+    expect(deleteFile).toHaveBeenCalledWith(racedKey);
+    expect(await repository.findOneBy({ id: saved.conversation.id })).toBeNull();
+  });
+
   it('deduplicates stable content even when connector IDs change', async () => {
     const first = await service.save(baseInput);
     const second = await service.save({

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -303,9 +303,10 @@ describe('ConversationIntakeService', () => {
       .fn()
       .mockRejectedValueOnce(new Error('storage unavailable'))
       .mockResolvedValueOnce(undefined);
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
     const artifactService = new ConversationIntakeService(dataSource, {
       uploadFile,
-      deleteFile: jest.fn().mockResolvedValue(undefined),
+      deleteFile,
     } as unknown as StorageService);
     const saved = await artifactService.save(baseInput);
     const artifact = { body: '{"retry":true}', contentType: 'application/json' as const };
@@ -329,6 +330,8 @@ describe('ConversationIntakeService', () => {
     expect(uploadFile).toHaveBeenCalledTimes(2);
     expect(retried.rawArtifactKey).not.toBe(failedKey);
     expect(uploadFile.mock.calls[1][0]).toBe(retried.rawArtifactKey);
+    expect(deleteFile).toHaveBeenCalledWith(failedKey);
+    expect(retried.rawArtifactCleanupKeys).toBeNull();
   });
 
   it('can retry deletion when the artifact is already absent after a database error', async () => {
@@ -450,7 +453,7 @@ describe('ConversationIntakeService', () => {
     expect(deleteFile).toHaveBeenCalledTimes(2);
   });
 
-  it('reloads a claim won by another replica immediately before tombstoning', async () => {
+  it('retries the tombstone CAS when another replica wins a claim first', async () => {
     const deleteFile = jest.fn().mockResolvedValue(undefined);
     const artifactService = new ConversationIntakeService(dataSource, {
       deleteFile,
@@ -458,10 +461,22 @@ describe('ConversationIntakeService', () => {
     const saved = await artifactService.save(baseInput);
     const repository = dataSource.getRepository(ConversationIntake);
     const update = repository.update.bind(repository);
+    const supersededKey = `raw-intakes/raced/${saved.conversation.id}/old/artifact.json`;
     const racedKey = `raw-intakes/raced/${saved.conversation.id}/claim/artifact.json`;
+    await update(saved.conversation.id, {
+      rawArtifactKey: supersededKey,
+      rawArtifactSha256: createHash('sha256').update('raced').digest('hex'),
+      rawArtifactSize: 5,
+      rawArtifactStatus: 'pending',
+      rawArtifactClaimId: '00000000-0000-4000-8000-000000000098',
+      rawArtifactClaimedAt: new Date(
+        Date.now() - AZURE_UPLOAD_TOTAL_TIMEOUT_MS - RAW_ARTIFACT_DELETE_GRACE_MS
+      ),
+    });
     jest.spyOn(repository, 'update').mockImplementationOnce(async (criteria, partialEntity) => {
       await update(saved.conversation.id, {
         rawArtifactKey: racedKey,
+        rawArtifactCleanupKeys: [supersededKey],
         rawArtifactSha256: createHash('sha256').update('raced').digest('hex'),
         rawArtifactSize: 5,
         rawArtifactStatus: 'pending',
@@ -474,7 +489,9 @@ describe('ConversationIntakeService', () => {
     });
 
     expect(await artifactService.deleteForUser(baseInput.userId, saved.conversation.id)).toBe(true);
+    expect(deleteFile).toHaveBeenCalledWith(supersededKey);
     expect(deleteFile).toHaveBeenCalledWith(racedKey);
+    expect(deleteFile).toHaveBeenCalledTimes(2);
     expect(await repository.findOneBy({ id: saved.conversation.id })).toBeNull();
   });
 

--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -303,7 +303,10 @@ describe('ConversationIntakeService', () => {
       .fn()
       .mockRejectedValueOnce(new Error('storage unavailable'))
       .mockResolvedValueOnce(undefined);
-    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    const deleteFile = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('cleanup unavailable'))
+      .mockResolvedValue(undefined);
     const artifactService = new ConversationIntakeService(dataSource, {
       uploadFile,
       deleteFile,
@@ -331,7 +334,15 @@ describe('ConversationIntakeService', () => {
     expect(retried.rawArtifactKey).not.toBe(failedKey);
     expect(uploadFile.mock.calls[1][0]).toBe(retried.rawArtifactKey);
     expect(deleteFile).toHaveBeenCalledWith(failedKey);
-    expect(retried.rawArtifactCleanupKeys).toBeNull();
+    expect(retried.rawArtifactCleanupKeys).toEqual([failedKey]);
+
+    const afterCleanupRecovery = await artifactService.ensureRawArtifact(
+      saved.conversation,
+      baseInput.userId,
+      artifact
+    );
+    expect(deleteFile).toHaveBeenCalledTimes(2);
+    expect(afterCleanupRecovery.rawArtifactCleanupKeys).toBeNull();
   });
 
   it('can retry deletion when the artifact is already absent after a database error', async () => {

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -469,7 +469,7 @@ export class ConversationIntakeService {
     // overwriting the artifact selected by a newer lease for the same payload.
     const key = `raw-intakes/${ownerScope}/${conversation.id}/${claimId}/${sha256}.${extension}`;
     const claimedAt = new Date();
-    let supersededKey: string | undefined;
+    let cleanupKeys = current.rawArtifactCleanupKeys || [];
     let claim = await repository.update(
       {
         id: conversation.id,
@@ -494,6 +494,10 @@ export class ConversationIntakeService {
       // A retry may resume the same first artifact after a failed write, but a
       // different duplicate payload must never replace its provenance.
       if (claimed.rawArtifactStatus === 'failed' && claimed.rawArtifactSha256 === sha256) {
+        const nextCleanupKeys = this.appendRawArtifactCleanupKey(
+          claimed.rawArtifactCleanupKeys,
+          claimed.rawArtifactKey
+        );
         claim = await repository.update(
           {
             id: conversation.id,
@@ -507,11 +511,14 @@ export class ConversationIntakeService {
             rawArtifactStatus: 'pending',
             rawArtifactClaimId: claimId,
             rawArtifactClaimedAt: claimedAt,
+            rawArtifactCleanupKeys: nextCleanupKeys,
             status: 'received',
             errorCode: null,
           }
         );
-        if (claim.affected === 1) supersededKey = claimed.rawArtifactKey;
+        if (claim.affected === 1) {
+          cleanupKeys = nextCleanupKeys;
+        }
       }
 
       const claimExpired =
@@ -519,6 +526,10 @@ export class ConversationIntakeService {
         (!claimed.rawArtifactClaimedAt ||
           claimed.rawArtifactClaimedAt.getTime() <= Date.now() - RAW_ARTIFACT_CLAIM_LEASE_MS);
       if (claim.affected !== 1 && claimExpired && claimed.rawArtifactSha256 === sha256) {
+        const nextCleanupKeys = this.appendRawArtifactCleanupKey(
+          claimed.rawArtifactCleanupKeys,
+          claimed.rawArtifactKey
+        );
         claim = await repository.update(
           {
             id: conversation.id,
@@ -531,11 +542,14 @@ export class ConversationIntakeService {
             rawArtifactSize: buffer.length,
             rawArtifactClaimId: claimId,
             rawArtifactClaimedAt: claimedAt,
+            rawArtifactCleanupKeys: nextCleanupKeys,
             status: 'received',
             errorCode: null,
           }
         );
-        if (claim.affected === 1) supersededKey = claimed.rawArtifactKey;
+        if (claim.affected === 1) {
+          cleanupKeys = nextCleanupKeys;
+        }
       }
 
       if (claim.affected !== 1) {
@@ -576,11 +590,18 @@ export class ConversationIntakeService {
         if (resolved) return resolved;
         return this.ensureRawArtifactLocked(conversation, userId, artifact);
       }
-      if (supersededKey && supersededKey !== key) {
-        // Cleanup is best-effort after the durable row points at the winning
-        // artifact; a cleanup outage must not turn a stored intake back into a
-        // failed one.
-        await this.storage.deleteFile(supersededKey).catch(() => undefined);
+      if (cleanupKeys.length > 0) {
+        // The ledger remains durable until every superseded object is gone.
+        // A cleanup outage must not turn a stored intake back into a failed one.
+        const cleaned = await this.deleteRawArtifactKeys(cleanupKeys);
+        if (cleaned) {
+          await repository
+            .update(
+              { id: conversation.id, rawArtifactStatus: 'stored', rawArtifactKey: key },
+              { rawArtifactCleanupKeys: null }
+            )
+            .catch(() => undefined);
+        }
       }
     } catch (error) {
       await repository.update(
@@ -621,6 +642,24 @@ export class ConversationIntakeService {
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
     throw new Error('Timed out waiting for the first raw artifact write');
+  }
+
+  private appendRawArtifactCleanupKey(
+    cleanupKeys: string[] | null | undefined,
+    key: string | null | undefined
+  ): string[] {
+    return Array.from(new Set([...(cleanupKeys || []), ...(key ? [key] : [])]));
+  }
+
+  private async deleteRawArtifactKeys(keys: string[]): Promise<boolean> {
+    try {
+      for (const key of Array.from(new Set(keys))) {
+        await this.storage.deleteFile(key);
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async updateDuplicate(
@@ -951,19 +990,35 @@ export class ConversationIntakeService {
 
   async deleteForUser(userId: string, id: string): Promise<boolean> {
     const repository = this.dataSource.getRepository(ConversationIntake);
-    const conversation = await repository.findOneBy({ id, userId });
-    if (!conversation) return false;
+    let conversation: ConversationIntake | null = null;
 
-    // Tombstone the claim before touching Blob storage. A concurrent writer's
-    // claim-conditional finalization then fails and that writer cleans up its
-    // own late upload; new retries cannot claim a deleting row.
-    const marked = await repository.update({ id, userId }, { rawArtifactStatus: 'deleting' });
-    if (marked.affected !== 1) return false;
-    const tombstoned = await repository.findOneBy({ id, userId });
-    if (!tombstoned) return false;
-    if (tombstoned.rawArtifactClaimId && tombstoned.rawArtifactClaimedAt) {
+    // Compare-and-swap the complete claim identity into a tombstone. If another
+    // replica changes the key/claim/status after our read, retry from its new
+    // snapshot so deletion never loses a superseded artifact key.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const candidate = await repository.findOneBy({ id, userId });
+      if (!candidate) return false;
+      const marked = await repository.update(
+        {
+          id,
+          userId,
+          rawArtifactStatus: candidate.rawArtifactStatus,
+          rawArtifactClaimId: candidate.rawArtifactClaimId || IsNull(),
+          rawArtifactKey: candidate.rawArtifactKey || IsNull(),
+        },
+        { rawArtifactStatus: 'deleting' }
+      );
+      if (marked.affected === 1) {
+        conversation = candidate;
+        break;
+      }
+    }
+    if (!conversation) {
+      throw new Error('Conversation artifact changed too often to start deletion safely');
+    }
+    if (conversation.rawArtifactClaimId && conversation.rawArtifactClaimedAt) {
       const cleanupSafeAt =
-        tombstoned.rawArtifactClaimedAt.getTime() +
+        conversation.rawArtifactClaimedAt.getTime() +
         AZURE_UPLOAD_TOTAL_TIMEOUT_MS +
         RAW_ARTIFACT_DELETE_GRACE_MS;
       const remainingUploadWindow = cleanupSafeAt - Date.now();
@@ -971,8 +1026,12 @@ export class ConversationIntakeService {
         await new Promise((resolve) => setTimeout(resolve, remainingUploadWindow));
       }
     }
-    if (tombstoned.rawArtifactKey) {
-      await this.storage.deleteFile(tombstoned.rawArtifactKey);
+    const artifactKeys = this.appendRawArtifactCleanupKey(
+      conversation.rawArtifactCleanupKeys,
+      conversation.rawArtifactKey
+    );
+    for (const artifactKey of artifactKeys) {
+      await this.storage.deleteFile(artifactKey);
     }
     const result = await repository.delete({ id, userId });
     return result.affected === 1;

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -959,9 +959,11 @@ export class ConversationIntakeService {
     // own late upload; new retries cannot claim a deleting row.
     const marked = await repository.update({ id, userId }, { rawArtifactStatus: 'deleting' });
     if (marked.affected !== 1) return false;
-    if (conversation.rawArtifactClaimId && conversation.rawArtifactClaimedAt) {
+    const tombstoned = await repository.findOneBy({ id, userId });
+    if (!tombstoned) return false;
+    if (tombstoned.rawArtifactClaimId && tombstoned.rawArtifactClaimedAt) {
       const cleanupSafeAt =
-        conversation.rawArtifactClaimedAt.getTime() +
+        tombstoned.rawArtifactClaimedAt.getTime() +
         AZURE_UPLOAD_TOTAL_TIMEOUT_MS +
         RAW_ARTIFACT_DELETE_GRACE_MS;
       const remainingUploadWindow = cleanupSafeAt - Date.now();
@@ -969,8 +971,8 @@ export class ConversationIntakeService {
         await new Promise((resolve) => setTimeout(resolve, remainingUploadWindow));
       }
     }
-    if (conversation.rawArtifactKey) {
-      await this.storage.deleteFile(conversation.rawArtifactKey);
+    if (tombstoned.rawArtifactKey) {
+      await this.storage.deleteFile(tombstoned.rawArtifactKey);
     }
     const result = await repository.delete({ id, userId });
     return result.affected === 1;

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -1,5 +1,12 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { In, IsNull, QueryFailedError, type DataSource, type EntityManager } from 'typeorm';
+import {
+  In,
+  IsNull,
+  QueryFailedError,
+  type DataSource,
+  type EntityManager,
+  type Repository,
+} from 'typeorm';
 import { AppDataSource } from '../config/database';
 import {
   ConversationIntake,
@@ -459,7 +466,7 @@ export class ConversationIntakeService {
     // Connector-generated ids and extraction timestamps may differ on a retry,
     // so replacing the artifact would create unowned blobs and weaken provenance.
     if (current.rawArtifactStatus === 'stored' && current.rawArtifactKey) {
-      return current;
+      return this.retryStoredRawArtifactCleanup(repository, current);
     }
 
     const ownerScope = createHash('sha256').update(userId).digest('hex').slice(0, 32);
@@ -489,7 +496,9 @@ export class ConversationIntakeService {
 
     if (claim.affected !== 1) {
       const claimed = await repository.findOneByOrFail({ id: conversation.id });
-      if (claimed.rawArtifactStatus === 'stored' && claimed.rawArtifactKey) return claimed;
+      if (claimed.rawArtifactStatus === 'stored' && claimed.rawArtifactKey) {
+        return this.retryStoredRawArtifactCleanup(repository, claimed);
+      }
 
       // A retry may resume the same first artifact after a failed write, but a
       // different duplicate payload must never replace its provenance.
@@ -660,6 +669,28 @@ export class ConversationIntakeService {
     } catch {
       return false;
     }
+  }
+
+  private async retryStoredRawArtifactCleanup(
+    repository: Repository<ConversationIntake>,
+    conversation: ConversationIntake
+  ): Promise<ConversationIntake> {
+    const cleanupKeys = conversation.rawArtifactCleanupKeys || [];
+    if (cleanupKeys.length === 0) return conversation;
+    const cleaned = await this.deleteRawArtifactKeys(cleanupKeys);
+    if (!cleaned) return conversation;
+    const cleared = await repository
+      .update(
+        {
+          id: conversation.id,
+          rawArtifactStatus: 'stored',
+          rawArtifactKey: conversation.rawArtifactKey,
+        },
+        { rawArtifactCleanupKeys: null }
+      )
+      .catch(() => undefined);
+    if (cleared?.affected === 1) conversation.rawArtifactCleanupKeys = null;
+    return conversation;
   }
 
   private async updateDuplicate(


### PR DESCRIPTION
## Summary
- reload the current claim metadata after atomically tombstoning deletion
- wait and clean the winning key even if another replica claimed between the initial read and tombstone
- add a deterministic regression for the exact race found after PR #159 merged

## Validation
- 52 focused auth/storage/intake tests pass
- API production build passes
- diff and formatting checks pass

## Release boundary
This is a release-blocking follow-up to merged PR #159. Production deployment remains paused until this PR has clean exact-head checks and review.