### PR TITLE
test: share WhatsApp auth readiness selectors

### DIFF
--- a/apps/chrome-extension/e2e/auth.spec.ts
+++ b/apps/chrome-extension/e2e/auth.spec.ts
@@ -6,6 +6,7 @@ import {
   type Page,
 } from "@playwright/test";
 import { isAbsolute, relative, resolve } from "node:path";
+import { authenticatedWhatsAppReady } from "./whatsapp-readiness";
 
 const enabled = process.env.CONVOLENS_AUTHENTIC_ACCEPTANCE === "1";
 const profileDir = process.env.CONVOLENS_PW_PROFILE_DIR;
@@ -61,9 +62,7 @@ test.describe("operator-held authentic extension acceptance", () => {
     try {
       const page = await context.newPage();
       await page.goto("https://web.whatsapp.com/");
-      const chatList = page
-        .locator('[data-testid="chat-list"], #pane-side')
-        .first();
+      const chatList = authenticatedWhatsAppReady(page);
       await chatList.waitFor();
       await page.locator("#convolens-fab").waitFor();
       await page.locator("#ws-launcher-toggle").click();
@@ -113,9 +112,7 @@ test.describe("operator-held authentic extension acceptance", () => {
       const extensionPage = await openExtensionControlPage(context);
       const page = await context.newPage();
       await page.goto("https://web.whatsapp.com/");
-      const chatList = page
-        .locator('[data-testid="chat-list"], #pane-side')
-        .first();
+      const chatList = authenticatedWhatsAppReady(page);
       await chatList.waitFor();
       const target = chatList.getByText(targetChat!, { exact: true });
       await expect(target).toHaveCount(1);

--- a/apps/chrome-extension/e2e/auth.spec.ts
+++ b/apps/chrome-extension/e2e/auth.spec.ts
@@ -6,7 +6,10 @@ import {
   type Page,
 } from "@playwright/test";
 import { isAbsolute, relative, resolve } from "node:path";
-import { authenticatedWhatsAppReady } from "./whatsapp-readiness";
+import {
+  authenticatedWhatsAppReady,
+  whatsappChatTarget,
+} from "./whatsapp-readiness";
 
 const enabled = process.env.CONVOLENS_AUTHENTIC_ACCEPTANCE === "1";
 const profileDir = process.env.CONVOLENS_PW_PROFILE_DIR;
@@ -114,7 +117,7 @@ test.describe("operator-held authentic extension acceptance", () => {
       await page.goto("https://web.whatsapp.com/");
       const chatList = authenticatedWhatsAppReady(page);
       await chatList.waitFor();
-      const target = chatList.getByText(targetChat!, { exact: true });
+      const target = whatsappChatTarget(page, targetChat!);
       await expect(target).toHaveCount(1);
       await expect(target).toBeVisible();
       await target.click();

--- a/apps/chrome-extension/e2e/provision-auth.ts
+++ b/apps/chrome-extension/e2e/provision-auth.ts
@@ -2,6 +2,7 @@ import { chromium } from "@playwright/test";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, relative, resolve } from "node:path";
+import { authenticatedWhatsAppReady } from "./whatsapp-readiness";
 
 const extensionRoot = resolve(import.meta.dirname, "..");
 const extensionPath = extensionRoot;
@@ -64,10 +65,9 @@ try {
     "Complete WhatsApp QR and ConvoLens/Mystira sign-in in the visible browser. No cookie or token values will be printed.",
   );
 
-  await whatsapp
-    .locator('[data-testid="chat-list"], #pane-side')
-    .first()
-    .waitFor({ timeout: 10 * 60_000 });
+  await authenticatedWhatsAppReady(whatsapp).waitFor({
+    timeout: 10 * 60_000,
+  });
 
   const deadline = Date.now() + 10 * 60_000;
   let authenticated = false;

--- a/apps/chrome-extension/e2e/whatsapp-readiness.ts
+++ b/apps/chrome-extension/e2e/whatsapp-readiness.ts
@@ -1,0 +1,8 @@
+import type { Locator, Page } from "@playwright/test";
+import { SELECTORS } from "../src/config";
+
+export function authenticatedWhatsAppReady(page: Page): Locator {
+  return page
+    .locator(`${SELECTORS.primary.chatList}, ${SELECTORS.fallback.chatList}`)
+    .first();
+}

--- a/apps/chrome-extension/e2e/whatsapp-readiness.ts
+++ b/apps/chrome-extension/e2e/whatsapp-readiness.ts
@@ -6,3 +6,15 @@ export function authenticatedWhatsAppReady(page: Page): Locator {
     .locator(`${SELECTORS.primary.chatList}, ${SELECTORS.fallback.chatList}`)
     .first();
 }
+
+export function whatsappChatTarget(page: Page, targetChat: string): Locator {
+  const containerTarget = page
+    .locator(
+      `${SELECTORS.primary.chatList}, #pane-side, [aria-label="Chat list"]`,
+    )
+    .getByText(targetChat, { exact: true });
+  const fallbackRowTarget = page
+    .locator('.copyable-area [role="listitem"]')
+    .getByText(targetChat, { exact: true });
+  return containerTarget.or(fallbackRowTarget);
+}

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -39,6 +39,19 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   assert.match(workflow, /@convolens\/chrome-extension package/);
 });
 
+test("shares production WhatsApp readiness selectors with authentic fixtures", () => {
+  const readiness = read("../e2e/whatsapp-readiness.ts");
+  const provisioner = read("../e2e/provision-auth.ts");
+  const acceptance = read("../e2e/auth.spec.ts");
+  assert.match(readiness, /import \{ SELECTORS \} from "\.\.\/src\/config"/);
+  assert.match(readiness, /SELECTORS\.primary\.chatList/);
+  assert.match(readiness, /SELECTORS\.fallback\.chatList/);
+  assert.match(provisioner, /authenticatedWhatsAppReady\(whatsapp\)/);
+  assert.match(acceptance, /authenticatedWhatsAppReady\(page\)/);
+  assert.doesNotMatch(provisioner, /data-testid=\\?"chat-list/);
+  assert.doesNotMatch(acceptance, /data-testid=\\?"chat-list/);
+});
+
 test("requires local ZIP sizes and CRC when no data descriptor is present", () => {
   const entry = {
     name: "manifest.json",

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -46,8 +46,11 @@ test("shares production WhatsApp readiness selectors with authentic fixtures", (
   assert.match(readiness, /import \{ SELECTORS \} from "\.\.\/src\/config"/);
   assert.match(readiness, /SELECTORS\.primary\.chatList/);
   assert.match(readiness, /SELECTORS\.fallback\.chatList/);
+  assert.match(readiness, /export function whatsappChatTarget/);
+  assert.match(readiness, /containerTarget\.or\(fallbackRowTarget\)/);
   assert.match(provisioner, /authenticatedWhatsAppReady\(whatsapp\)/);
   assert.match(acceptance, /authenticatedWhatsAppReady\(page\)/);
+  assert.match(acceptance, /whatsappChatTarget\(page, targetChat!\)/);
   assert.doesNotMatch(provisioner, /data-testid=\\?"chat-list/);
   assert.doesNotMatch(acceptance, /data-testid=\\?"chat-list/);
 });


### PR DESCRIPTION
## Outcome
- authentic Playwright provisioning and no-send acceptance now share the production WhatsApp readiness selectors
- removes duplicated stale chat-list/#pane-side selectors
- keeps retries off, traces/screenshots/videos off, and credentials only in the dedicated external profile

## Validation
- extension build/typecheck: pass
- extension unit/release evidence: 149/149
- staffed authentic retry: correctly remained blocked because no WhatsApp chat-list selector became visible within 10 minutes; no authentic acceptance claimed

## Scope
Test tooling only; no runtime or deployment change.