### PR TITLE
feat(extension): polish launcher position controls

### DIFF
--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -121,3 +121,31 @@ test("attributes browser console output without leaking credentials", async ({
   expect(serialized).not.toContain("fixture-owner-a-token");
   expect(serialized).not.toContain("fixture-only");
 });
+
+test("moves the launcher with explicit height and side controls", async ({
+  harness,
+}) => {
+  await openCapturePanel(harness.page);
+
+  const bottom = harness.page.locator('[data-launcher-preset="lower"]');
+  const left = harness.page.locator('[data-launcher-edge="left"]');
+  await expect(
+    harness.page.locator('[data-launcher-preset="middle"]'),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    harness.page.locator('[data-launcher-edge="right"]'),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await bottom.click();
+  await left.click();
+
+  await expect(bottom).toHaveAttribute("aria-pressed", "true");
+  await expect(left).toHaveAttribute("aria-pressed", "true");
+  await expect(harness.page.locator("#convolens-fab")).toHaveClass(
+    /ws-edge-left/,
+  );
+  await expect(harness.page.locator("#convolens-fab")).toHaveAttribute(
+    "data-preset",
+    "lower",
+  );
+});

--- a/apps/chrome-extension/src/content.css
+++ b/apps/chrome-extension/src/content.css
@@ -163,7 +163,8 @@
 
 .ws-launcher-header span,
 .ws-scope-copy,
-.ws-position-controls > span,
+.ws-position-heading span,
+.ws-position-field > span,
 .ws-legacy-attention span {
   color: var(--ws-text-muted);
   font-size: 12px;
@@ -511,35 +512,65 @@
 
 .ws-position-controls {
   display: grid;
-  gap: 7px;
+  gap: 11px;
   margin-top: 13px;
   padding-top: 11px;
   border-top: 1px solid var(--ws-border);
 }
 
-.ws-position-controls div {
+.ws-position-heading {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 5px;
+  gap: 2px;
 }
 
-.ws-position-controls div button,
+.ws-position-heading strong {
+  color: var(--ws-text);
+  font-size: 12px;
+}
+
+.ws-position-field {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.ws-position-field > span {
+  font-weight: 650;
+}
+
+.ws-position-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  padding: 3px;
+  border: 1px solid var(--ws-border);
+  border-radius: 10px;
+  background: var(--ws-surface-muted);
+}
+
+.ws-position-side-options {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.ws-position-options button,
 .ws-link-btn {
   min-height: 30px;
   padding: 5px 8px;
-  border: 1px solid var(--ws-border);
-  border-radius: 8px;
-  background: var(--ws-surface);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
   color: var(--ws-text);
   font-size: 11px;
   font-weight: 650;
   cursor: pointer;
 }
 
-.ws-position-controls div button[aria-pressed="true"] {
-  border-color: var(--ws-green);
-  background: #eaf8f1;
+.ws-position-options button[aria-pressed="true"] {
+  border-color: rgba(8, 122, 85, 0.35);
+  background: var(--ws-surface);
   color: #05603a;
+  box-shadow: 0 1px 3px rgba(15, 23, 20, 0.12);
 }
 
 .ws-link-btn {
@@ -584,7 +615,7 @@
   }
 
   .ws-status-success,
-  .ws-position-controls div button[aria-pressed="true"] {
+  .ws-position-options button[aria-pressed="true"] {
     background: #123d2d;
     color: #a6f4c5;
   }
@@ -643,7 +674,7 @@
   .ws-launcher-toggle,
   .ws-launcher-panel,
   .ws-capture-btn,
-  .ws-position-controls div button,
+  .ws-position-options button,
   .ws-legacy-attention {
     border: 2px solid currentColor;
     forced-color-adjust: auto;

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -449,13 +449,25 @@ async function injectUI(): Promise<void> {
         <button id="ws-open-settings" class="ws-link-btn" type="button">Open migration settings</button>
       </div>
       <div class="ws-position-controls" aria-label="Launcher position">
-        <span>Position</span>
-        <div role="group" aria-label="Vertical launcher position">
-          <button type="button" data-launcher-preset="upper">Top</button>
-          <button type="button" data-launcher-preset="middle">Middle</button>
-          <button type="button" data-launcher-preset="lower">Bottom</button>
+        <div class="ws-position-heading">
+          <strong>Launcher position</strong>
+          <span>Pin the button where it stays out of the way.</span>
         </div>
-        <button id="ws-launcher-side" class="ws-link-btn" type="button"></button>
+        <div class="ws-position-field">
+          <span id="ws-position-height-label">Height</span>
+          <div class="ws-position-options" role="group" aria-labelledby="ws-position-height-label">
+            <button type="button" data-launcher-preset="upper">Top</button>
+            <button type="button" data-launcher-preset="middle">Middle</button>
+            <button type="button" data-launcher-preset="lower">Bottom</button>
+          </div>
+        </div>
+        <div class="ws-position-field">
+          <span id="ws-position-side-label">Side</span>
+          <div class="ws-position-options ws-position-side-options" role="group" aria-labelledby="ws-position-side-label">
+            <button type="button" data-launcher-edge="left">Left</button>
+            <button type="button" data-launcher-edge="right">Right</button>
+          </div>
+        </div>
       </div>
     </section>
     <button id="ws-launcher-toggle" class="ws-launcher-toggle" type="button" aria-expanded="false" aria-controls="ws-launcher-panel" aria-label="Open ConvoLens capture panel. Drag to move.">
@@ -629,12 +641,16 @@ function setupLauncherInteraction(): void {
         });
       });
     });
-  document.getElementById("ws-launcher-side")?.addEventListener("click", () => {
-    void setLauncherPosition({
-      ...launcherPosition,
-      edge: launcherPosition.edge === "right" ? "left" : "right",
+  fab
+    .querySelectorAll<HTMLButtonElement>("[data-launcher-edge]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        void setLauncherPosition({
+          ...launcherPosition,
+          edge: button.dataset.launcherEdge as LauncherPosition["edge"],
+        });
+      });
     });
-  });
   fab.addEventListener("keydown", (event) => {
     if (event.key === "Escape") setLauncherExpanded(false, true);
   });
@@ -678,10 +694,14 @@ function applyLauncherPosition(): void {
         String(button.dataset.launcherPreset === launcherPosition.preset),
       );
     });
-  const side = document.getElementById("ws-launcher-side");
-  if (side) {
-    side.textContent = `Move to ${launcherPosition.edge === "right" ? "left" : "right"} edge`;
-  }
+  fab
+    .querySelectorAll<HTMLButtonElement>("[data-launcher-edge]")
+    .forEach((button) => {
+      button.setAttribute(
+        "aria-pressed",
+        String(button.dataset.launcherEdge === launcherPosition.edge),
+      );
+    });
 }
 
 function handleViewportResize(): void {

--- a/apps/chrome-extension/tests/phase4-launcher.test.ts
+++ b/apps/chrome-extension/tests/phase4-launcher.test.ts
@@ -65,6 +65,11 @@ test("renders a compact inward-opening launcher with explicit position controls"
   assert.match(contentSource, /data-launcher-preset="upper"/);
   assert.match(contentSource, /data-launcher-preset="middle"/);
   assert.match(contentSource, /data-launcher-preset="lower"/);
+  assert.match(contentSource, /data-launcher-edge="left"/);
+  assert.match(contentSource, /data-launcher-edge="right"/);
+  assert.match(contentSource, /aria-labelledby="ws-position-height-label"/);
+  assert.match(contentSource, /aria-labelledby="ws-position-side-label"/);
+  assert.doesNotMatch(contentSource, /Move to .* edge/);
   assert.match(contentSource, /setPointerCapture/);
   assert.match(contentSource, /resolveLauncherEdge/);
   assert.match(contentSource, /resolveLauncherPreset/);
@@ -80,6 +85,8 @@ test("renders a compact inward-opening launcher with explicit position controls"
   );
   assert.match(styles, /position: absolute/);
   assert.match(styles, /data-preset="lower"[\s\S]*bottom: 0/);
+  assert.match(styles, /\.ws-position-options \{/);
+  assert.match(styles, /\.ws-position-side-options \{/);
 });
 
 test("keeps operation, migration, and accessibility state inside the panel", () => {

--- a/docs/HANDOFF-2026-07-31-CANDIDATE-BATON.md
+++ b/docs/HANDOFF-2026-07-31-CANDIDATE-BATON.md
@@ -31,6 +31,7 @@ This slice implements the Phase 5/6 prerequisite for the serial go-live:
 - publication attempts, failures, retries, task ids, and links are persisted;
 - an admin-only retry endpoint is available in addition to the owner retry control;
 - deleting the source intake cascades its local candidates and attempt audit.
+- launcher placement now uses explicit, accessible Height and Side segmented controls with visible selected state instead of an ambiguous edge-action link.
 
 The canonical Baton API is configured as `https://baton-backend.up.railway.app`, with the Convolens project `d20d739a-89b0-4a48-8f9b-dcb0724c149d` as the editable default suggestion.
 
@@ -46,7 +47,7 @@ Validated locally:
 - focused candidate UI plus Mystira auth/session suite: 5/5;
 - headed Playwright persistence fixture: 1/1;
 - headed authenticated Playwright no-send fixture: 1/1, with the guarded send case skipped;
-- headed extension UI/console fixtures: 4/4;
+- headed extension UI/console fixtures: 5/5, including persisted launcher height/side interaction;
 - extension unit and release-evidence suite: 149/149;
 - monorepo build: 8/8;
 - production Terraform validation: passed.
@@ -59,4 +60,6 @@ PR #163 merged the test-only auth-fixture follow-up as `31a31d3fa79d9aa9cdb712c8
 
 Two initial staffed provisioning attempts used only the dedicated profile outside the repository and timed out because no WhatsApp chat-list readiness selector became visible. A later staffed retry succeeded, provisioned `C:\Users\smitj\AppData\Local\ConvoLens\Playwright\acceptance-profile`, and the headed authenticated no-send fixture passed against real WhatsApp and ConvoLens sessions. No cookies or tokens were printed or copied.
 
-Authentic send/persistence acceptance remains open. The guarded send case was skipped because no exact allowlisted test-chat name, verified WhatsApp chat JID, or one-intake confirmation phrase was supplied to the runner. Consequently no authentic conversation upload or Baton task is claimed; duplicate submission, session reload, production restart persistence, and one-task Baton replay remain operator-held.
+Authentic send/persistence acceptance remains open. On 2026-08-01 the operator supplied the exact one-intake confirmation and authorized any visible chat. The guarded runner selected a real chat, completed loaded-message review, and stopped before confirmation because the reviewed payload contained no stable `sourceConversationId`. A follow-up read-only redacted DOM-shape check found no `data-jid` or `data-chat-id` in either the active conversation or sidebar, and current message `data-id` values were opaque rather than WhatsApp JIDs. Scanning the first 20 visible chats found no supported stable identity. No authentic conversation upload or Baton task occurred.
+
+The remaining blocker is current WhatsApp compatibility for stable conversation identity. Do not weaken the guard or substitute a display label. Until a verified stable JID source is implemented and covered by fixtures, duplicate submission, session reload, production restart persistence, and one-task Baton replay remain operator-held.


### PR DESCRIPTION
## Summary
- replace the ambiguous edge-action link with explicit Height and Side segmented controls
- expose selected placement through accessible pressed states and preserve existing storage behavior
- add headed Playwright interaction coverage
- record the authentic WhatsApp stable-identity blocker without claiming an upload

## Validation
- pnpm --filter @convolens/chrome-extension test (149/149)
- pnpm --filter @convolens/chrome-extension typecheck
- pnpm --filter @convolens/chrome-extension test:browser:fixtures (5/5)
- Prettier check
- git diff --check

## Authentic acceptance boundary
The operator authorized one authentic intake, but the runner stopped before confirmation because current WhatsApp DOM exposed no stable JID in the active conversation or sidebar. No authentic upload or Baton task occurred.