### PR TITLE
ci: publish verified extension artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,19 @@ jobs:
 
       - name: Package and inspect extension
         run: pnpm --filter @convolens/chrome-extension package
+
+      - name: Write extension checksum
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: apps/chrome-extension
+        run: sha256sum convolens-extension.zip > convolens-extension.zip.sha256
+
+      - name: Upload current-main extension artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: convolens-extension-${{ github.sha }}
+          path: |
+            apps/chrome-extension/convolens-extension.zip
+            apps/chrome-extension/convolens-extension.zip.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -368,6 +368,7 @@ jobs:
       - name: Attach extension to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: >-
           gh release upload "$RELEASE_TAG"

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to validate'
+        description: "Environment to validate"
         required: true
         type: choice
         options:
@@ -17,7 +17,7 @@ on:
           - staging
           - prod
       skip_infra_check:
-        description: 'Skip infrastructure validation'
+        description: "Skip infrastructure validation"
         required: false
         type: boolean
         default: false
@@ -28,7 +28,7 @@ permissions:
   issues: write
 
 env:
-  ARM_USE_OIDC: 'true'
+  ARM_USE_OIDC: "true"
   ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
   ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
   ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -290,7 +290,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02f16a352d659b7a8b369e36afe6af41e57315 # v4.0.0
@@ -308,6 +308,23 @@ jobs:
 
       - name: Build applications
         run: pnpm run build
+
+      - name: Package and inspect extension
+        run: pnpm --filter @convolens/chrome-extension package
+
+      - name: Write extension checksum
+        working-directory: apps/chrome-extension
+        run: sha256sum convolens-extension.zip > convolens-extension.zip.sha256
+
+      - name: Upload validated extension artifact
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: convolens-extension-${{ github.sha }}
+          path: |
+            apps/chrome-extension/convolens-extension.zip
+            apps/chrome-extension/convolens-extension.zip.sha256
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Validate build outputs
         run: |
@@ -332,12 +349,40 @@ jobs:
           echo "✅ All build validations passed"
 
   # =============================================================================
+  # Publish validated browser extension assets
+  # =============================================================================
+  publish-extension-release:
+    name: Publish Extension Release Asset
+    runs-on: ubuntu-latest
+    needs: validate-application
+    if: github.event_name == 'release' && needs.validate-application.result == 'success'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download validated extension artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: convolens-extension-${{ github.sha }}
+
+      - name: Attach extension to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: >-
+          gh release upload "$RELEASE_TAG"
+          convolens-extension.zip
+          convolens-extension.zip.sha256
+          --clobber
+
+  # =============================================================================
   # Release Summary
   # =============================================================================
   release-summary:
     name: Release Summary
     runs-on: ubuntu-latest
-    needs: [validate-infrastructure, validate-application]
+    needs:
+      [validate-infrastructure, validate-application, publish-extension-release]
     if: always()
 
     steps:
@@ -349,9 +394,10 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Infrastructure | ${{ needs.validate-infrastructure.result == 'success' && '✅ Passed' || (needs.validate-infrastructure.result == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Application | ${{ needs.validate-application.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Extension asset | ${{ github.event_name != 'release' && '⏭️ Not a release' || (needs.publish-extension-release.result == 'success' && '✅ Published' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ needs.validate-infrastructure.result }}" == "success" ] && [ "${{ needs.validate-application.result }}" == "success" ]; then
+          if [ "${{ needs.validate-infrastructure.result }}" == "success" ] && [ "${{ needs.validate-application.result }}" == "success" ] && { [ "${{ github.event_name }}" != "release" ] || [ "${{ needs.publish-extension-release.result }}" == "success" ]; }; then
             echo "## ✅ Ready for Release" >> $GITHUB_STEP_SUMMARY
           else
             echo "## ❌ Not Ready for Release" >> $GITHUB_STEP_SUMMARY
@@ -359,7 +405,7 @@ jobs:
           fi
 
       - name: Fail if any check failed
-        if: needs.validate-infrastructure.result == 'failure' || needs.validate-application.result == 'failure'
+        if: needs.validate-infrastructure.result == 'failure' || needs.validate-application.result == 'failure' || needs.publish-extension-release.result == 'failure'
         run: |
           echo "Release validation failed!"
           exit 1

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -57,6 +57,7 @@ test("publishes only a validated extension ZIP and checksum to releases", () => 
   );
   assert.match(workflow, /permissions:\s*\n\s*contents: write/);
   assert.match(workflow, /actions\/download-artifact@/);
+  assert.match(workflow, /GH_REPO: \$\{\{ github\.repository \}\}/);
   assert.match(workflow, /gh release upload "\$RELEASE_TAG"/);
   assert.match(workflow, /convolens-extension\.zip\.sha256/);
 });

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -37,6 +37,28 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   );
   assert.match(workflow, /test:browser:persistence/);
   assert.match(workflow, /@convolens\/chrome-extension package/);
+  assert.match(workflow, /Upload current-main extension artifact/);
+  assert.match(
+    workflow,
+    /github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'/,
+  );
+  assert.match(workflow, /convolens-extension\.zip\.sha256/);
+  assert.match(workflow, /if-no-files-found: error/);
+});
+
+test("publishes only a validated extension ZIP and checksum to releases", () => {
+  const workflow = read("../../../.github/workflows/release-validation.yml");
+  assert.match(workflow, /@convolens\/chrome-extension package/);
+  assert.match(workflow, /sha256sum convolens-extension\.zip/);
+  assert.match(workflow, /name: Publish Extension Release Asset/);
+  assert.match(
+    workflow,
+    /github\.event_name == 'release' && needs\.validate-application\.result == 'success'/,
+  );
+  assert.match(workflow, /permissions:\s*\n\s*contents: write/);
+  assert.match(workflow, /actions\/download-artifact@/);
+  assert.match(workflow, /gh release upload "\$RELEASE_TAG"/);
+  assert.match(workflow, /convolens-extension\.zip\.sha256/);
 });
 
 test("shares production WhatsApp readiness selectors with authentic fixtures", () => {

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -72,14 +72,17 @@ The current integration is an operator-assisted Chrome extension path:
 
 1. Build the extension in `apps/chrome-extension`.
 2. Open `chrome://extensions`, enable Developer mode, and choose Load unpacked.
-3. Select the extension directory or its built output according to the extension
-   README.
+3. Select the extracted extension ZIP root (the directory containing
+   `manifest.json`) or the local built output according to the extension README.
 4. In ConvoLens, open Dashboard -> Import -> WhatsApp Web and complete the
    import flow.
 
 The extension targets the production API and dashboard through
-`apps/chrome-extension/src/config.ts`. There is no browser-store release or
-unattended WhatsApp ingestion service at present.
+`apps/chrome-extension/src/config.ts`. Successful `main` CI runs retain the
+verified extension ZIP and SHA-256 checksum as a 30-day Actions artifact.
+Created GitHub Releases attach the same validated ZIP and checksum. Chrome still
+requires extracting the ZIP and using **Load unpacked**; there is no signed CRX,
+browser-store release, or unattended WhatsApp ingestion service at present.
 
 ## Monitoring and diagnostics
 


### PR DESCRIPTION
## What changed

- retain the verified extension ZIP and SHA-256 checksum as a 30-day artifact on every successful `main` CI push
- package and retain the same verified assets during release validation
- attach the ZIP and checksum to a created GitHub Release only after application validation succeeds
- isolate `contents: write` permission to the release publishing job
- document the download and Load unpacked workflow

## Why

CI previously created and inspected `convolens-extension.zip` but discarded it when the runner finished. Release validation did not package or publish the extension, leaving operators to rebuild locally.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release-validation.yml`
- `pnpm --filter @convolens/chrome-extension test` (150/150)
- `pnpm --filter @convolens/chrome-extension package` (ZIP integrity verified)
- Prettier check
- `git diff --check`

## Operator impact

Chrome still requires extracting the ZIP and choosing **Load unpacked**. This does not create a signed CRX or Chrome Web Store release.
