### PR TITLE
Fix stable WhatsApp conversation identity

### DIFF
--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -102,6 +102,45 @@ test("invalidates a reviewed payload when the authenticated owner changes", asyn
   expect(harness.apiRequests).toHaveLength(0);
 });
 
+test("keeps confirmation unavailable without a verified conversation identity", async ({
+  harness,
+}) => {
+  await openCapturePanel(harness.page);
+  await harness.page.evaluate(() => {
+    (
+      window as typeof window & {
+        __convolensFixtureSetConversationIdentity: (jid?: string) => void;
+      }
+    ).__convolensFixtureSetConversationIdentity();
+  });
+
+  await harness.page.locator("#ws-extract-btn").click();
+  await expect(harness.page.locator("#ws-status-text")).toContainText(
+    "could not verify a stable WhatsApp conversation identity",
+  );
+  await expect(harness.page.locator("#ws-capture-review")).toBeHidden();
+  expect(harness.apiRequests).toHaveLength(0);
+});
+
+test("invalidates a reviewed payload when the verified chat identity changes", async ({
+  harness,
+}) => {
+  await reviewLoadedMessages(harness.page);
+  await harness.page.evaluate(() => {
+    (
+      window as typeof window & {
+        __convolensFixtureSetConversationIdentity: (jid: string) => void;
+      }
+    ).__convolensFixtureSetConversationIdentity("120363999999999999@g.us");
+  });
+
+  await expect(harness.page.locator("#ws-status-text")).toContainText(
+    "selected chat changed",
+  );
+  await expect(harness.page.locator("#ws-capture-review")).toBeHidden();
+  expect(harness.apiRequests).toHaveLength(0);
+});
+
 test("attributes browser console output without leaking credentials", async ({
   harness,
 }) => {

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -9,10 +9,7 @@
       <button type="button">Fixture Group</button>
     </aside>
     <main id="main" data-testid="conversation-panel-wrapper">
-      <header
-        data-testid="conversation-header"
-        data-chat-id="120363000000000000@g.us"
-      >
+      <header data-testid="conversation-header">
         <span data-testid="conversation-info-header-chat-title"
           >Fixture Group</span
         >
@@ -21,7 +18,6 @@
       <section data-testid="conversation-panel-body">
         <section
           data-testid="conversation-panel-messages"
-          data-jid="120363000000000000@g.us"
           aria-label="Synthetic messages"
         >
           <article
@@ -58,5 +54,26 @@
         </section>
       </section>
     </main>
+    <script>
+      (() => {
+        const header = document.querySelector(
+          '[data-testid="conversation-header"]',
+        );
+        const reactProperty = "__reactProps$convolensFixture";
+        window.__convolensFixtureSetConversationIdentity = (jid) => {
+          const id = jid ? { _serialized: jid } : {};
+          Object.defineProperty(header, reactProperty, {
+            configurable: true,
+            value: {
+              children: [{ props: { chat: { id, __x_id: id } } }],
+            },
+          });
+          header.appendChild(document.createComment("identity changed"));
+        };
+        window.__convolensFixtureSetConversationIdentity(
+          "120363000000000000@g.us",
+        );
+      })();
+    </script>
   </body>
 </html>

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {
@@ -33,6 +33,12 @@
   },
 
   "content_scripts": [
+    {
+      "matches": ["https://web.whatsapp.com/*"],
+      "js": ["dist/whatsapp-page-identity.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
     {
       "matches": ["https://web.whatsapp.com/*"],
       "js": ["dist/content.js"],

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -58,5 +58,5 @@
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
 
-  "minimum_chrome_version": "102"
+  "minimum_chrome_version": "111"
 }

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/popup/popup.js
+++ b/apps/chrome-extension/popup/popup.js
@@ -444,6 +444,11 @@ async function sendToWhatsApp(tabId, message) {
     });
     await chrome.scripting.executeScript({
       target: { tabId },
+      files: ["dist/whatsapp-page-identity.js"],
+      world: "MAIN",
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId },
       files: ["dist/content.js"],
     });
 

--- a/apps/chrome-extension/scripts/build-extension.mjs
+++ b/apps/chrome-extension/scripts/build-extension.mjs
@@ -17,6 +17,14 @@ await Promise.all([
     target: "chrome102",
   }),
   build({
+    entryPoints: ["./src/whatsapp-page-identity.ts"],
+    bundle: true,
+    outfile: "./dist/whatsapp-page-identity.js",
+    format: "iife",
+    platform: "browser",
+    target: "chrome102",
+  }),
+  build({
     entryPoints: ["./src/background.ts"],
     bundle: true,
     outfile: "./dist/background.js",

--- a/apps/chrome-extension/scripts/build-extension.mjs
+++ b/apps/chrome-extension/scripts/build-extension.mjs
@@ -14,7 +14,7 @@ await Promise.all([
     outfile: "./dist/content.js",
     format: "iife",
     platform: "browser",
-    target: "chrome102",
+    target: "chrome111",
   }),
   build({
     entryPoints: ["./src/whatsapp-page-identity.ts"],
@@ -22,7 +22,7 @@ await Promise.all([
     outfile: "./dist/whatsapp-page-identity.js",
     format: "iife",
     platform: "browser",
-    target: "chrome102",
+    target: "chrome111",
   }),
   build({
     entryPoints: ["./src/background.ts"],
@@ -30,7 +30,7 @@ await Promise.all([
     outfile: "./dist/background.js",
     format: "esm",
     platform: "browser",
-    target: "chrome102",
+    target: "chrome111",
   }),
   copyFile(resolve("src/content.css"), resolve("dist/content.css")),
 ]);

--- a/apps/chrome-extension/scripts/verify-package.mjs
+++ b/apps/chrome-extension/scripts/verify-package.mjs
@@ -11,6 +11,7 @@ const EXPECTED_ENTRIES = [
   "dist/background.js",
   "dist/content.css",
   "dist/content.js",
+  "dist/whatsapp-page-identity.js",
   "icons/icon-128.png",
   "icons/icon-16.png",
   "icons/icon-32.png",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -167,6 +167,9 @@ let authToken: string | null = null;
 let currentChatId: string | null = null;
 let chatObserver: MutationObserver | null = null;
 let isInitialized = false;
+let pageSourceConversationId: string | null = null;
+const WHATSAPP_IDENTITY_REQUEST_EVENT = "convolens:whatsapp-identity-request";
+const WHATSAPP_IDENTITY_RESPONSE_EVENT = "convolens:whatsapp-identity-response";
 interface ActiveCaptureOperation {
   operationId: string;
   chatIdentity: string;
@@ -1679,7 +1682,7 @@ function getLauncherAccessibleStatus(): string {
   return "Ready.";
 }
 
-function getCurrentChatIdentity(): string {
+function getDomConversationIdentity(): string | undefined {
   const messageList = findConversationRoot(
     document,
     SELECTORS.primary.messageList,
@@ -1692,7 +1695,7 @@ function getCurrentChatIdentity(): string {
         SELECTORS.fallback.messageContainer,
       )
     : [];
-  const stableId = extractStableWhatsAppConversationId([
+  return extractStableWhatsAppConversationId([
     messageList?.getAttribute("data-chat-id"),
     messageList?.getAttribute("data-jid"),
     messageList?.closest("[data-chat-id]")?.getAttribute("data-chat-id"),
@@ -1702,6 +1705,88 @@ function getCurrentChatIdentity(): string {
       .map((container) =>
         findMessageRecord(container as HTMLElement).getAttribute("data-id"),
       ),
+  ]);
+}
+
+function cancelCaptureForIdentityChange(): void {
+  const operation = activeCaptureOperation;
+  if (!operation || operation.state === "uploading") return;
+  if (guidedCaptureSession?.operationId === operation.operationId) {
+    teardownGuidedCaptureSession(operation.operationId);
+  }
+  activeCaptureOperation = null;
+  sendRuntimeLifecycleMessage({
+    action: "CANCEL_CAPTURE_OPERATION",
+    operationId: operation.operationId,
+    reason: "The selected chat changed. Nothing was sent.",
+  });
+}
+
+async function requestPageConversationIdentity(): Promise<string | undefined> {
+  const requestId = crypto.randomUUID();
+  return await new Promise((resolve) => {
+    const timeoutId = window.setTimeout(() => {
+      document.removeEventListener(
+        WHATSAPP_IDENTITY_RESPONSE_EVENT,
+        handleResponse,
+      );
+      resolve(undefined);
+    }, 500);
+    const handleResponse = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{
+          requestId?: unknown;
+          sourceConversationId?: unknown;
+        }>
+      ).detail;
+      if (detail?.requestId !== requestId) return;
+      window.clearTimeout(timeoutId);
+      document.removeEventListener(
+        WHATSAPP_IDENTITY_RESPONSE_EVENT,
+        handleResponse,
+      );
+      const identity =
+        typeof detail.sourceConversationId === "string"
+          ? extractStableWhatsAppConversationId([detail.sourceConversationId])
+          : undefined;
+      resolve(identity);
+    };
+    document.addEventListener(WHATSAPP_IDENTITY_RESPONSE_EVENT, handleResponse);
+    document.dispatchEvent(
+      new CustomEvent(WHATSAPP_IDENTITY_REQUEST_EVENT, {
+        detail: { requestId },
+      }),
+    );
+  });
+}
+
+async function resolveCurrentStableConversationIdentity(): Promise<
+  string | undefined
+> {
+  const pageIdentity = await requestPageConversationIdentity();
+  const identity = extractStableWhatsAppConversationId([
+    getDomConversationIdentity(),
+    pageIdentity,
+  ]);
+  pageSourceConversationId = identity || null;
+  return identity;
+}
+
+async function refreshPageConversationIdentity(): Promise<void> {
+  const identity = await resolveCurrentStableConversationIdentity();
+  const operation = activeCaptureOperation;
+  if (
+    operation?.chatIdentity.startsWith("whatsapp:") &&
+    identity !== operation.chatIdentity
+  ) {
+    cancelCaptureForIdentityChange();
+  }
+}
+
+function getCurrentChatIdentity(): string {
+  const stableId = extractStableWhatsAppConversationId([
+    getDomConversationIdentity(),
+    pageSourceConversationId,
   ]);
   if (stableId) return stableId;
 
@@ -2653,7 +2738,12 @@ async function collectCaptureOperation(
     throw new Error("Another capture operation is already active in this tab.");
   }
 
-  const chatIdentity = getCurrentChatIdentity();
+  const chatIdentity = await resolveCurrentStableConversationIdentity();
+  if (!chatIdentity) {
+    throw new Error(
+      "ConvoLens could not verify a stable WhatsApp conversation identity. Nothing was sent.",
+    );
+  }
   activeCaptureOperation = {
     operationId,
     chatIdentity,
@@ -2796,17 +2886,12 @@ async function extractCurrentChat(
   const participantRefs = new Map<string, string>();
   const totalMessages = messageContainers.length;
   const diagnostics = createExtractionDiagnostics(totalMessages);
-  const sourceConversationId = extractStableWhatsAppConversationId([
-    messageList.getAttribute("data-chat-id"),
-    messageList.getAttribute("data-jid"),
-    messageList.closest("[data-chat-id]")?.getAttribute("data-chat-id"),
-    messageList.closest("[data-jid]")?.getAttribute("data-jid"),
-    ...messageContainers
-      .slice(0, 20)
-      .map((container) =>
-        findMessageRecord(container as HTMLElement).getAttribute("data-id"),
-      ),
-  ]);
+  const sourceConversationId = await resolveCurrentStableConversationIdentity();
+  if (!sourceConversationId) {
+    throw new Error(
+      "ConvoLens could not verify a stable WhatsApp conversation identity. Nothing was sent.",
+    );
+  }
 
   for (let i = 0; i < messageContainers.length; i++) {
     // Update progress
@@ -3266,6 +3351,7 @@ function observeChatChanges(): void {
   }
 
   chatObserver = new MutationObserver(() => {
+    void refreshPageConversationIdentity();
     const header = querySelector(
       SELECTORS.primary.chatHeader,
       SELECTORS.fallback.chatHeader,
@@ -3282,15 +3368,7 @@ function observeChatChanges(): void {
           operation.chatIdentity !== newChatId &&
           operation.state !== "uploading"
         ) {
-          if (guidedCaptureSession?.operationId === operation.operationId) {
-            teardownGuidedCaptureSession(operation.operationId);
-          }
-          activeCaptureOperation = null;
-          sendRuntimeLifecycleMessage({
-            action: "CANCEL_CAPTURE_OPERATION",
-            operationId: operation.operationId,
-            reason: "The selected chat changed. Nothing was sent.",
-          });
+          cancelCaptureForIdentityChange();
         }
       }
     }

--- a/apps/chrome-extension/src/whatsapp-identity.ts
+++ b/apps/chrome-extension/src/whatsapp-identity.ts
@@ -65,12 +65,13 @@ export function combineSenderEvidence(input: SenderEvidenceInput): {
 export function extractStableWhatsAppConversationId(
   values: Array<string | null | undefined>,
 ): string | undefined {
+  const identities = new Set<string>();
   for (const value of values) {
     const jid = value
       ?.match(WHATSAPP_JID_PATTERN)?.[1]
       ?.toLowerCase()
       .replace(/@c\.us$/, "@s.whatsapp.net");
-    if (jid) return `whatsapp:${jid}`;
+    if (jid) identities.add(`whatsapp:${jid}`);
   }
-  return undefined;
+  return identities.size === 1 ? [...identities][0] : undefined;
 }

--- a/apps/chrome-extension/src/whatsapp-page-identity.ts
+++ b/apps/chrome-extension/src/whatsapp-page-identity.ts
@@ -121,4 +121,11 @@ export function installWhatsAppIdentityBridge(): () => void {
   };
 }
 
-if (typeof document !== "undefined") installWhatsAppIdentityBridge();
+if (typeof document !== "undefined") {
+  const bridgeDocument = document as Document & {
+    __convolensWhatsAppIdentityBridgeCleanup?: () => void;
+  };
+  bridgeDocument.__convolensWhatsAppIdentityBridgeCleanup?.();
+  bridgeDocument.__convolensWhatsAppIdentityBridgeCleanup =
+    installWhatsAppIdentityBridge();
+}

--- a/apps/chrome-extension/src/whatsapp-page-identity.ts
+++ b/apps/chrome-extension/src/whatsapp-page-identity.ts
@@ -1,0 +1,124 @@
+import { extractStableWhatsAppConversationId } from "./whatsapp-identity";
+
+export const WHATSAPP_IDENTITY_REQUEST_EVENT =
+  "convolens:whatsapp-identity-request";
+export const WHATSAPP_IDENTITY_RESPONSE_EVENT =
+  "convolens:whatsapp-identity-response";
+
+interface IdentityRequestDetail {
+  requestId?: unknown;
+}
+
+interface IdentityResponseDetail {
+  requestId: string;
+  sourceConversationId: string | null;
+}
+
+const ACTIVE_HEADER_SELECTORS = [
+  '[data-testid="conversation-header"]',
+  "#main header",
+  '[data-testid="conversation-info-header"]',
+];
+const MAX_VISITED_OBJECTS = 5_000;
+const MAX_DEPTH = 7;
+
+function readChatIdentity(chat: unknown): string | undefined {
+  if (!chat || typeof chat !== "object") return undefined;
+  const candidate = chat as {
+    id?: unknown;
+    __x_id?: unknown;
+  };
+  const values: unknown[] = [];
+  for (const value of [candidate.id, candidate.__x_id]) {
+    if (typeof value === "string") {
+      values.push(value);
+    } else if (value && typeof value === "object") {
+      const wid = value as { _serialized?: unknown };
+      if (typeof wid._serialized === "string") values.push(wid._serialized);
+    }
+  }
+  return extractStableWhatsAppConversationId(
+    values.filter((value): value is string => typeof value === "string"),
+  );
+}
+
+export function extractReactChatIdentity(
+  element: Element | null,
+): string | undefined {
+  if (!element) return undefined;
+  const roots = Object.getOwnPropertyNames(element)
+    .filter((key) => key.startsWith("__reactProps$"))
+    .map((key) => (element as unknown as Record<string, unknown>)[key])
+    .filter((value): value is object =>
+      Boolean(value && typeof value === "object"),
+    );
+  const stack = roots.map((value) => ({ value, depth: 0 }));
+  const seen = new WeakSet<object>();
+  const identities: string[] = [];
+  let visited = 0;
+
+  while (stack.length && visited < MAX_VISITED_OBJECTS) {
+    const current = stack.pop()!;
+    if (seen.has(current.value)) continue;
+    seen.add(current.value);
+    visited += 1;
+    if (current.depth >= MAX_DEPTH) continue;
+
+    for (const key of Reflect.ownKeys(current.value)) {
+      if (typeof key !== "string") continue;
+      const descriptor = Object.getOwnPropertyDescriptor(current.value, key);
+      if (!descriptor || !("value" in descriptor)) continue;
+      const value = descriptor.value;
+      if (key === "chat") {
+        const identity = readChatIdentity(value);
+        if (identity) identities.push(identity);
+        continue;
+      }
+      if (value && typeof value === "object") {
+        stack.push({ value, depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return extractStableWhatsAppConversationId(identities);
+}
+
+export function extractActiveWhatsAppConversationIdentity(
+  root: ParentNode = document,
+): string | undefined {
+  const identities = ACTIVE_HEADER_SELECTORS.map((selector) =>
+    extractReactChatIdentity(root.querySelector(selector)),
+  );
+  return extractStableWhatsAppConversationId(identities);
+}
+
+function dispatchIdentityResponse(detail: IdentityResponseDetail): void {
+  document.dispatchEvent(
+    new CustomEvent<IdentityResponseDetail>(WHATSAPP_IDENTITY_RESPONSE_EVENT, {
+      detail,
+    }),
+  );
+}
+
+export function installWhatsAppIdentityBridge(): () => void {
+  const handleRequest = (event: Event) => {
+    const requestId = (event as CustomEvent<IdentityRequestDetail>).detail
+      ?.requestId;
+    if (typeof requestId !== "string" || requestId.length > 128) return;
+    dispatchIdentityResponse({
+      requestId,
+      sourceConversationId: extractActiveWhatsAppConversationIdentity() || null,
+    });
+  };
+
+  document.addEventListener(WHATSAPP_IDENTITY_REQUEST_EVENT, handleRequest);
+
+  return () => {
+    document.removeEventListener(
+      WHATSAPP_IDENTITY_REQUEST_EVENT,
+      handleRequest,
+    );
+  };
+}
+
+if (typeof document !== "undefined") installWhatsAppIdentityBridge();

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -20,8 +20,14 @@ const read = (path: string) =>
 test("keeps release versions aligned and package inspection mandatory", () => {
   const manifest = JSON.parse(read("../manifest.json"));
   const packageJson = JSON.parse(read("../package.json"));
-  assert.equal(manifest.version, "1.0.20");
+  assert.equal(manifest.version, "1.0.21");
   assert.equal(packageJson.version, manifest.version);
+  assert.deepEqual(manifest.content_scripts[0], {
+    matches: ["https://web.whatsapp.com/*"],
+    js: ["dist/whatsapp-page-identity.js"],
+    run_at: "document_start",
+    world: "MAIN",
+  });
   assert.match(
     packageJson.scripts.package,
     /package-extension\.mjs && node scripts\/verify-package\.mjs$/,

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -54,11 +54,21 @@ test("self-heals a missing content-script receiver and retries the message", () 
   assert.ok(manifest.permissions.includes("scripting"));
   assert.match(popupSource, /chrome\.scripting\.insertCSS/);
   assert.match(popupSource, /chrome\.scripting\.executeScript/);
+  assert.equal(manifest.minimum_chrome_version, "111");
 
   const receiverError = popupSource.indexOf("Receiving end does not exist");
-  const injection = popupSource.indexOf("chrome.scripting.executeScript");
+  const bridgeInjection = popupSource.indexOf(
+    'files: ["dist/whatsapp-page-identity.js"]',
+  );
+  const mainWorld = popupSource.indexOf('world: "MAIN"', bridgeInjection);
+  const contentInjection = popupSource.indexOf(
+    'files: ["dist/content.js"]',
+    bridgeInjection,
+  );
   const retry = popupSource.lastIndexOf("chrome.tabs.sendMessage");
 
-  assert.ok(receiverError < injection);
-  assert.ok(injection < retry);
+  assert.ok(receiverError < bridgeInjection);
+  assert.ok(bridgeInjection < mainWorld);
+  assert.ok(mainWorld < contentInjection);
+  assert.ok(contentInjection < retry);
 });

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.20");
+  assert.equal(manifest.version, "1.0.21");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/apps/chrome-extension/tests/whatsapp-identity.test.ts
+++ b/apps/chrome-extension/tests/whatsapp-identity.test.ts
@@ -78,4 +78,11 @@ test("uses only a WhatsApp JID as stable conversation identity", () => {
     extractStableWhatsAppConversationId(["Team chat", "message_123"]),
     undefined,
   );
+  assert.equal(
+    extractStableWhatsAppConversationId([
+      "120363123456789@g.us",
+      "120363987654321@g.us",
+    ]),
+    undefined,
+  );
 });

--- a/apps/chrome-extension/tests/whatsapp-page-identity.test.ts
+++ b/apps/chrome-extension/tests/whatsapp-page-identity.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { extractReactChatIdentity } from "../src/whatsapp-page-identity";
+
+function reactBackedElement(value: unknown): Element {
+  const element = {} as Element;
+  Object.defineProperty(element, "__reactProps$fixture", { value });
+  return element;
+}
+
+test("reads only the active React chat model identity", () => {
+  const element = reactBackedElement({
+    children: [
+      {
+        props: {
+          chat: {
+            id: { _serialized: "120363000000000000@g.us" },
+            participants: [{ id: { _serialized: "27820000000@lid" } }],
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(
+    extractReactChatIdentity(element),
+    "whatsapp:120363000000000000@g.us",
+  );
+});
+
+test("fails closed when React chat models conflict or expose no JID", () => {
+  assert.equal(
+    extractReactChatIdentity(
+      reactBackedElement({
+        children: [
+          { props: { chat: { id: { _serialized: "111111111@g.us" } } } },
+          { props: { chat: { id: { _serialized: "222222222@g.us" } } } },
+        ],
+      }),
+    ),
+    undefined,
+  );
+  assert.equal(
+    extractReactChatIdentity(
+      reactBackedElement({ children: [{ props: { chat: { id: {} } } }] }),
+    ),
+    undefined,
+  );
+});

--- a/docs/HANDOFF-2026-08-01-EXTENSION-ARTIFACT-AND-AUTHENTIC-ACCEPTANCE.md
+++ b/docs/HANDOFF-2026-08-01-EXTENSION-ARTIFACT-AND-AUTHENTIC-ACCEPTANCE.md
@@ -2,6 +2,8 @@
 
 Date: 2026-08-01
 
+Current continuation: [WhatsApp stable conversation identity handoff](HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md). This file retains the artifact and predecessor acceptance evidence.
+
 ## Current stop point
 
 The implementation baseline before this documentation-only handoff is `d91ab0ea3b98d041991d9820be8705992f7eeb4b`, the squash merge of PR #167. The current extension version is `1.0.20`.

--- a/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
+++ b/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
@@ -15,12 +15,14 @@ The current WhatsApp DOM no longer exposes `data-jid` or `data-chat-id` for the 
 The shipped bridge:
 
 - runs as a manifest-declared `MAIN`-world content script at `document_start`;
+- requires Chrome 111 or newer, matching declarative `MAIN`-world support;
 - reads only the active header's React properties and only the active chat model's `id`/`__x_id` serialized value;
 - accepts only recognized WhatsApp JID domains and canonicalizes direct-chat `@c.us` identity;
 - rejects missing or conflicting candidates;
 - returns the JID to the isolated content script only through an ephemeral request/response event;
 - does not store the page object graph, cookies, tokens, chat labels, participants, or message content;
 - rechecks identity during collection and on chat DOM changes, invalidating an unconfirmed review when the verified identity changes or disappears.
+- restores the bridge in `MAIN` before the isolated content script during popup self-healing after an extension reload, replacing any prior bridge listener.
 
 This relies on a private WhatsApp React shape and may drift. Drift fails closed: confirmation remains unavailable and the status states that no data was sent.
 

--- a/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
+++ b/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
@@ -1,0 +1,56 @@
+# WhatsApp stable conversation identity handoff
+
+Date: 2026-08-01
+
+## Outcome
+
+The implementation portion of Baton task `afabf0bd-5a6b-4272-b37a-b4bfd5601227` is complete on branch `agent/stable-whatsapp-identity`. Extension version `1.0.21` restores a privacy-safe stable identity source for the current WhatsApp Web runtime while remaining fail-closed.
+
+Authentic intake acceptance is not complete. No conversation was uploaded, no production receipt or duplicate attempt exists, no deletion was performed, and no Baton candidate was published during this slice.
+
+## Verified runtime source
+
+The current WhatsApp DOM no longer exposes `data-jid` or `data-chat-id` for the active conversation. A headed, read-only inspection of the dedicated profile established that the active conversation header has React properties whose active `chat.id` and `chat.__x_id` values expose the WhatsApp JID. Participant and quoted-message identities exist elsewhere in the object graph and are deliberately ignored.
+
+The shipped bridge:
+
+- runs as a manifest-declared `MAIN`-world content script at `document_start`;
+- reads only the active header's React properties and only the active chat model's `id`/`__x_id` serialized value;
+- accepts only recognized WhatsApp JID domains and canonicalizes direct-chat `@c.us` identity;
+- rejects missing or conflicting candidates;
+- returns the JID to the isolated content script only through an ephemeral request/response event;
+- does not store the page object graph, cookies, tokens, chat labels, participants, or message content;
+- rechecks identity during collection and on chat DOM changes, invalidating an unconfirmed review when the verified identity changes or disappears.
+
+This relies on a private WhatsApp React shape and may drift. Drift fails closed: confirmation remains unavailable and the status states that no data was sent.
+
+## Evidence
+
+Credential-free validation passed:
+
+- extension unit/release suite: 152/152;
+- extension TypeScript: passed;
+- headed browser fixtures: 7/7, including current-DOM React identity, missing-identity refusal, and chat-change invalidation;
+- persistence fixture: 1/1 across duplicate, API restart, owner isolation, and deletion;
+- inspected production package: 14 expected ZIP payloads with matching sizes and CRCs;
+- `git diff --check`: passed.
+
+A final headed, read-only verification loaded the built extension into the dedicated profile and selected two visible chats. The bridge recognized a group `@g.us` identity, then a direct `@s.whatsapp.net` identity, and reported that the identity changed. The diagnostic emitted no JIDs, names, or messages and was removed after the run.
+
+The existing authenticated no-send fixture reached WhatsApp and loaded the extension, but the ConvoLens web token in the dedicated profile had expired, so the capture control correctly remained at **Sign in to capture**. This is an authentication readiness result, not intake acceptance.
+
+## Remaining staffed acceptance
+
+Continue only with the dedicated profile and fresh operator participation:
+
+1. Reauthenticate ConvoLens legitimately in the visible browser; do not export or expose the session.
+2. Obtain a fresh exact authorization for one intake. The 2026-08-01 authorization used by the predecessor run is not reusable.
+3. Run one zero-retry authentic intake and require the reviewed `sourceConversationId` to match the allowlisted target JID before confirmation.
+4. Only after a production receipt exists, verify deterministic duplicate handling, session reload, API restart durability, owner isolation, authenticated deletion of both row and raw artifact, candidate generation, and exactly one approved Baton publication.
+5. Record only opaque IDs, timestamps, build identity, and outcomes. Do not record cookies, tokens, chat content, participant names, message text, or the WhatsApp JID.
+
+Cloud deployment, Chrome Web Store publication, session export, and bypassing the stable-identity guard remain out of scope unless separately authorized.
+
+## Workspace
+
+The dirty primary checkout was preserved. Work was performed in `C:\tmp\convolens-stable-identity` from current `origin/main`.


### PR DESCRIPTION
## Summary

- add a main-world, request/response bridge that reads only the active WhatsApp React chat model JID
- fail closed on missing/conflicting identity and invalidate unconfirmed reviews when the verified chat changes
- update current-DOM fixtures, package verification, version 1.0.21, and the durable staffed-acceptance handoff

## Runtime evidence

A headed read-only check against the dedicated authenticated WhatsApp profile verified the built bridge on two visible chats:

- group identity recognized as `@g.us`
- direct identity recognized as `@s.whatsapp.net`
- identity changed across chat selection

No JIDs, names, messages, cookies, or tokens were logged. No capture was confirmed or uploaded. The ConvoLens web token in the profile is expired, so staffed intake acceptance remains explicitly pending fresh operator reauthentication and one-intake authorization.

## Validation

- `pnpm --dir apps/chrome-extension test` (152 passed)
- `pnpm --dir apps/chrome-extension typecheck`
- `pnpm --dir apps/chrome-extension test:browser:fixtures` (7 passed)
- `pnpm --dir apps/chrome-extension test:browser:persistence` (1 passed)
- `pnpm --dir apps/chrome-extension package` (14 expected ZIP payloads verified)
- `pnpm build` (8/8 packages)
- `git diff --cached --check`

## Boundary

This PR does not deploy, publish to the Chrome Web Store, export sessions, upload an authentic conversation, or claim production acceptance.
