### PR TITLE
Fix production intake advisory-lock encoding

### DIFF
--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -15,6 +15,7 @@ import {
   createConversationCompatibilityHash,
   createConversationContentHash,
   createConversationContentHashV2,
+  createPostgresCompatibilityAdvisoryLockKey,
   type ConversationIntakeInput,
 } from '../conversation-intake.service';
 import { AZURE_UPLOAD_TOTAL_TIMEOUT_MS, StorageService } from '../storage/storage.service';
@@ -104,6 +105,16 @@ describe('ConversationIntakeService', () => {
     expect(AZURE_UPLOAD_TOTAL_TIMEOUT_MS + RAW_ARTIFACT_DELETE_GRACE_MS + 15_000).toBeLessThan(
       60_000
     );
+  });
+
+  it('encodes compatibility advisory lock keys as PostgreSQL-safe deterministic text', () => {
+    const rawKey = ['owner-a', 'whatsapp', 'compatibility-hash'].join('\u0000');
+    const encoded = createPostgresCompatibilityAdvisoryLockKey(rawKey);
+
+    expect(encoded).toMatch(/^[a-f0-9]{64}$/);
+    expect(encoded).not.toContain('\u0000');
+    expect(createPostgresCompatibilityAdvisoryLockKey(rawKey)).toBe(encoded);
+    expect(createPostgresCompatibilityAdvisoryLockKey(`${rawKey}-other`)).not.toBe(encoded);
   });
 
   afterAll(async () => {

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -29,6 +29,10 @@ export const RAW_ARTIFACT_DELETE_GRACE_MS = 2_000;
 const compatibilityQueues = new Map<string, Promise<void>>();
 const rawArtifactQueues = new Map<string, Promise<void>>();
 
+export function createPostgresCompatibilityAdvisoryLockKey(key: string): string {
+  return createHash('sha256').update(key, 'utf8').digest('hex');
+}
+
 async function withLocalCompatibilityLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
   const previous = compatibilityQueues.get(key) || Promise.resolve();
   let release!: () => void;
@@ -822,7 +826,7 @@ export class ConversationIntakeService {
         this.dataSource.transaction(async (manager) => {
           if (manager.connection.options.type === 'postgres') {
             await manager.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
-              compatibilityLockKey,
+              createPostgresCompatibilityAdvisoryLockKey(compatibilityLockKey),
             ]);
           }
 

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -2,7 +2,7 @@
  * ConvoLens Chrome Extension - Background Service Worker (Production)
  *
  * Handles all background operations for the extension:
- * - API communication with retry logic
+ * - API communication with one attempt per explicit confirmation
  * - Authentication state management
  * - Explicit retry-required responses without persisting new raw captures
  * - Settings management
@@ -1459,11 +1459,11 @@ async function sendChatData(
 async function fetchWithRetry(
   url: string,
   options: RequestInit,
-  maxRetries: number = 2,
+  maxAttempts: number = 1,
 ): Promise<any> {
   let lastError: Error | null = null;
 
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const controller = new AbortController();
     let didTimeout = false;
     const timeoutId = setTimeout(() => {
@@ -1532,7 +1532,7 @@ async function fetchWithRetry(
         throw normalizedError;
       }
 
-      if (attempt < maxRetries - 1) {
+      if (attempt < maxAttempts - 1) {
         const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }

--- a/apps/chrome-extension/tests/phase1-capture-safety.test.ts
+++ b/apps/chrome-extension/tests/phase1-capture-safety.test.ts
@@ -51,6 +51,15 @@ test("does not persist or automatically transmit new or legacy raw captures", ()
   assert.ok(!manifest.permissions.includes("alarms"));
 });
 
+test("uses one network attempt for each explicitly confirmed capture", () => {
+  assert.match(
+    backgroundSource,
+    /async function fetchWithRetry\([\s\S]*maxAttempts: number = 1/,
+  );
+  assert.match(backgroundSource, /attempt < maxAttempts/);
+  assert.doesNotMatch(backgroundSource, /maxRetries: number = [2-9]/);
+});
+
 test("offers export or confirmed deletion for unowned legacy entries", () => {
   assert.match(optionsHtml, /Export Local Queue/);
   assert.match(optionsHtml, /Delete Local Queue/);

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -20,7 +20,7 @@ const read = (path: string) =>
 test("keeps release versions aligned and package inspection mandatory", () => {
   const manifest = JSON.parse(read("../manifest.json"));
   const packageJson = JSON.parse(read("../package.json"));
-  assert.equal(manifest.version, "1.0.21");
+  assert.equal(manifest.version, "1.0.22");
   assert.equal(packageJson.version, manifest.version);
   assert.deepEqual(manifest.content_scripts[0], {
     matches: ["https://web.whatsapp.com/*"],

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.21");
+  assert.equal(manifest.version, "1.0.22");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {

--- a/docs/HANDOFF-2026-08-01-AUTHENTIC-INTAKE-POSTGRES-BLOCKER.md
+++ b/docs/HANDOFF-2026-08-01-AUTHENTIC-INTAKE-POSTGRES-BLOCKER.md
@@ -1,0 +1,50 @@
+# Authentic intake PostgreSQL blocker handoff
+
+Date: 2026-08-01
+
+## Outcome
+
+The operator legitimately reauthenticated the dedicated external profile and the read-only authentic readiness test passed against extension `1.0.21`. The operator then supplied the fresh exact phrase `I authorize one ConvoLens intake` and authorized any visible chat.
+
+The guarded runner selected one chat ephemerally, established and rechecked its stable WhatsApp JID, reviewed 11 loaded messages, and clicked confirmation exactly once. It did not log the chat label, JID, participants, or message content.
+
+No intake was persisted. Production returned an error and no receipt exists, so duplicate, restart, isolation, deletion, candidate, and Baton-publication acceptance remain unstarted.
+
+## Production evidence
+
+Azure Container App `nl-prod-convolens-api` was running and ready on revision `nl-prod-convolens-api--0000042`. Redacted logs showed one logical upload correlation at `2026-08-01T20:02:12Z`. The extension's network helper issued two HTTP attempts under that correlation. Both reached the API and both failed before persistence with PostgreSQL SQLSTATE `22021`:
+
+```text
+invalid byte sequence for encoding "UTF8": 0x00
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+```
+
+The failure occurred when the NUL-delimited local compatibility-lock key was passed as a PostgreSQL text parameter. No production receipt, raw artifact, duplicate result, or candidate was created. The one-intake authorization is exhausted; do not retry it.
+
+## Bounded fix
+
+The hotfix:
+
+- retains the NUL-delimited key for collision-safe in-process queueing;
+- SHA-256 encodes that key to deterministic 64-character hexadecimal text before the PostgreSQL advisory-lock query;
+- adds a regression proving the database key is deterministic and contains no NUL;
+- changes the extension network helper to one attempt per explicit confirmation;
+- bumps the extension to `1.0.22` and updates release-version assertions.
+
+Credential-free validation passed:
+
+- focused conversation-intake suite: 49/49;
+- extension unit/release suite: 153/153;
+- headed browser fixtures: 7/7;
+- full workspace build: 8/8 packages;
+- inspected extension package: 14 expected ZIP payloads with matching sizes and CRCs.
+
+## Next gates
+
+1. Review and merge the hotfix only after exact-head CI and thread-aware review pass.
+2. Deploy the exact merge commit through the governed production workflow and verify build identity, readiness, and the PostgreSQL fix in that revision.
+3. Reprovision the dedicated profile with the exact deployed extension build.
+4. Obtain a new exact one-intake authorization; the authorization recorded here cannot be reused.
+5. Run one single-attempt authentic intake. Only after a receipt exists may the remaining duplicate, restart, isolation, deletion, candidate-review, and exactly-one Baton-publication gates proceed under their own authority boundaries.
+
+Do not record cookies, tokens, chat content, participant names, message text, the chat label, or the WhatsApp JID. Production restart, deletion, and Baton publication remain separate external-effect gates.

--- a/docs/HANDOFF-2026-08-01-AUTHENTIC-INTAKE-POSTGRES-BLOCKER.md
+++ b/docs/HANDOFF-2026-08-01-AUTHENTIC-INTAKE-POSTGRES-BLOCKER.md
@@ -23,7 +23,7 @@ The failure occurred when the NUL-delimited local compatibility-lock key was pas
 
 ## Bounded fix
 
-The hotfix:
+Draft PR `#170` carries the hotfix from branch `agent/postgres-advisory-lock-key` (initial implementation commit `56e4997aacf046463fd1b5a690b106840f4965ef`). The hotfix:
 
 - retains the NUL-delimited key for collision-safe in-process queueing;
 - SHA-256 encodes that key to deterministic 64-character hexadecimal text before the PostgreSQL advisory-lock query;

--- a/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
+++ b/docs/HANDOFF-2026-08-01-WHATSAPP-STABLE-IDENTITY.md
@@ -2,6 +2,8 @@
 
 Date: 2026-08-01
 
+Current continuation: [Authentic intake PostgreSQL blocker](HANDOFF-2026-08-01-AUTHENTIC-INTAKE-POSTGRES-BLOCKER.md).
+
 ## Outcome
 
 The implementation portion of Baton task `afabf0bd-5a6b-4272-b37a-b4bfd5601227` is complete on branch `agent/stable-whatsapp-identity`. Extension version `1.0.21` restores a privacy-safe stable identity source for the current WhatsApp Web runtime while remaining fail-closed.


### PR DESCRIPTION
## Summary

- encode the NUL-delimited compatibility key as deterministic SHA-256 hex before passing it to PostgreSQL `hashtextextended`
- limit each explicitly confirmed extension capture to one network attempt
- bump the extension to 1.0.22 and record the fail-closed authentic acceptance evidence

## Root cause

The authorized authentic capture reached production, but PostgreSQL rejected the NUL-delimited advisory-lock text parameter with SQLSTATE `22021`. The extension then made its configured second HTTP attempt under the same logical correlation; it failed identically. No intake receipt or persisted artifact was created.

## Validation

- focused conversation-intake suite: 49/49
- extension unit/release suite: 153/153
- headed browser fixtures: 7/7
- workspace build: 8/8 packages
- extension package inspection: 14 expected ZIP payloads with matching sizes and CRCs
- `git diff --check`

## Boundaries

This PR does not deploy, retry the authentic capture, restart production, delete data, or publish a Baton candidate. A fresh exact one-intake authorization is required after the exact merged build is deployed and verified.