### PR TITLE
ci: publish versioned extension releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
     needs: validate
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: extension-release-${{ github.repository }}
+      cancel-in-progress: false
     permissions:
       contents: write
 
@@ -127,7 +130,12 @@ jobs:
             unzip -qq convolens-extension.zip -d "$RUNNER_TEMP/current"
             gh release download "$TAG" \
               --pattern convolens-extension.zip \
+              --pattern convolens-extension.zip.sha256 \
               --dir "$RUNNER_TEMP/assets"
+            (
+              cd "$RUNNER_TEMP/assets"
+              sha256sum --check convolens-extension.zip.sha256
+            )
             unzip -qq "$RUNNER_TEMP/assets/convolens-extension.zip" \
               -d "$RUNNER_TEMP/released"
             (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,70 @@ jobs:
             apps/chrome-extension/convolens-extension.zip.sha256
           if-no-files-found: error
           retention-days: 30
+
+  publish-extension-release:
+    name: Publish Extension Release
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release metadata
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Download validated extension artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: convolens-extension-${{ github.sha }}
+
+      - name: Verify validated checksum
+        run: sha256sum --check convolens-extension.zip.sha256
+
+      - name: Publish immutable versioned release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r '.version' apps/chrome-extension/manifest.json)
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Extension manifest version is not a supported semantic version: $VERSION" >&2
+            exit 1
+          fi
+          TAG="extension-v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/current" "$RUNNER_TEMP/released" "$RUNNER_TEMP/assets"
+            unzip -qq convolens-extension.zip -d "$RUNNER_TEMP/current"
+            gh release download "$TAG" \
+              --pattern convolens-extension.zip \
+              --dir "$RUNNER_TEMP/assets"
+            unzip -qq "$RUNNER_TEMP/assets/convolens-extension.zip" \
+              -d "$RUNNER_TEMP/released"
+            (
+              cd "$RUNNER_TEMP/current"
+              find . -type f -print0 | sort -z | xargs -0 sha256sum
+            ) > "$RUNNER_TEMP/current-payload.sha256"
+            (
+              cd "$RUNNER_TEMP/released"
+              find . -type f -print0 | sort -z | xargs -0 sha256sum
+            ) > "$RUNNER_TEMP/released-payload.sha256"
+            if ! cmp -s \
+              "$RUNNER_TEMP/current-payload.sha256" \
+              "$RUNNER_TEMP/released-payload.sha256"; then
+              echo "Release $TAG already exists with different extension payloads." >&2
+              echo "Bump manifest and package versions before publishing changed extension code." >&2
+              exit 1
+            fi
+            echo "Release $TAG already contains these validated extension payloads."
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            "convolens-extension.zip#ConvoLens extension v${VERSION}" \
+            "convolens-extension.zip.sha256#SHA-256 checksum" \
+            --target "$GITHUB_SHA" \
+            --title "ConvoLens Extension v${VERSION}" \
+            --notes "Validated unpacked Chrome extension build from commit ${GITHUB_SHA}. Download and extract convolens-extension.zip, then load the extracted directory containing manifest.json through chrome://extensions."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,16 @@ jobs:
             exit 0
           fi
 
+          TAG_TARGET=$(git ls-remote --tags origin "refs/tags/${TAG}^{}" | awk 'NR == 1 { print $1 }')
+          if [ -z "$TAG_TARGET" ]; then
+            TAG_TARGET=$(git ls-remote --tags origin "refs/tags/${TAG}" | awk 'NR == 1 { print $1 }')
+          fi
+          if [ -n "$TAG_TARGET" ] && [ "$TAG_TARGET" != "$GITHUB_SHA" ]; then
+            echo "Tag $TAG already points to $TAG_TARGET, not validated commit $GITHUB_SHA." >&2
+            echo "Delete or repair the orphaned tag before publishing this release." >&2
+            exit 1
+          fi
+
           gh release create "$TAG" \
             "convolens-extension.zip#ConvoLens extension v${VERSION}" \
             "convolens-extension.zip.sha256#SHA-256 checksum" \

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -54,10 +54,20 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   assert.match(workflow, /name: Publish Extension Release/);
   assert.match(workflow, /needs: validate/);
   assert.match(workflow, /permissions:\s*\n\s*contents: write/);
+  assert.match(
+    workflow,
+    /group: extension-release-\$\{\{ github\.repository \}\}/,
+  );
+  assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /actions\/download-artifact@/);
   assert.match(workflow, /sha256sum --check convolens-extension\.zip\.sha256/);
   assert.match(workflow, /TAG="extension-v\$\{VERSION\}"/);
   assert.match(workflow, /gh release download "\$TAG"/);
+  assert.match(workflow, /--pattern convolens-extension\.zip\.sha256/);
+  assert.match(
+    workflow,
+    /cd "\$RUNNER_TEMP\/assets"[\s\S]*sha256sum --check convolens-extension\.zip\.sha256/,
+  );
   assert.match(workflow, /cmp -s/);
   assert.match(workflow, /gh release create "\$TAG"/);
   assert.match(workflow, /--target "\$GITHUB_SHA"/);

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -69,6 +69,10 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
     /cd "\$RUNNER_TEMP\/assets"[\s\S]*sha256sum --check convolens-extension\.zip\.sha256/,
   );
   assert.match(workflow, /cmp -s/);
+  assert.match(workflow, /git ls-remote --tags origin/);
+  assert.match(workflow, /refs\/tags\/\$\{TAG\}\^\{\}/);
+  assert.match(workflow, /TAG_TARGET.*GITHUB_SHA/);
+  assert.match(workflow, /orphaned tag/);
   assert.match(workflow, /gh release create "\$TAG"/);
   assert.match(workflow, /--target "\$GITHUB_SHA"/);
 });

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -50,6 +50,17 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   );
   assert.match(workflow, /convolens-extension\.zip\.sha256/);
   assert.match(workflow, /if-no-files-found: error/);
+  assert.match(workflow, /publish-extension-release:/);
+  assert.match(workflow, /name: Publish Extension Release/);
+  assert.match(workflow, /needs: validate/);
+  assert.match(workflow, /permissions:\s*\n\s*contents: write/);
+  assert.match(workflow, /actions\/download-artifact@/);
+  assert.match(workflow, /sha256sum --check convolens-extension\.zip\.sha256/);
+  assert.match(workflow, /TAG="extension-v\$\{VERSION\}"/);
+  assert.match(workflow, /gh release download "\$TAG"/);
+  assert.match(workflow, /cmp -s/);
+  assert.match(workflow, /gh release create "\$TAG"/);
+  assert.match(workflow, /--target "\$GITHUB_SHA"/);
 });
 
 test("publishes only a validated extension ZIP and checksum to releases", () => {

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -79,10 +79,13 @@ The current integration is an operator-assisted Chrome extension path:
 
 The extension targets the production API and dashboard through
 `apps/chrome-extension/src/config.ts`. Successful `main` CI runs retain the
-verified extension ZIP and SHA-256 checksum as a 30-day Actions artifact.
-Created GitHub Releases attach the same validated ZIP and checksum. Chrome still
-requires extracting the ZIP and using **Load unpacked**; there is no signed CRX,
-browser-store release, or unattended WhatsApp ingestion service at present.
+verified extension ZIP and SHA-256 checksum as a 30-day Actions artifact and
+publish them to the immutable `extension-v<manifest version>` GitHub Release.
+If the version already exists, CI compares extracted payloads and succeeds only
+when they are identical; changed extension payloads require a version bump.
+Chrome still requires extracting the ZIP and using **Load unpacked**; there is
+no signed CRX, browser-store release, or unattended WhatsApp ingestion service
+at present.
 
 ## Monitoring and diagnostics
 


### PR DESCRIPTION
## What changed

- publish the exact validated extension ZIP and checksum from successful `main` CI as `extension-v<manifest version>`
- make an existing identical release a no-op, while failing if extension payloads changed without a version bump
- document the permanent GitHub Releases download path and cover the workflow contract in release-evidence tests

## Why

The current Actions artifact expires after 30 days and is difficult for operators to discover. The existing release workflow only attaches assets after somebody manually creates a release, so normal deployment never produced a downloadable GitHub Release.

## Impact

After this PR merges and the `main` CI validation succeeds, GitHub Releases will contain `convolens-extension.zip` and its SHA-256 checksum. Chrome installation remains **Load unpacked** after extracting the ZIP; this does not add a signed CRX or browser-store publication.

## Validation

- `actionlint .github/workflows/ci.yml`
- `pnpm exec prettier --check .github/workflows/ci.yml apps/chrome-extension/tests/phase9-release-evidence.test.ts docs/runbook.md`
- `git diff --check`
- extension tests: 153 passed
- focused release-evidence tests: 13 passed
- extension package inspection: 14 expected payloads