### PR TITLE
fix: preserve WhatsApp message identities

### DIFF
--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -76,7 +76,8 @@ test("loads the production extension and sends only after explicit review", asyn
   expect(messages[5]).toMatchObject({
     sender: "Participant Reply",
     text: "✅",
-    replyTo: "fixture-001",
+    isMedia: false,
+    replyTo: (messages[0] as { id: string }).id,
   });
   const participants = harness.apiRequests[0].body.participants as Array<{
     rawDisplayName?: string;

--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -14,9 +14,9 @@ async function reviewLoadedMessages(page: import("@playwright/test").Page) {
   await expect(review).toHaveText("Review loaded messages");
   await review.click();
   await expect(page.locator("#ws-status-text")).toHaveText(
-    "3 loaded messages ready for review.",
+    "6 loaded messages ready for review.",
   );
-  await expect(page.locator("#ws-preview-loaded")).toHaveText("3");
+  await expect(page.locator("#ws-preview-loaded")).toHaveText("6");
 }
 
 test("loads the production extension and sends only after explicit review", async ({
@@ -27,7 +27,7 @@ test("loads the production extension and sends only after explicit review", asyn
 
   await harness.page.locator("#ws-confirm-capture").click();
   await expect(harness.page.locator("#ws-status-text")).toHaveText(
-    "3 loaded messages received by ConvoLens.",
+    "6 loaded messages received by ConvoLens.",
   );
   expect(harness.apiRequests).toHaveLength(1);
   expect(harness.apiRequests[0]).toMatchObject({
@@ -36,7 +36,7 @@ test("loads the production extension and sends only after explicit review", asyn
     body: {
       chatName: "Fixture Group",
       isGroup: true,
-      messageCount: 3,
+      messageCount: 6,
       source: "chrome-extension",
       sourceConversationId: "whatsapp:120363000000000000@g.us",
     },
@@ -44,14 +44,67 @@ test("loads the production extension and sends only after explicit review", asyn
   expect(harness.apiRequests[0].correlationId).toMatch(/^ext_/);
   const messages = harness.apiRequests[0].body.messages as Array<{
     text: string;
+    sender: string;
     isOutgoing: boolean;
+    isMedia: boolean;
+    mediaType?: string;
+    replyTo?: string;
   }>;
   expect(messages.map((message) => message.text)).toEqual([
     "Repeatable fixture message",
     "Repeatable fixture message",
     "TODO: Synthetic reply",
+    "👍",
+    "",
+    "✅",
   ]);
   expect(messages.filter((message) => message.isOutgoing)).toHaveLength(1);
+  expect(messages[2]).toMatchObject({
+    sender: "Fixture Owner",
+    isOutgoing: true,
+  });
+  expect(messages[3]).toMatchObject({
+    sender: "Participant Emoji · +27821234567",
+    text: "👍",
+  });
+  expect(messages[4]).toMatchObject({
+    sender: "Participant Media · +27837654321",
+    text: "",
+    isMedia: true,
+    mediaType: "image",
+  });
+  expect(messages[5]).toMatchObject({
+    sender: "Participant Reply",
+    text: "✅",
+    replyTo: "fixture-001",
+  });
+  const participants = harness.apiRequests[0].body.participants as Array<{
+    rawDisplayName?: string;
+    normalizedPhone?: string;
+    isSelf: boolean;
+  }>;
+  expect(participants).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        rawDisplayName: "Fixture Owner",
+        isSelf: true,
+      }),
+      expect.objectContaining({
+        rawDisplayName: "Participant Emoji",
+        normalizedPhone: "+27821234567",
+        isSelf: false,
+      }),
+      expect.objectContaining({
+        rawDisplayName: "Participant Media",
+        normalizedPhone: "+27837654321",
+        isSelf: false,
+      }),
+      expect.objectContaining({
+        rawDisplayName: "Participant Reply",
+        isSelf: false,
+      }),
+    ]),
+  );
 });
 
 test("renders deterministic duplicate evidence on a repeated reviewed capture", async ({
@@ -67,7 +120,7 @@ test("renders deterministic duplicate evidence on a repeated reviewed capture", 
   expect(harness.apiRequests).toHaveLength(1);
   await harness.page.locator("#ws-confirm-capture").click();
   await expect(harness.page.locator("#ws-status-text")).toHaveText(
-    "3 loaded messages already exist in ConvoLens.",
+    "6 loaded messages already exist in ConvoLens.",
   );
   expect(harness.apiRequests).toHaveLength(2);
   const canonicalMessages = (value: unknown) =>

--- a/apps/chrome-extension/e2e/fixture.spec.ts
+++ b/apps/chrome-extension/e2e/fixture.spec.ts
@@ -106,6 +106,11 @@ test("loads the production extension and sends only after explicit review", asyn
       }),
     ]),
   );
+  expect(
+    participants.find(
+      (participant) => participant.rawDisplayName === "Participant Reply",
+    ),
+  ).not.toHaveProperty("normalizedPhone");
 });
 
 test("renders deterministic duplicate evidence on a repeated reviewed capture", async ({

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -30,6 +30,7 @@
             data-pre-plain-text="[09:55, 30/07/2026] Participant A: "
           >
             <span data-testid="msg-sender">Participant A</span>
+            <div class="selectable-text" dir="auto">Link preview text</div>
             <div data-testid="msg-text">Repeatable fixture message</div>
             <span data-testid="msg-meta">09:55</span>
           </article>
@@ -47,7 +48,7 @@
             class="message-out"
             data-testid="msg-container"
             data-id="fixture-003"
-            data-pre-plain-text="[10:00, 30/07/2026] You: "
+            data-pre-plain-text="[10:00, 30/07/2026] Vous: "
           >
             <div data-testid="msg-out">
               <div data-testid="msg-text">TODO: Synthetic reply</div>

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -63,6 +63,9 @@
           >
             <span data-testid="message-author" title="Participant Emoji"></span>
             <img class="emoji" alt="👍" />
+            <span data-testid="msg-reaction"
+              ><img class="emoji" alt="❤️"
+            /></span>
             <span data-testid="msg-meta">10:01</span>
           </article>
           <article

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -89,6 +89,7 @@
               <span class="selectable-text" dir="auto"
                 >Quoted fixture text</span
               >
+              <img data-testid="image-content" alt="Quoted attachment" />
             </div>
             <img class="emoji" alt="✅" />
             <span data-testid="msg-meta">10:03</span>

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -5,6 +5,9 @@
     <title>Synthetic WhatsApp fixture</title>
   </head>
   <body>
+    <nav aria-label="Profile">
+      <img alt="Fixture Owner" data-testid="menu-bar-avatar" />
+    </nav>
     <aside id="pane-side" data-testid="chat-list" aria-label="Chat list">
       <button type="button">Fixture Group</button>
     </aside>
@@ -50,6 +53,45 @@
               <div data-testid="msg-text">TODO: Synthetic reply</div>
               <span data-testid="msg-meta">10:00</span>
             </div>
+          </article>
+          <article
+            class="message-in"
+            data-testid="msg-container"
+            data-id="fixture-004"
+            data-pre-plain-text="[10:01, 30/07/2026] +27 82 123 4567: "
+          >
+            <span data-testid="message-author" title="Participant Emoji"></span>
+            <img class="emoji" alt="👍" />
+            <span data-testid="msg-meta">10:01</span>
+          </article>
+          <article
+            class="message-in"
+            data-testid="msg-container"
+            data-id="fixture-005"
+            data-pre-plain-text="[10:02, 30/07/2026] +27 83 765 4321: "
+          >
+            <span data-testid="message-author" title="Participant Media"></span>
+            <img data-testid="image-content" alt="" />
+            <span data-testid="msg-meta">10:02</span>
+          </article>
+          <article
+            class="message-in"
+            data-testid="msg-container"
+            data-id="fixture-006"
+            data-pre-plain-text="[10:03, 30/07/2026] Participant Reply: "
+          >
+            <span data-testid="message-author">Participant Reply</span>
+            <div
+              data-testid="quoted-message"
+              data-quoted-message-id="fixture-001"
+            >
+              <span data-phone="+27 84 000 0000">Quoted sender</span>
+              <span class="selectable-text" dir="auto"
+                >Quoted fixture text</span
+              >
+            </div>
+            <img class="emoji" alt="✅" />
+            <span data-testid="msg-meta">10:03</span>
           </article>
         </section>
       </section>

--- a/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
+++ b/apps/chrome-extension/e2e/fixtures/whatsapp-web.html
@@ -91,6 +91,7 @@
               >
               <img data-testid="image-content" alt="Quoted attachment" />
             </div>
+            <span data-phone="+27 85 111 2233">Shared contact card</span>
             <img class="emoji" alt="✅" />
             <span data-testid="msg-meta">10:03</span>
           </article>

--- a/apps/chrome-extension/e2e/persistence.spec.ts
+++ b/apps/chrome-extension/e2e/persistence.spec.ts
@@ -156,7 +156,7 @@ async function reviewLoadedMessages(page: Page): Promise<void> {
     await toggle.click();
   await page.locator("#ws-extract-btn").click();
   await expect(page.locator("#ws-status-text")).toHaveText(
-    "3 loaded messages ready for review.",
+    "6 loaded messages ready for review.",
     { timeout: 15_000 },
   );
 }
@@ -249,7 +249,7 @@ test("persists a reviewed extension capture across duplicate, restart, isolation
     };
     expect(list.data.conversations).toHaveLength(1);
     expect(list.data.conversations[0]).toMatchObject({
-      messageCount: 3,
+      messageCount: 6,
       rawArtifactStatus: "stored",
     });
     const intakeId = list.data.conversations[0].id;
@@ -268,7 +268,7 @@ test("persists a reviewed extension capture across duplicate, restart, isolation
         };
       };
     };
-    expect(detail.data.conversation.messages).toHaveLength(3);
+    expect(detail.data.conversation.messages).toHaveLength(6);
     expect(detail.data.conversation.rawArtifact).toMatchObject({
       status: "stored",
     });
@@ -388,7 +388,7 @@ test("persists a reviewed extension capture across duplicate, restart, isolation
       body: Buffer.from(
         JSON.stringify({
           intakeId,
-          messageCount: 3,
+          messageCount: 6,
           rawArtifactStatus: "stored",
           duplicateCount: 1,
           restartStatus: afterRestart.status(),

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ConvoLens - WhatsApp Intake",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Send the WhatsApp Web conversation you choose into your ConvoLens workspace.",
 
   "icons": {

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convolens/chrome-extension",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "type": "module",
   "description": "ConvoLens Chrome Extension for WhatsApp Web",

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -55,7 +55,9 @@ import {
   findMessageText,
   findReplyTargetId,
   findSelfDisplayName,
+  hasCurrentMessageEvidence,
   QUOTED_MESSAGE_SELECTOR,
+  resolveCapturedReplyTargets,
 } from "./dom-selectors";
 import {
   DEFAULT_LAUNCHER_POSITION,
@@ -88,6 +90,7 @@ interface ExtractedMessage {
   replyTo?: string;
   senderRef?: string;
   captureSourceId?: string;
+  captureReplyToSourceId?: string;
   captureAlignmentToken?: string;
   captureMetadataPath?: MetadataPath;
   captureSenderMethod?: ExtractedParticipant["extractionMethod"];
@@ -1841,6 +1844,10 @@ function cloneGuidedMessage(
       value: message.captureSourceId,
       enumerable: false,
     },
+    captureReplyToSourceId: {
+      value: message.captureReplyToSourceId,
+      enumerable: false,
+    },
     captureAlignmentToken: {
       value: message.captureAlignmentToken,
       enumerable: false,
@@ -2074,6 +2081,7 @@ function mergeGuidedPayload(
     incoming.diagnostics.unreadableMessageCount * addedRatio,
   );
   session.payload.messages = session.items.map((item) => item.value);
+  resolveCapturedReplyTargets(session.payload.messages);
   const retainedParticipantRefs = new Set(
     session.payload.messages
       .map((message) => message.senderRef)
@@ -2268,6 +2276,7 @@ function retainAutomaticItems(
   session.items = items;
   reconcileGuidedAlignmentWarnings(session);
   session.payload.messages = items.map((item) => item.value);
+  resolveCapturedReplyTargets(session.payload.messages);
   session.payload.messageCount = session.payload.messages.length;
   session.skippedCount = 0;
   session.unreadableCount = 0;
@@ -2689,6 +2698,7 @@ async function finalizeGuidedCaptureOperation(
     throw new Error("The guided capture buffer is no longer available.");
   }
   prepareSummary?.(session);
+  resolveCapturedReplyTargets(session.payload.messages);
   const summary = summarizeCapturePayload(
     session.payload,
     session.chatIdentity,
@@ -2937,6 +2947,9 @@ async function extractCurrentChat(
     }
   }
 
+  await assignOpaqueSourceMessageIds(messages, sourceConversationId);
+  resolveCapturedReplyTargets(messages);
+
   return {
     chatName,
     chatId: generateChatId(chatName),
@@ -3034,10 +3047,10 @@ function extractMessageData(
     isOutgoing,
     isMedia,
     mediaType,
-    replyTo: findReplyTargetId(messageRecord),
     senderRef,
   };
   const captureSourceId = messageRecord.getAttribute("data-id")?.trim();
+  const captureReplyToSourceId = findReplyTargetId(messageRecord);
   const captureAlignmentToken = JSON.stringify({
     metadata: metadata.value,
     direction: isOutgoing ? "out" : "in",
@@ -3050,6 +3063,10 @@ function extractMessageData(
   Object.defineProperties(message, {
     captureSourceId: {
       value: captureSourceId || undefined,
+      enumerable: false,
+    },
+    captureReplyToSourceId: {
+      value: captureReplyToSourceId,
       enumerable: false,
     },
     captureAlignmentToken: {
@@ -3264,33 +3281,33 @@ function detectMediaMessage(container: HTMLElement): boolean {
   if (getMediaType(container)) return true;
   const mediaIndicators = ['[data-testid="media-state-icon"]'];
 
-  return mediaIndicators.some(
-    (selector) => container.querySelector(selector) !== null,
+  return mediaIndicators.some((selector) =>
+    hasCurrentMessageEvidence(container, selector),
   );
 }
 
 function getMediaType(container: HTMLElement): MediaType | undefined {
   return classifyMediaEvidence({
-    video:
-      container.querySelector(
-        'video, [data-testid="video-thumb"], [data-testid="video-content"], .message-video',
-      ) !== null,
-    audio:
-      container.querySelector(
-        'audio, [data-testid="audio-player"], [data-testid="audio-content"], [data-icon="audio-play"], .message-audio',
-      ) !== null,
-    document:
-      container.querySelector(
-        '[data-testid="document-thumb"], [data-testid="document-content"], [data-icon="document"], .message-document',
-      ) !== null,
-    sticker:
-      container.querySelector(
-        '[data-testid="sticker"], [data-testid="sticker-content"], img[alt="Sticker"]',
-      ) !== null,
-    image:
-      container.querySelector(
-        '[data-testid="image-thumb"], [data-testid="image-content"], .message-image',
-      ) !== null,
+    video: hasCurrentMessageEvidence(
+      container,
+      'video, [data-testid="video-thumb"], [data-testid="video-content"], .message-video',
+    ),
+    audio: hasCurrentMessageEvidence(
+      container,
+      'audio, [data-testid="audio-player"], [data-testid="audio-content"], [data-icon="audio-play"], .message-audio',
+    ),
+    document: hasCurrentMessageEvidence(
+      container,
+      '[data-testid="document-thumb"], [data-testid="document-content"], [data-icon="document"], .message-document',
+    ),
+    sticker: hasCurrentMessageEvidence(
+      container,
+      '[data-testid="sticker"], [data-testid="sticker-content"], img[alt="Sticker"]',
+    ),
+    image: hasCurrentMessageEvidence(
+      container,
+      '[data-testid="image-thumb"], [data-testid="image-content"], .message-image',
+    ),
   });
 }
 
@@ -3366,6 +3383,26 @@ function generateMessageId(): string {
     b.toString(16).padStart(2, "0"),
   ).join("");
   return "msg_" + Date.now().toString(36) + randomHex;
+}
+
+async function assignOpaqueSourceMessageIds(
+  messages: ExtractedMessage[],
+  sourceConversationId: string,
+): Promise<void> {
+  await Promise.all(
+    messages.map(async (message) => {
+      if (!message.captureSourceId) return;
+      const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(
+          `${sourceConversationId}\u0000${message.captureSourceId}`,
+        ),
+      );
+      message.id = `msg_${Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, "0"),
+      ).join("")}`;
+    }),
+  );
 }
 
 function generateChatId(name: string): string {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -3015,7 +3015,8 @@ function extractMessageData(
     container.closest('[data-testid="msg-out"]') !== null ||
     messageRecord.classList.contains("message-out") ||
     messageRecord.closest('[data-testid="msg-out"]') !== null ||
-    messageRecord.querySelector('[data-testid="msg-out"]') !== null;
+    messageRecord.querySelector('[data-testid="msg-out"], .message-out') !==
+      null;
   const metadata = getMessageMetadata(messageRecord);
   const identity = extractSenderIdentity(
     messageRecord,

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -3105,6 +3105,7 @@ function extractSenderIdentity(
     senderEl?.textContent?.trim() || senderEl?.getAttribute("title")?.trim();
   const scopedPhoneEvidence = collectScopedIdentityEvidence(senderEl);
   if (isOutgoing) {
+    const selfProfileName = findSelfDisplayName(document);
     const specificMetadataSender = isGenericSelfLabel(metadataSender)
       ? undefined
       : metadataSender;
@@ -3112,9 +3113,11 @@ function extractSenderIdentity(
       ? undefined
       : explicitSender;
     const combined = combineSenderEvidence({
-      metadataSender: specificMetadataSender,
-      visibleSender: specificVisibleSender,
-      headerSender: findSelfDisplayName(document),
+      metadataSender: selfProfileName || specificMetadataSender,
+      visibleSender: selfProfileName
+        ? specificMetadataSender
+        : specificVisibleSender,
+      headerSender: selfProfileName ? specificVisibleSender : undefined,
       scopedPhoneEvidence,
     });
     return {

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -3103,10 +3103,7 @@ function extractSenderIdentity(
   ).sender;
   const explicitSender =
     senderEl?.textContent?.trim() || senderEl?.getAttribute("title")?.trim();
-  const scopedPhoneEvidence = collectScopedIdentityEvidence(
-    container,
-    senderEl,
-  );
+  const scopedPhoneEvidence = collectScopedIdentityEvidence(senderEl);
   if (isOutgoing) {
     const specificMetadataSender = isGenericSelfLabel(metadataSender)
       ? undefined
@@ -3152,8 +3149,6 @@ function extractSenderIdentity(
   const platformUserId =
     senderEl?.getAttribute("data-contact-id") ||
     senderEl?.closest("[data-contact-id]")?.getAttribute("data-contact-id") ||
-    container.getAttribute("data-contact-id") ||
-    container.closest("[data-contact-id]")?.getAttribute("data-contact-id") ||
     undefined;
   const extractionMethod = metadataSender
     ? "metadata"
@@ -3183,10 +3178,7 @@ function isGenericSelfLabel(value?: string): boolean {
   return !value || /^(you|me|myself)$/i.test(value.trim());
 }
 
-function collectScopedIdentityEvidence(
-  container: HTMLElement,
-  senderEl: Element | null,
-): string[] {
+function collectScopedIdentityEvidence(senderEl: Element | null): string[] {
   const evidence = new Set<string>();
   const add = (value: string | null | undefined) => {
     const normalized = value?.trim();
@@ -3199,8 +3191,7 @@ function collectScopedIdentityEvidence(
     "title",
   ]) {
     add(senderEl?.getAttribute(attribute));
-    for (const element of container.querySelectorAll(`[${attribute}]`)) {
-      if (element.closest(QUOTED_MESSAGE_SELECTOR)) continue;
+    for (const element of senderEl?.querySelectorAll(`[${attribute}]`) || []) {
       add(element.getAttribute(attribute));
     }
   }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -49,8 +49,13 @@ import { classifyMediaEvidence, type MediaType } from "./media-evidence";
 import {
   findConversationRoot,
   findMessageContainers,
+  findMessageEmojiText,
   findMessageRecord,
+  findMessageSender,
   findMessageText,
+  findReplyTargetId,
+  findSelfDisplayName,
+  QUOTED_MESSAGE_SELECTOR,
 } from "./dom-selectors";
 import {
   DEFAULT_LAUNCHER_POSITION,
@@ -2968,7 +2973,8 @@ function extractMessageData(
     SELECTORS.fallback.messageText,
   );
 
-  const text = textEl?.textContent?.trim() || "";
+  const text =
+    textEl?.textContent?.trim() || findMessageEmojiText(messageRecord) || "";
 
   // Check for media messages
   const isMedia = detectMediaMessage(messageRecord);
@@ -2984,9 +2990,11 @@ function extractMessageData(
   const timeText = timeEl?.textContent?.trim() || "";
 
   // Get sender (for group chats)
-  const senderEl =
-    messageRecord.querySelector(SELECTORS.primary.senderName) ||
-    messageRecord.querySelector(SELECTORS.fallback.senderName);
+  const senderEl = findMessageSender(
+    messageRecord,
+    SELECTORS.primary.senderName,
+    SELECTORS.fallback.senderName,
+  );
 
   // Determine direction
   const isOutgoing =
@@ -3026,6 +3034,7 @@ function extractMessageData(
     isOutgoing,
     isMedia,
     mediaType,
+    replyTo: findReplyTargetId(messageRecord),
     senderRef,
   };
   const captureSourceId = messageRecord.getAttribute("data-id")?.trim();
@@ -3071,20 +3080,38 @@ function extractSenderIdentity(
   chatName: string,
   metadata: string,
 ): Omit<ExtractedParticipant, "ref"> & { displayLabel?: string } {
+  const metadataSender = parseWhatsAppMessageMetadata(
+    metadata,
+    document.documentElement.lang || navigator.language,
+  ).sender;
+  const explicitSender =
+    senderEl?.textContent?.trim() || senderEl?.getAttribute("title")?.trim();
+  const scopedPhoneEvidence = collectScopedIdentityEvidence(
+    container,
+    senderEl,
+  );
   if (isOutgoing) {
+    const specificMetadataSender = isGenericSelfLabel(metadataSender)
+      ? undefined
+      : metadataSender;
+    const specificVisibleSender = isGenericSelfLabel(explicitSender)
+      ? undefined
+      : explicitSender;
+    const combined = combineSenderEvidence({
+      metadataSender: specificMetadataSender,
+      visibleSender: specificVisibleSender,
+      headerSender: findSelfDisplayName(document),
+      scopedPhoneEvidence,
+    });
     return {
-      rawDisplayName: "You",
-      displayLabel: "You",
+      rawDisplayName: combined.rawDisplayName || "You",
+      displayLabel: combined.displayLabel || "You",
+      normalizedPhone: combined.normalizedPhone,
       isSelf: true,
       extractionMethod: "outgoing",
       confidence: "high",
     };
   }
-  const metadataSender = parseWhatsAppMessageMetadata(
-    metadata,
-    document.documentElement.lang || navigator.language,
-  ).sender;
-  const explicitSender = senderEl?.textContent?.trim();
   // A failure to recognise a group is not proof this is a direct chat.
   const headerSender = isDirectChat
     ? querySelector(
@@ -3093,11 +3120,6 @@ function extractSenderIdentity(
       )?.textContent?.trim() ||
       (chatName === "Unknown Chat" ? undefined : chatName)
     : undefined;
-  const scopedPhoneEvidence = [
-    senderEl?.getAttribute("data-phone"),
-    senderEl?.getAttribute("title"),
-    senderEl?.closest("[data-contact-id]")?.getAttribute("data-contact-id"),
-  ].filter((value): value is string => Boolean(value));
   const combined = combineSenderEvidence({
     metadataSender,
     visibleSender: explicitSender,
@@ -3111,6 +3133,8 @@ function extractSenderIdentity(
   const normalizedPhone = combined.normalizedPhone;
   // data-id identifies an individual message in WhatsApp Web, not its sender.
   const platformUserId =
+    senderEl?.getAttribute("data-contact-id") ||
+    senderEl?.closest("[data-contact-id]")?.getAttribute("data-contact-id") ||
     container.getAttribute("data-contact-id") ||
     container.closest("[data-contact-id]")?.getAttribute("data-contact-id") ||
     undefined;
@@ -3136,6 +3160,35 @@ function extractSenderIdentity(
           ? "low"
           : "medium",
   };
+}
+
+function isGenericSelfLabel(value?: string): boolean {
+  return !value || /^(you|me|myself)$/i.test(value.trim());
+}
+
+function collectScopedIdentityEvidence(
+  container: HTMLElement,
+  senderEl: Element | null,
+): string[] {
+  const evidence = new Set<string>();
+  const add = (value: string | null | undefined) => {
+    const normalized = value?.trim();
+    if (normalized) evidence.add(normalized);
+  };
+  for (const attribute of [
+    "data-phone",
+    "data-contact-id",
+    "data-jid",
+    "title",
+  ]) {
+    add(senderEl?.getAttribute(attribute));
+    for (const element of container.querySelectorAll(`[${attribute}]`)) {
+      if (element.closest(QUOTED_MESSAGE_SELECTOR)) continue;
+      add(element.getAttribute(attribute));
+    }
+  }
+  add(senderEl?.closest("[data-contact-id]")?.getAttribute("data-contact-id"));
+  return [...evidence];
 }
 
 function getMessageMetadata(container: HTMLElement): {
@@ -3220,20 +3273,24 @@ function getMediaType(container: HTMLElement): MediaType | undefined {
   return classifyMediaEvidence({
     video:
       container.querySelector(
-        'video, [data-testid="video-thumb"], .message-video',
+        'video, [data-testid="video-thumb"], [data-testid="video-content"], .message-video',
       ) !== null,
     audio:
       container.querySelector(
-        'audio, [data-testid="audio-player"], .message-audio',
+        'audio, [data-testid="audio-player"], [data-testid="audio-content"], [data-icon="audio-play"], .message-audio',
       ) !== null,
     document:
       container.querySelector(
-        '[data-testid="document-thumb"], .message-document',
+        '[data-testid="document-thumb"], [data-testid="document-content"], [data-icon="document"], .message-document',
       ) !== null,
-    sticker: container.querySelector('[data-testid="sticker"]') !== null,
+    sticker:
+      container.querySelector(
+        '[data-testid="sticker"], [data-testid="sticker-content"], img[alt="Sticker"]',
+      ) !== null,
     image:
-      container.querySelector('[data-testid="image-thumb"], .message-image') !==
-      null,
+      container.querySelector(
+        '[data-testid="image-thumb"], [data-testid="image-content"], .message-image',
+      ) !== null,
   });
 }
 

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -30,8 +30,7 @@ function closestMessageRecord(element: Element): HTMLElement | null {
     ) as HTMLElement | null) ||
     (recordSearchRoot.closest?.(
       MESSAGE_CONTAINER_SELECTOR,
-    ) as HTMLElement | null) ||
-    (element as HTMLElement)
+    ) as HTMLElement | null)
   );
 }
 

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -114,13 +114,19 @@ export function findMessageText(
   primarySelector: string,
   fallbackSelector: string,
 ): Element | null {
-  const selectors = `${primarySelector}, ${fallbackSelector}, ${MESSAGE_TEXT_SELECTOR}`;
-
-  const candidates = [
-    ...(container.matches?.(selectors) ? [container] : []),
-    ...container.querySelectorAll(selectors),
-  ];
-  return candidates.find((candidate) => !isQuotedEvidence(candidate)) || null;
+  for (const selector of [
+    primarySelector,
+    fallbackSelector,
+    MESSAGE_TEXT_SELECTOR,
+  ]) {
+    const candidates = [
+      ...(container.matches?.(selector) ? [container] : []),
+      ...container.querySelectorAll(selector),
+    ];
+    const match = candidates.find((candidate) => !isQuotedEvidence(candidate));
+    if (match) return match;
+  }
+  return null;
 }
 
 export function findMessageEmojiText(container: Element): string | undefined {

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -10,6 +10,9 @@ export const QUOTED_MESSAGE_SELECTOR =
 export const MESSAGE_SENDER_SELECTOR =
   '[data-testid="msg-sender"], [data-testid="author"], [data-testid="message-author"], [data-testid="group-message-author"]';
 
+const MESSAGE_REACTION_SELECTOR =
+  '[data-testid*="reaction"], [data-icon*="reaction"], [data-reaction]';
+
 export const MESSAGE_RECORD_EVIDENCE_SELECTOR = [
   MESSAGE_TEXT_SELECTOR,
   "[data-pre-plain-text]",
@@ -135,7 +138,11 @@ export function findMessageEmojiText(container: Element): string | undefined {
       "img.emoji[alt], img[data-emoji][alt], [data-emoji][aria-label]",
     ),
   )
-    .filter((candidate) => !isQuotedEvidence(candidate))
+    .filter(
+      (candidate) =>
+        !isQuotedEvidence(candidate) &&
+        !candidate.closest?.(MESSAGE_REACTION_SELECTOR),
+    )
     .map(
       (candidate) =>
         candidate.getAttribute("alt") ||

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -67,7 +67,7 @@ export function findConversationRoot(
   const activeConversation = documentRoot.querySelector("#main");
   if (
     activeConversation?.querySelector(MESSAGE_CONTAINER_SELECTOR) ||
-    activeConversation?.querySelector(MESSAGE_TEXT_SELECTOR)
+    activeConversation?.querySelector(MESSAGE_RECORD_EVIDENCE_SELECTOR)
   ) {
     return activeConversation;
   }
@@ -152,12 +152,17 @@ export function findMessageSender(
   primarySelector: string,
   fallbackSelector: string,
 ): Element | null {
-  const selectors = `${primarySelector}, ${fallbackSelector}, ${MESSAGE_SENDER_SELECTOR}`;
-  return (
-    Array.from(container.querySelectorAll(selectors)).find(
+  for (const selector of [
+    primarySelector,
+    fallbackSelector,
+    MESSAGE_SENDER_SELECTOR,
+  ]) {
+    const match = Array.from(container.querySelectorAll(selector)).find(
       (candidate) => !isQuotedEvidence(candidate),
-    ) || null
-  );
+    );
+    if (match) return match;
+  }
+  return null;
 }
 
 export function findReplyTargetId(container: Element): string | undefined {

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -23,14 +23,28 @@ const MESSAGE_RECORD_SELECTOR =
   '[data-id], [role="row"], [data-testid="msg-container"], .message-in, .message-out';
 
 function closestMessageRecord(element: Element): HTMLElement | null {
+  const quotedPreview = element.closest?.(QUOTED_MESSAGE_SELECTOR);
+  const recordSearchRoot = quotedPreview?.parentElement || element;
   return (
-    (element.closest?.(MESSAGE_RECORD_SELECTOR) as HTMLElement | null) ||
-    (element as HTMLElement)
+    (recordSearchRoot.closest?.(
+      MESSAGE_RECORD_SELECTOR,
+    ) as HTMLElement | null) || (element as HTMLElement)
   );
 }
 
 function isQuotedEvidence(element: Element): boolean {
   return Boolean(element.closest?.(QUOTED_MESSAGE_SELECTOR));
+}
+
+export function hasCurrentMessageEvidence(
+  container: Element,
+  selector: string,
+): boolean {
+  const candidates = [
+    ...(container.matches?.(selector) ? [container] : []),
+    ...container.querySelectorAll(selector),
+  ];
+  return candidates.some((candidate) => !isQuotedEvidence(candidate));
 }
 
 /**
@@ -161,6 +175,37 @@ export function findReplyTargetId(container: Element): string | undefined {
     if (candidate && candidate !== currentId) return candidate;
   }
   return undefined;
+}
+
+export function resolveCapturedReplyTargets<
+  T extends {
+    id: string;
+    replyTo?: string;
+    captureSourceId?: string;
+    captureReplyToSourceId?: string;
+  },
+>(messages: T[]): void {
+  const exportedIdBySourceId = new Map(
+    messages.flatMap((message) =>
+      message.captureSourceId
+        ? ([[message.captureSourceId, message.id]] as const)
+        : [],
+    ),
+  );
+
+  for (const message of messages) {
+    const rawReplyTarget = message.captureReplyToSourceId;
+    if (!rawReplyTarget) {
+      delete message.replyTo;
+      continue;
+    }
+    const exportedTargetId = exportedIdBySourceId.get(rawReplyTarget);
+    if (exportedTargetId) {
+      message.replyTo = exportedTargetId;
+    } else {
+      delete message.replyTo;
+    }
+  }
 }
 
 export function findSelfDisplayName(root: ParentNode): string | undefined {

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -19,16 +19,19 @@ export const MESSAGE_RECORD_EVIDENCE_SELECTOR = [
   '[data-testid="audio-player"], [data-testid="audio-content"], [data-testid="document-thumb"], [data-testid="document-content"], [data-testid="sticker"], [data-testid="sticker-content"]',
 ].join(", ");
 
-const MESSAGE_RECORD_SELECTOR =
-  '[data-id], [role="row"], [data-testid="msg-container"], .message-in, .message-out';
+const OUTER_MESSAGE_RECORD_SELECTOR = '[data-id], [role="row"]';
 
 function closestMessageRecord(element: Element): HTMLElement | null {
   const quotedPreview = element.closest?.(QUOTED_MESSAGE_SELECTOR);
   const recordSearchRoot = quotedPreview?.parentElement || element;
   return (
     (recordSearchRoot.closest?.(
-      MESSAGE_RECORD_SELECTOR,
-    ) as HTMLElement | null) || (element as HTMLElement)
+      OUTER_MESSAGE_RECORD_SELECTOR,
+    ) as HTMLElement | null) ||
+    (recordSearchRoot.closest?.(
+      MESSAGE_CONTAINER_SELECTOR,
+    ) as HTMLElement | null) ||
+    (element as HTMLElement)
   );
 }
 
@@ -84,22 +87,12 @@ export function findMessageContainers(
   primarySelector: string,
   fallbackSelector: string,
 ): HTMLElement[] {
-  const directMatches = Array.from(
-    root.querySelectorAll(`${primarySelector}, ${fallbackSelector}`),
-  ) as HTMLElement[];
-
   const containers = new Set<HTMLElement>();
-  for (const directMatch of directMatches) {
-    const record = closestMessageRecord(directMatch);
-    if (record && (!root.contains || root.contains(record))) {
-      containers.add(record);
-    }
-  }
-
-  for (const evidence of root.querySelectorAll(
-    MESSAGE_RECORD_EVIDENCE_SELECTOR,
-  )) {
-    const record = closestMessageRecord(evidence);
+  const candidates = root.querySelectorAll(
+    `${primarySelector}, ${fallbackSelector}, ${MESSAGE_RECORD_EVIDENCE_SELECTOR}`,
+  );
+  for (const candidate of candidates) {
+    const record = closestMessageRecord(candidate);
     if (record && (!root.contains || root.contains(record))) {
       containers.add(record);
     }

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -4,6 +4,35 @@ export const MESSAGE_CONTAINER_SELECTOR =
 export const MESSAGE_TEXT_SELECTOR =
   '[data-testid="msg-text"], .selectable-text.copyable-text[dir], .selectable-text[dir]';
 
+export const QUOTED_MESSAGE_SELECTOR =
+  '[data-testid="quoted-message"], [data-testid="quoted-message-wrapper"], [data-testid="quoted-msg"], [data-quoted-message-id]';
+
+export const MESSAGE_SENDER_SELECTOR =
+  '[data-testid="msg-sender"], [data-testid="author"], [data-testid="message-author"], [data-testid="group-message-author"]';
+
+export const MESSAGE_RECORD_EVIDENCE_SELECTOR = [
+  MESSAGE_TEXT_SELECTOR,
+  "[data-pre-plain-text]",
+  QUOTED_MESSAGE_SELECTOR,
+  "img.emoji[alt], img[data-emoji][alt], [data-emoji][aria-label]",
+  'video, audio, [data-testid="image-thumb"], [data-testid="image-content"], [data-testid="video-thumb"], [data-testid="video-content"]',
+  '[data-testid="audio-player"], [data-testid="audio-content"], [data-testid="document-thumb"], [data-testid="document-content"], [data-testid="sticker"], [data-testid="sticker-content"]',
+].join(", ");
+
+const MESSAGE_RECORD_SELECTOR =
+  '[data-id], [role="row"], [data-testid="msg-container"], .message-in, .message-out';
+
+function closestMessageRecord(element: Element): HTMLElement | null {
+  return (
+    (element.closest?.(MESSAGE_RECORD_SELECTOR) as HTMLElement | null) ||
+    (element as HTMLElement)
+  );
+}
+
+function isQuotedEvidence(element: Element): boolean {
+  return Boolean(element.closest?.(QUOTED_MESSAGE_SELECTOR));
+}
+
 /**
  * Return the active conversation body without depending on WhatsApp's
  * frequently renamed scrolling wrapper.
@@ -31,8 +60,10 @@ export function findConversationRoot(
 }
 
 /**
- * Prefer message bubbles, but recover from class churn by walking from stable
- * selectable message text to its nearest message record.
+ * Merge configured message bubbles with text, metadata, reply, emoji, and media
+ * evidence. WhatsApp can omit text nodes entirely and can change only some
+ * container selectors, so returning early after one direct match loses valid
+ * records.
  */
 export function findMessageContainers(
   root: Element,
@@ -43,18 +74,20 @@ export function findMessageContainers(
     root.querySelectorAll(`${primarySelector}, ${fallbackSelector}`),
   ) as HTMLElement[];
 
-  if (directMatches.length > 0) return directMatches;
-
   const containers = new Set<HTMLElement>();
-  const textNodes = root.querySelectorAll(MESSAGE_TEXT_SELECTOR);
+  for (const directMatch of directMatches) {
+    const record = closestMessageRecord(directMatch);
+    if (record && (!root.contains || root.contains(record))) {
+      containers.add(record);
+    }
+  }
 
-  for (const textNode of textNodes) {
-    const container = textNode.closest(
-      '[data-id], [role="row"], .message-in, .message-out',
-    ) as HTMLElement | null;
-
-    if (container && (!root.contains || root.contains(container))) {
-      containers.add(container);
+  for (const evidence of root.querySelectorAll(
+    MESSAGE_RECORD_EVIDENCE_SELECTOR,
+  )) {
+    const record = closestMessageRecord(evidence);
+    if (record && (!root.contains || root.contains(record))) {
+      containers.add(record);
     }
   }
 
@@ -67,10 +100,7 @@ export function findMessageContainers(
  * because those fields may be siblings of the bubble rather than descendants.
  */
 export function findMessageRecord(element: HTMLElement): HTMLElement {
-  return (
-    (element.closest('[data-id], [role="row"]') as HTMLElement | null) ||
-    element
-  );
+  return closestMessageRecord(element) || element;
 }
 
 export function findMessageText(
@@ -80,11 +110,76 @@ export function findMessageText(
 ): Element | null {
   const selectors = `${primarySelector}, ${fallbackSelector}, ${MESSAGE_TEXT_SELECTOR}`;
 
-  if (container.matches?.(selectors)) return container;
+  const candidates = [
+    ...(container.matches?.(selectors) ? [container] : []),
+    ...container.querySelectorAll(selectors),
+  ];
+  return candidates.find((candidate) => !isQuotedEvidence(candidate)) || null;
+}
 
+export function findMessageEmojiText(container: Element): string | undefined {
+  const emoji = Array.from(
+    container.querySelectorAll(
+      "img.emoji[alt], img[data-emoji][alt], [data-emoji][aria-label]",
+    ),
+  )
+    .filter((candidate) => !isQuotedEvidence(candidate))
+    .map(
+      (candidate) =>
+        candidate.getAttribute("alt") ||
+        candidate.getAttribute("aria-label") ||
+        "",
+    )
+    .join("")
+    .trim();
+  return emoji || undefined;
+}
+
+export function findMessageSender(
+  container: Element,
+  primarySelector: string,
+  fallbackSelector: string,
+): Element | null {
+  const selectors = `${primarySelector}, ${fallbackSelector}, ${MESSAGE_SENDER_SELECTOR}`;
   return (
-    container.querySelector(primarySelector) ||
-    container.querySelector(fallbackSelector) ||
-    container.querySelector(MESSAGE_TEXT_SELECTOR)
+    Array.from(container.querySelectorAll(selectors)).find(
+      (candidate) => !isQuotedEvidence(candidate),
+    ) || null
   );
+}
+
+export function findReplyTargetId(container: Element): string | undefined {
+  const quoted = container.querySelector(QUOTED_MESSAGE_SELECTOR);
+  if (!quoted) return undefined;
+  const currentId = container.getAttribute("data-id")?.trim();
+  for (const attribute of [
+    "data-quoted-message-id",
+    "data-message-id",
+    "data-id",
+  ]) {
+    const candidate = quoted.getAttribute(attribute)?.trim();
+    if (candidate && candidate !== currentId) return candidate;
+  }
+  return undefined;
+}
+
+export function findSelfDisplayName(root: ParentNode): string | undefined {
+  const candidates = [
+    root
+      .querySelector('[data-testid="menu-bar-avatar"][title]')
+      ?.getAttribute("title"),
+    root
+      .querySelector('[data-testid="menu-bar-avatar"] img[alt]')
+      ?.getAttribute("alt"),
+    root
+      .querySelector('[data-testid="default-user"][title]')
+      ?.getAttribute("title"),
+    root.querySelector('[aria-label="Profile"] [title]')?.getAttribute("title"),
+    root.querySelector('[aria-label="Profile"] img[alt]')?.getAttribute("alt"),
+  ];
+  return candidates
+    .map((candidate) => candidate?.trim())
+    .find((candidate): candidate is string =>
+      Boolean(candidate && !/^(profile|you|avatar)$/i.test(candidate)),
+    );
 }

--- a/apps/chrome-extension/src/dom-selectors.ts
+++ b/apps/chrome-extension/src/dom-selectors.ts
@@ -18,8 +18,9 @@ export const MESSAGE_RECORD_EVIDENCE_SELECTOR = [
   "[data-pre-plain-text]",
   QUOTED_MESSAGE_SELECTOR,
   "img.emoji[alt], img[data-emoji][alt], [data-emoji][aria-label]",
-  'video, audio, [data-testid="image-thumb"], [data-testid="image-content"], [data-testid="video-thumb"], [data-testid="video-content"]',
-  '[data-testid="audio-player"], [data-testid="audio-content"], [data-testid="document-thumb"], [data-testid="document-content"], [data-testid="sticker"], [data-testid="sticker-content"]',
+  'video, audio, [data-testid="image-thumb"], [data-testid="image-content"], [data-testid="video-thumb"], [data-testid="video-content"], .message-video, .message-image',
+  '[data-testid="audio-player"], [data-testid="audio-content"], [data-testid="document-thumb"], [data-testid="document-content"], [data-testid="sticker"], [data-testid="sticker-content"], [data-testid="media-state-icon"]',
+  '[data-icon="audio-play"], [data-icon="document"], img[alt="Sticker"], .message-audio, .message-document',
 ].join(", ");
 
 const OUTER_MESSAGE_RECORD_SELECTOR = '[data-id], [role="row"]';

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -73,6 +73,23 @@ test("derives unique message records from selectable text when bubble selectors 
   );
 });
 
+test("rejects broad text evidence without a message-record ancestor", () => {
+  const composerDraft = { closest: () => null };
+  const root = {
+    querySelectorAll: () => [composerDraft],
+    contains: () => true,
+  };
+
+  assert.deepEqual(
+    findMessageContainers(
+      root as unknown as Element,
+      '[data-testid="msg-container"]',
+      ".message-in, .message-out",
+    ),
+    [],
+  );
+});
+
 test("reads text through the generic selector used for container discovery", () => {
   const genericText = { textContent: "Current WhatsApp message" };
   const container = {

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -93,9 +93,25 @@ test("reads text through the generic selector used for container discovery", () 
 
 test("normalizes a visual bubble to its enclosing WhatsApp message record", () => {
   const record = {};
-  const bubble = { closest: () => record };
+  const bubble = {
+    closest: (selector: string) =>
+      selector.includes("[data-id]") ? record : bubble,
+  };
 
   assert.equal(findMessageRecord(bubble as unknown as HTMLElement), record);
+});
+
+test("prefers an outer message record over a matching visual bubble", () => {
+  const outerRecord = {};
+  const bubble = {
+    closest: (selector: string) =>
+      selector.includes("[data-id]") ? outerRecord : bubble,
+  };
+
+  assert.equal(
+    findMessageRecord(bubble as unknown as HTMLElement),
+    outerRecord,
+  );
 });
 
 test("keeps the original visual bubble when detecting outgoing messages", () => {
@@ -125,10 +141,7 @@ test("discovers textless media and reply records alongside configured bubbles", 
   const mediaEvidence = { closest: () => mediaRecord };
   const replyEvidence = { closest: () => replyRecord };
   const root = {
-    querySelectorAll: (selector: string) => {
-      if (selector === ".configured, .fallback") return [directRecord];
-      return [mediaEvidence, replyEvidence];
-    },
+    querySelectorAll: () => [directRecord, mediaEvidence, replyEvidence],
     contains: () => true,
   };
 
@@ -139,6 +152,30 @@ test("discovers textless media and reply records alongside configured bubbles", 
       ".fallback",
     ),
     [directRecord, mediaRecord, replyRecord],
+  );
+});
+
+test("preserves DOM order across configured and evidence-only records", () => {
+  const firstRecord = { name: "first" };
+  const middleRecord = { name: "middle" };
+  const lastRecord = { name: "last" };
+  const candidates = [
+    { closest: () => firstRecord },
+    { closest: () => middleRecord },
+    { closest: () => lastRecord },
+  ];
+  const root = {
+    querySelectorAll: () => candidates,
+    contains: () => true,
+  };
+
+  assert.deepEqual(
+    findMessageContainers(
+      root as unknown as Element,
+      ".configured",
+      ".fallback",
+    ),
+    [firstRecord, middleRecord, lastRecord],
   );
 });
 
@@ -154,8 +191,7 @@ test("climbs past quoted media previews to the enclosing message record", () => 
       selector.includes("quoted-message") ? quotedPreview : quotedPreview,
   };
   const root = {
-    querySelectorAll: (selector: string) =>
-      selector === ".configured, .fallback" ? [] : [quotedMedia],
+    querySelectorAll: () => [quotedMedia],
     contains: () => true,
   };
 

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -9,7 +9,9 @@ import {
   findReplyTargetId,
   findSelfDisplayName,
   findMessageText,
+  hasCurrentMessageEvidence,
   MESSAGE_TEXT_SELECTOR,
+  resolveCapturedReplyTargets,
 } from "../src/dom-selectors.ts";
 
 test("registers the popup receiver before waiting for WhatsApp DOM readiness", () => {
@@ -140,6 +142,50 @@ test("discovers textless media and reply records alongside configured bubbles", 
   );
 });
 
+test("climbs past quoted media previews to the enclosing message record", () => {
+  const messageRecord = {};
+  const quotedPreview = {
+    parentElement: {
+      closest: () => messageRecord,
+    },
+  };
+  const quotedMedia = {
+    closest: (selector: string) =>
+      selector.includes("quoted-message") ? quotedPreview : quotedPreview,
+  };
+  const root = {
+    querySelectorAll: (selector: string) =>
+      selector === ".configured, .fallback" ? [] : [quotedMedia],
+    contains: () => true,
+  };
+
+  assert.deepEqual(
+    findMessageContainers(
+      root as unknown as Element,
+      ".configured",
+      ".fallback",
+    ),
+    [messageRecord],
+  );
+});
+
+test("does not classify quoted preview media as current-message evidence", () => {
+  const quotedPreview = {};
+  const quotedMedia = {
+    closest: (selector: string) =>
+      selector.includes("quoted-message") ? quotedPreview : null,
+  };
+  const record = {
+    matches: () => false,
+    querySelectorAll: () => [quotedMedia],
+  };
+
+  assert.equal(
+    hasCurrentMessageEvidence(record as unknown as Element, "video"),
+    false,
+  );
+});
+
 test("ignores quoted text while retaining emoji-only content and reply identity", () => {
   const quotedWrapper = {};
   const quotedText = { closest: () => quotedWrapper };
@@ -174,6 +220,29 @@ test("ignores quoted text while retaining emoji-only content and reply identity"
   );
   assert.equal(findMessageEmojiText(record as unknown as Element), "👍");
   assert.equal(findReplyTargetId(record as unknown as Element), "fixture-001");
+});
+
+test("maps captured reply targets to exported IDs without leaking unmatched raw IDs", () => {
+  const messages = [
+    { id: "generated-1", captureSourceId: "fixture-001" },
+    {
+      id: "generated-2",
+      captureSourceId: "fixture-002",
+      captureReplyToSourceId: "fixture-001",
+      replyTo: "stale-value",
+    },
+    {
+      id: "generated-3",
+      captureSourceId: "fixture-003",
+      captureReplyToSourceId: "not-captured",
+      replyTo: "stale-value",
+    },
+  ];
+
+  resolveCapturedReplyTargets(messages);
+
+  assert.equal(messages[1].replyTo, "generated-1");
+  assert.equal(messages[2].replyTo, undefined);
 });
 
 test("reads only a specifically scoped self profile display name", () => {

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -341,6 +341,24 @@ test("ignores quoted text while retaining emoji-only content and reply identity"
   assert.equal(findReplyTargetId(record as unknown as Element), "fixture-001");
 });
 
+test("excludes reaction chips from emoji-only message content", () => {
+  const messageEmoji = {
+    closest: () => null,
+    getAttribute: (name: string) => (name === "alt" ? "👍" : null),
+  };
+  const reactionContainer = {};
+  const reactionEmoji = {
+    closest: (selector: string) =>
+      selector.includes("reaction") ? reactionContainer : null,
+    getAttribute: (name: string) => (name === "alt" ? "❤️" : null),
+  };
+  const record = {
+    querySelectorAll: () => [messageEmoji, reactionEmoji],
+  };
+
+  assert.equal(findMessageEmojiText(record as unknown as Element), "👍");
+});
+
 test("maps captured reply targets to exported IDs without leaking unmatched raw IDs", () => {
   const messages = [
     { id: "generated-1", captureSourceId: "fixture-001" },

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import {
   findConversationRoot,
   findMessageContainers,
+  findMessageEmojiText,
   findMessageRecord,
+  findReplyTargetId,
+  findSelfDisplayName,
   findMessageText,
   MESSAGE_TEXT_SELECTOR,
 } from "../src/dom-selectors.ts";
@@ -72,8 +75,8 @@ test("reads text through the generic selector used for container discovery", () 
   const genericText = { textContent: "Current WhatsApp message" };
   const container = {
     matches: () => false,
-    querySelector: (selector: string) =>
-      selector === MESSAGE_TEXT_SELECTOR ? genericText : null,
+    querySelectorAll: (selector: string) =>
+      selector.includes(MESSAGE_TEXT_SELECTOR) ? [genericText] : [],
   };
 
   assert.equal(
@@ -110,5 +113,80 @@ test("keeps the original visual bubble when detecting outgoing messages", () => 
   assert.match(
     contentSource,
     /messageRecord\.querySelector\('\[data-testid="msg-out"\]'\)/,
+  );
+});
+
+test("discovers textless media and reply records alongside configured bubbles", () => {
+  const directRecord = { closest: () => directRecord };
+  const mediaRecord = {};
+  const replyRecord = {};
+  const mediaEvidence = { closest: () => mediaRecord };
+  const replyEvidence = { closest: () => replyRecord };
+  const root = {
+    querySelectorAll: (selector: string) => {
+      if (selector === ".configured, .fallback") return [directRecord];
+      return [mediaEvidence, replyEvidence];
+    },
+    contains: () => true,
+  };
+
+  assert.deepEqual(
+    findMessageContainers(
+      root as unknown as Element,
+      ".configured",
+      ".fallback",
+    ),
+    [directRecord, mediaRecord, replyRecord],
+  );
+});
+
+test("ignores quoted text while retaining emoji-only content and reply identity", () => {
+  const quotedWrapper = {};
+  const quotedText = { closest: () => quotedWrapper };
+  const emoji = {
+    closest: () => null,
+    getAttribute: (name: string) => (name === "alt" ? "👍" : null),
+  };
+  const quoted = {
+    getAttribute: (name: string) =>
+      name === "data-quoted-message-id" ? "fixture-001" : null,
+  };
+  const record = {
+    matches: () => false,
+    querySelectorAll: (selector: string) =>
+      selector.includes("msg-text")
+        ? [quotedText]
+        : selector.includes("emoji")
+          ? [emoji]
+          : [],
+    querySelector: () => quoted,
+    getAttribute: (name: string) =>
+      name === "data-id" ? "fixture-current" : null,
+  };
+
+  assert.equal(
+    findMessageText(
+      record as unknown as Element,
+      "[data-testid=msg-text]",
+      ".text",
+    ),
+    null,
+  );
+  assert.equal(findMessageEmojiText(record as unknown as Element), "👍");
+  assert.equal(findReplyTargetId(record as unknown as Element), "fixture-001");
+});
+
+test("reads only a specifically scoped self profile display name", () => {
+  const profileImage = {
+    getAttribute: (name: string) => (name === "alt" ? "Fixture Owner" : null),
+  };
+  const root = {
+    querySelector: (selector: string) =>
+      selector === '[aria-label="Profile"] img[alt]' ? profileImage : null,
+  };
+
+  assert.equal(
+    findSelfDisplayName(root as unknown as ParentNode),
+    "Fixture Owner",
   );
 });

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -11,6 +11,7 @@ import {
   findSelfDisplayName,
   findMessageText,
   hasCurrentMessageEvidence,
+  MESSAGE_RECORD_EVIDENCE_SELECTOR,
   MESSAGE_TEXT_SELECTOR,
   resolveCapturedReplyTargets,
 } from "../src/dom-selectors.ts";
@@ -68,6 +69,21 @@ test("falls back to #main for a media-only loaded window", () => {
     ),
     main,
   );
+});
+
+test("discovers every media fallback supported by classification", () => {
+  for (const selector of [
+    '[data-icon="audio-play"]',
+    '[data-icon="document"]',
+    'img[alt="Sticker"]',
+    ".message-video",
+    ".message-audio",
+    ".message-document",
+    ".message-image",
+    '[data-testid="media-state-icon"]',
+  ]) {
+    assert.ok(MESSAGE_RECORD_EVIDENCE_SELECTOR.includes(selector), selector);
+  }
 });
 
 test("derives unique message records from selectable text when bubble selectors change", () => {

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -108,6 +108,29 @@ test("reads text through the generic selector used for container discovery", () 
   );
 });
 
+test("prefers configured message text over earlier generic preview text", () => {
+  const previewText = { textContent: "Preview" };
+  const messageText = { textContent: "Current message" };
+  const container = {
+    matches: () => false,
+    querySelectorAll: (selector: string) =>
+      selector === '[data-testid="msg-text"]'
+        ? [messageText]
+        : selector.includes("selectable-text")
+          ? [previewText]
+          : [],
+  };
+
+  assert.equal(
+    findMessageText(
+      container as unknown as Element,
+      '[data-testid="msg-text"]',
+      ".configured-fallback",
+    ),
+    messageText,
+  );
+});
+
 test("normalizes a visual bubble to its enclosing WhatsApp message record", () => {
   const record = {};
   const bubble = {

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -6,6 +6,7 @@ import {
   findMessageContainers,
   findMessageEmojiText,
   findMessageRecord,
+  findMessageSender,
   findReplyTargetId,
   findSelfDisplayName,
   findMessageText,
@@ -34,6 +35,26 @@ test("falls back to the active #main conversation when WhatsApp removes its mess
   const main = {
     querySelector: (selector: string) =>
       selector.includes("selectable-text") ? message : null,
+  };
+  const documentRoot = {
+    querySelector: (selector: string) => (selector === "#main" ? main : null),
+  };
+
+  assert.equal(
+    findConversationRoot(
+      documentRoot as unknown as ParentNode,
+      '[data-testid="conversation-panel-messages"]',
+      ".message-list",
+    ),
+    main,
+  );
+});
+
+test("falls back to #main for a media-only loaded window", () => {
+  const media = {};
+  const main = {
+    querySelector: (selector: string) =>
+      selector.includes("image-content") ? media : null,
   };
   const documentRoot = {
     querySelector: (selector: string) => (selector === "#main" ? main : null),
@@ -128,6 +149,28 @@ test("prefers configured message text over earlier generic preview text", () => 
       ".configured-fallback",
     ),
     messageText,
+  );
+});
+
+test("prefers the configured sender over an earlier generic preview author", () => {
+  const previewAuthor = { textContent: "Preview author" };
+  const messageSender = { textContent: "Message sender" };
+  const container = {
+    querySelectorAll: (selector: string) =>
+      selector === '[data-testid="msg-sender"]'
+        ? [messageSender]
+        : selector.includes("message-author")
+          ? [previewAuthor]
+          : [],
+  };
+
+  assert.equal(
+    findMessageSender(
+      container as unknown as Element,
+      '[data-testid="msg-sender"]',
+      ".configured-sender-fallback",
+    ),
+    messageSender,
   );
 });
 

--- a/apps/chrome-extension/tests/dom-selectors.test.ts
+++ b/apps/chrome-extension/tests/dom-selectors.test.ts
@@ -229,7 +229,7 @@ test("keeps the original visual bubble when detecting outgoing messages", () => 
   );
   assert.match(
     contentSource,
-    /messageRecord\.querySelector\('\[data-testid="msg-out"\]'\)/,
+    /messageRecord\.querySelector\('\[data-testid="msg-out"\], \.message-out'\)/,
   );
 });
 

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -20,7 +20,7 @@ const read = (path: string) =>
 test("keeps release versions aligned and package inspection mandatory", () => {
   const manifest = JSON.parse(read("../manifest.json"));
   const packageJson = JSON.parse(read("../package.json"));
-  assert.equal(manifest.version, "1.0.22");
+  assert.equal(manifest.version, "1.0.23");
   assert.equal(packageJson.version, manifest.version);
   assert.deepEqual(manifest.content_scripts[0], {
     matches: ["https://web.whatsapp.com/*"],

--- a/apps/chrome-extension/tests/popup-runtime.test.ts
+++ b/apps/chrome-extension/tests/popup-runtime.test.ts
@@ -24,7 +24,7 @@ test("renders the runtime manifest version and keeps release versions aligned", 
     /extensionVersion\.textContent = `v\$\{chrome\.runtime\.getManifest\(\)\.version\}`/,
   );
   assert.equal(manifest.version, packageJson.version);
-  assert.equal(manifest.version, "1.0.22");
+  assert.equal(manifest.version, "1.0.23");
 });
 
 test("opens the conversation dashboard from both popup entry points", () => {


### PR DESCRIPTION
## What changed

- discover WhatsApp message records from text, metadata, reply, emoji, and media evidence instead of returning after partial container matches
- keep emoji-only messages, classify current media-only structures, exclude quoted text from current-message content, and carry stable quoted-message IDs when WhatsApp exposes them
- combine incoming display names with message-scoped phone evidence
- resolve outgoing self labels from message metadata or the explicitly scoped WhatsApp profile control before falling back to `You`
- keep quoted sender evidence isolated from the current sender
- bump the extension to `1.0.23`

## Root cause

The extractor's fallback discovery was text-node-only, sender selectors were narrower than current WhatsApp structures, replies were declared but never populated, and outgoing messages were hardcoded to `You`. That caused identity loss for textless media, emoji, and reply records and discarded available self display names.

## Privacy and behavior

Identity evidence remains limited to the selected message record and the signed-in user's visible profile control. The change does not scan the address book, merge people by name, or persist new raw queues. Quoted-message sender evidence is deliberately excluded from current-sender attribution.

## Validation

- extension typecheck
- 156 extension unit tests passed
- 7 headed Chromium extension fixture tests passed, covering emoji-only, media-only, replies, incoming display names and phones, self display name, and quoted-sender isolation
- Prettier check and `git diff --check`
- extension `1.0.23` package verified: 14 expected payloads with matching sizes and CRCs, no duplicates or unsafe paths