### PR TITLE
feat: route grounded catch-ups through Sluice

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,6 +53,16 @@ jobs:
             fi
           done
 
+      - name: Verify Governed AI Configuration
+        env:
+          SLUICE_API_KEY: ${{ secrets.SLUICE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SLUICE_API_KEY" ]; then
+            echo "Error: the restricted SLUICE_API_KEY production secret is required for grounded catch-ups." >&2
+            exit 1
+          fi
+
       - name: Azure Login
         uses: azure/login@v2
         with:
@@ -232,6 +242,7 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
         run: |
@@ -300,6 +311,7 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -76,7 +76,14 @@ FRONTEND_URL=http://localhost:3000
 # ===========================================
 # AI Services
 # ===========================================
-# Provider priority: Azure > OpenAI > Anthropic > Mock
+# Grounded conversation catch-ups route through Sluice. Do not configure a
+# direct provider fallback for this workflow: Sluice owns provider credentials,
+# model routing, budgets, and telemetry.
+# SLUICE_BASE_URL=https://litellm.sluice.phoenixvc.tech
+# SLUICE_API_KEY=sk-...
+# SLUICE_MODEL=convolens-catch-up-v1
+
+# Legacy summary services may still use the provider-specific settings below.
 
 # Azure AI Foundry (Azure OpenAI) - RECOMMENDED FOR ENTERPRISE
 # Get credentials from: https://portal.azure.com -> Azure AI Foundry

--- a/apps/api/src/services/ai/__tests__/catch-up-generator.service.test.ts
+++ b/apps/api/src/services/ai/__tests__/catch-up-generator.service.test.ts
@@ -1,8 +1,20 @@
 import {
+  AiCatchUpGenerator,
   buildCatchUpPrompt,
   normalizeCatchUpDraft,
   type CatchUpSourceMessage,
 } from '../catch-up-generator.service';
+
+const sluiceEnvKeys = [
+  'SLUICE_BASE_URL',
+  'SLUICE_API_KEY',
+  'SLUICE_MODEL',
+  'AZURE_OPENAI_ENDPOINT',
+  'AZURE_OPENAI_API_KEY',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+] as const;
+const originalFetch = global.fetch;
 
 const messages: CatchUpSourceMessage[] = [
   {
@@ -20,6 +32,12 @@ const messages: CatchUpSourceMessage[] = [
 ];
 
 describe('catch-up generator grounding', () => {
+  afterEach(() => {
+    for (const key of sluiceEnvKeys) delete process.env[key];
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
   it('serializes source messages as data with stable evidence refs', () => {
     const prompt = buildCatchUpPrompt(messages);
     expect(prompt).toContain('"ref":"M1"');
@@ -55,5 +73,87 @@ describe('catch-up generator grounding', () => {
     expect(() =>
       normalizeCatchUpDraft({ overview: '', overviewEvidence: ['M1'] }, messages)
     ).toThrow('AI response did not include an overview');
+  });
+
+  it('is configured only when both Sluice endpoint and virtual key are present', () => {
+    const generator = new AiCatchUpGenerator();
+    process.env.SLUICE_BASE_URL = 'https://litellm.sluice.example';
+    expect(generator.getProviderInfo()).toEqual({
+      provider: 'unconfigured',
+      configured: false,
+      model: undefined,
+    });
+
+    process.env.SLUICE_API_KEY = 'test-virtual-key';
+    expect(generator.getProviderInfo()).toEqual({
+      provider: 'sluice',
+      configured: true,
+      model: 'convolens-catch-up-v1',
+    });
+  });
+
+  it('does not bypass Sluice when direct provider credentials are present', () => {
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://direct-provider.example';
+    process.env.AZURE_OPENAI_API_KEY = 'direct-provider-key';
+    process.env.OPENAI_API_KEY = 'direct-openai-key';
+    process.env.ANTHROPIC_API_KEY = 'direct-anthropic-key';
+
+    expect(new AiCatchUpGenerator().getProviderInfo()).toEqual({
+      provider: 'unconfigured',
+      configured: false,
+      model: undefined,
+    });
+  });
+
+  it('routes grounded generation through the governed Sluice capability alias', async () => {
+    process.env.SLUICE_BASE_URL = 'https://litellm.sluice.example/';
+    process.env.SLUICE_API_KEY = 'test-virtual-key';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                overview: 'A revised deck is due Friday.',
+                overviewEvidence: ['M2'],
+                keyTopics: [],
+                decisions: [],
+                actionItems: [
+                  {
+                    text: 'Send the revised deck',
+                    owner: 'Thabo',
+                    due: 'Friday',
+                    evidence: ['M2'],
+                  },
+                ],
+                openQuestions: [],
+              }),
+            },
+          },
+        ],
+      }),
+    } as Partial<Response>) as jest.Mock;
+
+    const result = await new AiCatchUpGenerator().generate(messages);
+
+    expect(result).toMatchObject({ provider: 'sluice', model: 'convolens-catch-up-v1' });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://litellm.sluice.example/v1/chat/completions');
+    expect(options.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-virtual-key',
+    });
+    const body = JSON.parse(String(options.body));
+    expect(body.model).toBe('convolens-catch-up-v1');
+    expect(body.metadata).toMatchObject({
+      app: 'convolens',
+      agent: 'catch-up-generator',
+      workflow: 'conversation-catch-up',
+      stage: 'summary-chunk',
+    });
+    expect(body.metadata.request_id).toEqual(expect.any(String));
+    expect(JSON.stringify(body.metadata)).not.toContain('Thabo');
   });
 });

--- a/apps/api/src/services/ai/catch-up-generator.service.ts
+++ b/apps/api/src/services/ai/catch-up-generator.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { logger } from '../../utils/logger';
 import type {
   ConversationSummaryContent,
@@ -15,7 +16,7 @@ export interface CatchUpSourceMessage {
 
 export interface CatchUpGenerationResult {
   content: ConversationSummaryContent;
-  provider: 'azure' | 'openai' | 'anthropic';
+  provider: 'sluice';
   model: string;
 }
 
@@ -44,18 +45,27 @@ const REQUEST_TIMEOUT_MS = 45_000;
 const MAX_CHUNK_CHARACTERS = 28_000;
 const MAX_TOTAL_CHARACTERS = 168_000;
 const MAX_ITEMS_PER_SECTION = 8;
+const DEFAULT_SLUICE_MODEL = 'convolens-catch-up-v1';
 
-function activeProvider(): CatchUpGenerationResult['provider'] | null {
-  if (process.env.AZURE_OPENAI_ENDPOINT && process.env.AZURE_OPENAI_API_KEY) return 'azure';
-  if (process.env.OPENAI_API_KEY) return 'openai';
-  if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
-  return null;
+interface SluiceConfig {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
 }
 
-function activeModel(provider: CatchUpGenerationResult['provider']): string {
-  if (provider === 'azure') return process.env.AZURE_OPENAI_DEPLOYMENT || 'gpt-4';
-  if (provider === 'openai') return process.env.OPENAI_MODEL || 'gpt-4-turbo-preview';
-  return process.env.ANTHROPIC_MODEL || 'claude-3-sonnet-20240229';
+function activeSluiceConfig(): SluiceConfig | null {
+  const baseUrl = process.env.SLUICE_BASE_URL?.trim().replace(/\/$/, '');
+  const apiKey = process.env.SLUICE_API_KEY?.trim();
+  if (!baseUrl || !apiKey) return null;
+  return {
+    apiKey,
+    baseUrl,
+    model: process.env.SLUICE_MODEL?.trim() || DEFAULT_SLUICE_MODEL,
+  };
+}
+
+function chatCompletionsUrl(baseUrl: string): string {
+  return `${baseUrl}${baseUrl.endsWith('/v1') ? '' : '/v1'}/chat/completions`;
 }
 
 function formatSourceMessage(message: CatchUpSourceMessage): string {
@@ -257,93 +267,77 @@ async function fetchWithTimeout(url: string, options: RequestInit): Promise<Resp
 }
 
 async function requestCompletion(
-  provider: CatchUpGenerationResult['provider'],
-  prompt: string
+  config: SluiceConfig,
+  prompt: string,
+  stage: 'summary-chunk' | 'summary-consolidation'
 ): Promise<string> {
-  const model = activeModel(provider);
-  if (provider === 'anthropic') {
-    const response = await fetchWithTimeout('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': process.env.ANTHROPIC_API_KEY!,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 2_000,
-        temperature: 0.2,
-        system: systemPrompt(),
-        messages: [{ role: 'user', content: prompt }],
-      }),
-    });
-    if (!response.ok) throw new Error(`Anthropic request failed (${response.status})`);
-    const data = await response.json();
-    return data.content?.[0]?.text || '';
-  }
-
-  const isAzure = provider === 'azure';
-  const endpoint = isAzure
-    ? `${process.env.AZURE_OPENAI_ENDPOINT!.replace(/\/$/, '')}/openai/deployments/${encodeURIComponent(model)}/chat/completions${process.env.AZURE_OPENAI_API_VERSION ? `?api-version=${encodeURIComponent(process.env.AZURE_OPENAI_API_VERSION)}` : ''}`
-    : 'https://api.openai.com/v1/chat/completions';
-  const response = await fetchWithTimeout(endpoint, {
+  const response = await fetchWithTimeout(chatCompletionsUrl(config.baseUrl), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(isAzure
-        ? { 'api-key': process.env.AZURE_OPENAI_API_KEY! }
-        : { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` }),
+      Authorization: `Bearer ${config.apiKey}`,
     },
     body: JSON.stringify({
-      ...(!isAzure ? { model } : {}),
+      model: config.model,
       messages: [
         { role: 'system', content: systemPrompt() },
         { role: 'user', content: prompt },
       ],
       max_tokens: 2_000,
       temperature: 0.2,
+      metadata: {
+        app: 'convolens',
+        agent: 'catch-up-generator',
+        workflow: 'conversation-catch-up',
+        stage,
+        request_id: randomUUID(),
+      },
     }),
   });
-  if (!response.ok)
-    throw new Error(`${isAzure ? 'Azure OpenAI' : 'OpenAI'} request failed (${response.status})`);
+  if (!response.ok) throw new Error(`Sluice request failed (${response.status})`);
   const data = await response.json();
   return data.choices?.[0]?.message?.content || '';
 }
 
 export class AiCatchUpGenerator implements CatchUpGenerator {
   getProviderInfo() {
-    const provider = activeProvider();
+    const config = activeSluiceConfig();
     return {
-      provider: provider || 'unconfigured',
-      configured: Boolean(provider),
-      model: provider ? activeModel(provider) : undefined,
+      provider: config ? 'sluice' : 'unconfigured',
+      configured: Boolean(config),
+      model: config?.model,
     };
   }
 
   async generate(messages: CatchUpSourceMessage[]): Promise<CatchUpGenerationResult> {
-    const provider = activeProvider();
-    if (!provider) throw new Error('AI_PROVIDER_NOT_CONFIGURED');
+    const config = activeSluiceConfig();
+    if (!config) throw new Error('AI_PROVIDER_NOT_CONFIGURED');
     if (messages.length === 0) throw new Error('NO_MESSAGES_TO_SUMMARIZE');
 
     const chunks = splitIntoChunks(messages);
     logger.info('[CatchUpGenerator] Generating grounded summary', {
-      provider,
+      provider: 'sluice',
+      model: config.model,
       messageCount: messages.length,
       chunkCount: chunks.length,
     });
     const partials: ConversationSummaryContent[] = [];
     for (const chunk of chunks) {
-      const response = await requestCompletion(provider, buildCatchUpPrompt(chunk));
+      const response = await requestCompletion(config, buildCatchUpPrompt(chunk), 'summary-chunk');
       partials.push(normalizeCatchUpDraft(extractJson(response), chunk));
     }
 
     let content = partials[0];
     if (partials.length > 1) {
-      const response = await requestCompletion(provider, consolidationPrompt(partials));
+      const response = await requestCompletion(
+        config,
+        consolidationPrompt(partials),
+        'summary-consolidation'
+      );
       content = normalizeCatchUpDraft(extractJson(response), messages);
     }
     content.importantLinks = extractImportantLinks(messages);
-    return { content, provider, model: activeModel(provider) };
+    return { content, provider: 'sluice', model: config.model };
   }
 }
 

--- a/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
+++ b/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
@@ -60,7 +60,9 @@ worktrees:
 
 The Sluice change is published for review as
 [phoenixvc/sluice#153](https://github.com/phoenixvc/sluice/pull/153). It must
-land and deploy before the ConvoLens change can be deployed.
+land and deploy before the dependent ConvoLens change in
+[neuralliquid/convolens#175](https://github.com/neuralliquid/convolens/pull/175)
+can be deployed.
 
 The Sluice slice declares `convolens-catch-up-v1`, a `convolens` virtual key
 limited to that capability, bounded spend/rate limits, and global suppression

--- a/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
+++ b/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
@@ -75,7 +75,8 @@ from grounded catch-up generation. It requires `SLUICE_BASE_URL` plus the
 restricted `SLUICE_API_KEY`, sends only bounded attribution metadata with an
 opaque request ID, and fails closed with `AI_PROVIDER_NOT_CONFIGURED` otherwise.
 Production Terraform stores the key in `nl-prod-convolens-kv` as
-`sluice-api-key` and exposes it through a Container App secret reference.
+`sluice-api-key` and exposes it through a Container App secret reference
+using the pre-authorized `nl-prod-convolens-api-secrets` user-assigned identity.
 
 Local evidence for this unmerged slice:
 

--- a/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
+++ b/docs/HANDOFF-2026-08-03-PERSONAL-TODOS.md
@@ -42,11 +42,63 @@ The demo labels Email and Discord evidence as synthetic context. It does not cla
 
 All five checklist items on implementation task `0f46847f-575d-4e95-9219-322bdc3cf484` are complete and that task is done.
 
+## Foundry-through-Sluice continuation
+
+The approved architecture is now:
+
+```text
+ConvoLens API -> Sluice capability alias -> Azure AI Foundry
+```
+
+The implementation is prepared but not yet merged or deployed in two clean
+worktrees:
+
+- Sluice: `C:\tmp\sluice-convolens-catch-up`, branch
+  `agent/convolens-catch-up`;
+- ConvoLens: `C:\tmp\convolens-personal-todos-acceptance`, branch
+  `agent/personal-todos-production-acceptance`.
+
+The Sluice change is published for review as
+[phoenixvc/sluice#153](https://github.com/phoenixvc/sluice/pull/153). It must
+land and deploy before the ConvoLens change can be deployed.
+
+The Sluice slice declares `convolens-catch-up-v1`, a `convolens` virtual key
+limited to that capability, bounded spend/rate limits, and global suppression
+of prompt/response content in callbacks and OpenTelemetry. The alias initially
+uses Sluice's existing Azure OpenAI deployment; ConvoLens does not receive a
+Foundry/provider credential or select an upstream model.
+
+The ConvoLens slice removes direct Azure OpenAI, OpenAI, and Anthropic fallback
+from grounded catch-up generation. It requires `SLUICE_BASE_URL` plus the
+restricted `SLUICE_API_KEY`, sends only bounded attribution metadata with an
+opaque request ID, and fails closed with `AI_PROVIDER_NOT_CONFIGURED` otherwise.
+Production Terraform stores the key in `nl-prod-convolens-kv` as
+`sluice-api-key` and exposes it through a Container App secret reference.
+
+Local evidence for this unmerged slice:
+
+- Sluice Terraform validation: passed;
+- Sluice virtual-key manifest parse and unique restricted alias check: passed;
+- ConvoLens production Terraform validation: passed;
+- catch-up generator suite: 6 tests passed;
+- neighboring conversation-summary persistence suite: 2 tests passed;
+- ConvoLens API production bundle: passed;
+- focused source lint excluding the repository's unresolved missing
+  `import/order` rule registration: passed;
+- full API `tsc --noEmit` remains red for pre-existing controller/entity typing
+  errors outside this slice; no reported error referenced a modified file.
+
 ## Current boundary
 
 No deployment was performed for PR #173. CI, a production build, and the synthetic browser demo do not prove the authenticated production workflow.
 
-Production summarization configuration is a confirmed blocker. `activeProvider()` in `apps/api/src/services/ai/catch-up-generator.service.ts` requires either both `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`. The tracked production Container App in `infra/terraform/env/prod/main.tf` currently provisions none of them. Deploying the current Terraform unchanged would leave catch-up generation unavailable with `AI_PROVIDER_NOT_CONFIGURED` even if health probes pass.
+Production summarization remains blocked until the two prepared changes land in
+dependency order. Sluice must first deploy the capability alias and payload
+privacy settings. A separately authorized operator must then reconcile
+`scripts/keys.yaml`, capture the newly issued `vkey-convolens` without logging
+it, and store it as the ConvoLens Production environment secret
+`SLUICE_API_KEY`. Only then can the ConvoLens change be deployed. Deploying
+ConvoLens first fails closed with `AI_PROVIDER_NOT_CONFIGURED`.
 
 The following remain unverified for this merged build:
 
@@ -66,13 +118,21 @@ Do not use fabricated accounts, export or reuse session material, record convers
 
 1. Recheck live `origin/main`, PR #173, Baton task `263ca89a-6c9d-4a74-a137-48dfc888b2e3`, deployment state, and the primary checkout before acting.
 2. Work in a clean isolated worktree from current `origin/main`; preserve unrelated primary-checkout state.
-3. Resolve the summarization-provider blocker before deployment acceptance: select an approved provider, provision its secret through the governed Key Vault/Terraform path, bind only the required Container App environment variables, and validate that no secret enters Git, logs, plans, or handoff evidence. This provider choice and secret write require explicit authorization.
-4. Obtain fresh explicit deployment authorization. Deploy only the exact intended `main` commit and verify build identity, API/web health, provider readiness, and relevant configuration independently. A healthy API with `AI_PROVIDER_NOT_CONFIGURED` is not feature readiness.
-5. With a legitimate operator session and an authorized test conversation, generate grounded drafts and verify refresh persistence plus exact catch-up/message navigation.
-6. Verify user isolation and edit, dismiss, return-to-review, and deletion before any publication history exists.
-7. Obtain separate exact authorization for one production Baton write. Confirm the reviewed draft, publish once, then verify retry/reload produces exactly one task and preserves the backlink.
-8. Record opaque IDs, timestamps, build identity, and outcomes only. Do not record tokens, cookies, participant names, conversation text, or stable WhatsApp identifiers.
-9. Update the successor task checklist and add a repository-backed closeout. Do not close it from deployment health alone.
+3. Merge and deploy the reviewed Sluice change first. Verify the rendered
+   capability alias, payload-logging suppression, health, and unauthenticated
+   `401` boundary without making a billable provider call.
+4. Obtain separate exact authorization to reconcile the Sluice manifest and
+   create `vkey-convolens`. Store it immediately as the ConvoLens Production
+   environment secret `SLUICE_API_KEY`; never record the value.
+5. Merge the ConvoLens change, obtain fresh explicit deployment authorization,
+   and deploy only the exact intended `main` commit. Verify build identity,
+   API/web health, Sluice configuration, and provider readiness independently.
+   A healthy API with `AI_PROVIDER_NOT_CONFIGURED` is not feature readiness.
+6. With a legitimate operator session and an authorized test conversation, generate grounded drafts and verify refresh persistence plus exact catch-up/message navigation.
+7. Verify user isolation and edit, dismiss, return-to-review, and deletion before any publication history exists.
+8. Obtain separate exact authorization for one production Baton write. Confirm the reviewed draft, publish once, then verify retry/reload produces exactly one task and preserves the backlink.
+9. Record opaque IDs, timestamps, build identity, and outcomes only. Do not record tokens, cookies, participant names, conversation text, or stable WhatsApp identifiers.
+10. Update the successor task checklist and add a repository-backed closeout. Do not close it from deployment health alone.
 
 ## Copy-paste restart
 
@@ -93,4 +153,7 @@ Then read this file and Baton task `263ca89a-6c9d-4a74-a137-48dfc888b2e3` before
 
 ## Workspace note
 
-The stale primary checkout at `C:\Users\smitj\repos\convolens` and its unrelated untracked handoff file were preserved. Implementation and this handoff were prepared in the isolated worktree `C:\tmp\convolens-catch-up`.
+The primary checkout at `C:\Users\smitj\repos\convolens` and its unrelated
+work were preserved. This continuation was implemented in the isolated
+ConvoLens worktree `C:\tmp\convolens-personal-todos-acceptance`; the paired
+Sluice change was prepared in `C:\tmp\sluice-convolens-catch-up`.

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -12,6 +12,7 @@ locals {
   postgres_name        = "${local.prefix}-pg"
   cae_name             = "${local.prefix}-cae"
   api_name             = "${local.prefix}-api"
+  api_secrets_name     = "${local.prefix}-api-secrets"
   service_plan_name    = "${local.prefix}-asp"
   frontend_name        = "${local.prefix}-web"
   acr_name             = substr("${local.alphanumeric}acr", 0, 50)
@@ -216,6 +217,19 @@ resource "azurerm_container_app_environment" "cae" {
   tags                       = local.tags
 }
 
+resource "azurerm_user_assigned_identity" "api_secrets" {
+  name                = local.api_secrets_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "api_secrets_key_vault_secrets_user" {
+  scope                = azurerm_key_vault.kv.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.api_secrets.principal_id
+}
+
 resource "azurerm_container_app" "api" {
   name                         = local.api_name
   container_app_environment_id = azurerm_container_app_environment.cae.id
@@ -224,7 +238,8 @@ resource "azurerm_container_app" "api" {
   tags                         = local.tags
 
   identity {
-    type = "SystemAssigned"
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.api_secrets.id]
   }
 
   secret {
@@ -245,8 +260,10 @@ resource "azurerm_container_app" "api" {
   secret {
     name                = "sluice-api-key"
     key_vault_secret_id = azurerm_key_vault_secret.sluice_api_key.versionless_id
-    identity            = "System"
+    identity            = azurerm_user_assigned_identity.api_secrets.id
   }
+
+  depends_on = [azurerm_role_assignment.api_secrets_key_vault_secrets_user]
 
   dynamic "secret" {
     for_each = var.enable_container_registry ? [azurerm_container_registry.acr[0]] : []

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -190,6 +190,12 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
   key_vault_id = azurerm_key_vault.kv.id
 }
 
+resource "azurerm_key_vault_secret" "sluice_api_key" {
+  name         = "sluice-api-key"
+  value        = var.sluice_api_key
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
 resource "azurerm_container_registry" "acr" {
   count                         = var.enable_container_registry ? 1 : 0
   name                          = local.acr_name
@@ -234,6 +240,12 @@ resource "azurerm_container_app" "api" {
   secret {
     name  = "jwt-secret"
     value = var.api_jwt_secret
+  }
+
+  secret {
+    name                = "sluice-api-key"
+    key_vault_secret_id = azurerm_key_vault_secret.sluice_api_key.versionless_id
+    identity            = "System"
   }
 
   dynamic "secret" {
@@ -372,6 +384,18 @@ resource "azurerm_container_app" "api" {
       env {
         name  = "AZURE_PROVIDER_ENABLED"
         value = "true"
+      }
+      env {
+        name  = "SLUICE_BASE_URL"
+        value = var.sluice_base_url
+      }
+      env {
+        name        = "SLUICE_API_KEY"
+        secret_name = "sluice-api-key"
+      }
+      env {
+        name  = "SLUICE_MODEL"
+        value = var.sluice_model
       }
       env {
         name  = "BATON_BASE_URL"

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -97,6 +97,39 @@ variable "api_jwt_secret" {
   }
 }
 
+variable "sluice_base_url" {
+  type        = string
+  description = "Canonical Sluice LiteLLM gateway URL used for governed AI requests."
+  default     = "https://litellm.sluice.phoenixvc.tech"
+
+  validation {
+    condition     = startswith(var.sluice_base_url, "https://")
+    error_message = "sluice_base_url must use HTTPS."
+  }
+}
+
+variable "sluice_api_key" {
+  type        = string
+  description = "Restricted ConvoLens Sluice virtual key."
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.sluice_api_key)) > 0
+    error_message = "sluice_api_key must be configured for grounded catch-ups."
+  }
+}
+
+variable "sluice_model" {
+  type        = string
+  description = "Sluice-owned capability alias for grounded conversation catch-ups."
+  default     = "convolens-catch-up-v1"
+
+  validation {
+    condition     = var.sluice_model == "convolens-catch-up-v1"
+    error_message = "Production catch-ups must use the governed convolens-catch-up-v1 alias."
+  }
+}
+
 variable "frontend_runtime_stack" {
   type        = string
   description = "Linux App Service runtime stack for the Next.js frontend."


### PR DESCRIPTION
## Description

Routes grounded conversation catch-up generation exclusively through Sluice using the stable `convolens-catch-up-v1` capability alias. Direct Azure OpenAI, OpenAI, and Anthropic fallback is removed for this workflow.

Production Terraform stores the restricted virtual key in Key Vault and binds it to the API Container App. The deploy workflow fails closed until the GitHub Production environment has `SLUICE_API_KEY`. No live key was created and nothing was deployed.

Dependency: phoenixvc/sluice#153 must merge and deploy before this PR is deployed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] Catch-up generator Jest suite: 6 passed
- [x] Neighboring conversation-summary persistence suite: 2 passed
- [x] API production bundle
- [x] Production Terraform validate and fmt check
- [x] Focused source lint, Prettier, and `git diff --check`

The repository-wide API `tsc --noEmit` remains red on pre-existing errors outside the modified files. The normal ESLint config also references an unregistered pre-existing `import/order` rule; the modified source passes with that missing rule disabled.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new source warnings
- [x] I have added tests that prove the routing boundary
- [x] New and neighboring focused unit tests pass locally
- [ ] The dependent Sluice change has been merged and deployed

## Additional Notes:

This PR is intentionally not a deployment or authentic-production acceptance. After both PRs are reviewed, the order is: deploy Sluice; separately authorize and reconcile `vkey-convolens`; store it directly as the ConvoLens Production secret; then separately authorize the ConvoLens deployment and staffed acceptance.