### PR TITLE
test(api): replace timer-based race window in tombstone deletion test

### DIFF
--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -398,7 +398,16 @@ describe('ConversationIntakeService', () => {
     const uploadStarted = new Promise<void>((resolvePromise) => {
       reportUploadStarted = resolvePromise;
     });
-    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    // deleteForUser only reaches storage.deleteFile after it has committed the
+    // 'deleting' tombstone, so the first call is a durable signal that the late
+    // upload is now guaranteed to lose its compare-and-swap.
+    let reportCleanupStarted!: () => void;
+    const cleanupStarted = new Promise<void>((resolvePromise) => {
+      reportCleanupStarted = resolvePromise;
+    });
+    const deleteFile = jest.fn().mockImplementation(async () => {
+      reportCleanupStarted();
+    });
     const storage = {
       uploadFile: jest.fn(async () => {
         reportUploadStarted();
@@ -423,7 +432,9 @@ describe('ConversationIntakeService', () => {
       ),
     });
     const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+    // Racing the deletion itself keeps this from hanging if cleanup ever stops
+    // touching storage; either way the tombstone is committed before we release.
+    await Promise.race([cleanupStarted, deletion.catch(() => undefined)]);
     releaseUpload();
 
     expect(await deletion).toBe(true);


### PR DESCRIPTION
## Problem

`ConversationIntakeService › tombstones deletion so a concurrent late upload cleans itself up` opened its race window with a fixed sleep:

```ts
const deletion = artifactService.deleteForUser(...);
await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
releaseUpload();
```

The assertion requires the `'deleting'` tombstone to be committed **before** the late upload runs its compare-and-swap on `rawArtifactStatus: 'pending'`. If the 10 ms elapses first, the CAS succeeds, the upload resolves instead of rejecting, and the test fails:

```
expect(received).rejects.toThrow()
Received promise resolved instead of rejected
```

It failed exactly that way once during a loaded full-suite run on 2026-08-06 (surfaced while validating #176).

## Fix

Wait on the ordering the test actually depends on instead of on wall-clock time.

`deleteForUser` only reaches `storage.deleteFile` after the CAS that writes the tombstone has affected a row — so the first `deleteFile` call is a durable happens-after signal for "the tombstone is committed". The mock now resolves a promise on first invocation, and the test awaits that before releasing the upload.

The wait is raced against the deletion promise, so if cleanup ever stops touching storage the test fails fast rather than hanging.

Both accepted rejection paths still hold: losing the CAS yields `deletion started`, and losing it after the row is already gone yields `Could not find any entity`. The existing regex covers both.

**No production code changes** — test file only, 13 insertions / 2 deletions.

## Verification

- 5/5 targeted runs, idle machine
- 3/3 targeted runs under saturating load on all 16 cores
- full API suite: 16/16 suites, 165/165 tests

One honest caveat on the diagnosis: I could not force the *original* test to fail on demand under synthetic load — it passed 2/2 before the harness cut the run short. So the reproduction rests on the single observed real failure plus the mechanism, which is legible in the source. The fix is sound regardless of reproduction rate, because it removes the timing dependency entirely rather than widening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
