### PR TITLE
test(api): gate tombstone deletion race on the committed write

### DIFF
--- a/apps/api/src/services/__tests__/conversation-intake.service.test.ts
+++ b/apps/api/src/services/__tests__/conversation-intake.service.test.ts
@@ -408,6 +408,7 @@ describe('ConversationIntakeService', () => {
     } as unknown as StorageService;
     const artifactService = new ConversationIntakeService(dataSource, storage);
     const saved = await artifactService.save(baseInput);
+    const repository = dataSource.getRepository(ConversationIntake);
 
     const persistence = artifactService.ensureRawArtifact(saved.conversation, baseInput.userId, {
       body: '{"late":true}',
@@ -417,17 +418,44 @@ describe('ConversationIntakeService', () => {
       /deletion started|Could not find any entity/
     );
     await uploadStarted;
-    await dataSource.getRepository(ConversationIntake).update(saved.conversation.id, {
+    await repository.update(saved.conversation.id, {
       rawArtifactClaimedAt: new Date(
         Date.now() - AZURE_UPLOAD_TOTAL_TIMEOUT_MS - RAW_ARTIFACT_DELETE_GRACE_MS
       ),
     });
-    const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
-    releaseUpload();
 
-    expect(await deletion).toBe(true);
-    await persistenceAssertion;
+    // The late upload may only be released once the tombstone is committed and
+    // readable: release it earlier and the upload's finalize CAS still matches
+    // the pending claim, so the race under test never happens. Gating on the
+    // committed write keeps that ordering independent of machine load.
+    const update = repository.update.bind(repository);
+    let reportTombstoned!: () => void;
+    const tombstoned = new Promise<void>((resolvePromise) => {
+      reportTombstoned = resolvePromise;
+    });
+    const updateSpy = jest
+      .spyOn(repository, 'update')
+      .mockImplementation(async (criteria, partialEntity) => {
+        const result = await update(criteria, partialEntity);
+        const nextStatus = (partialEntity as { rawArtifactStatus?: unknown }).rawArtifactStatus;
+        if (nextStatus === 'deleting' && result.affected === 1) {
+          reportTombstoned();
+        }
+        return result;
+      });
+
+    try {
+      const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
+      // Racing against the deletion surfaces its own failure instead of hanging
+      // on a tombstone that never lands.
+      await Promise.race([tombstoned, deletion]);
+      releaseUpload();
+
+      expect(await deletion).toBe(true);
+      await persistenceAssertion;
+    } finally {
+      updateSpy.mockRestore();
+    }
     expect(deleteFile).toHaveBeenCalledTimes(2);
     expect(deleteFile.mock.calls[1][0]).toBe(deleteFile.mock.calls[0][0]);
     expect(await artifactService.getForUser(baseInput.userId, saved.conversation.id)).toBeNull();


### PR DESCRIPTION
## Problem

`ConversationIntakeService › tombstones deletion so a concurrent late upload cleans itself up` is load-sensitive and fails intermittently.

The race window was opened with a hard-coded sleep:

```ts
const deletion = artifactService.deleteForUser(baseInput.userId, saved.conversation.id);
await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
releaseUpload();
```

The intent is to let `deleteForUser` get far enough to write the tombstone before the gated upload is released, so `ensureRawArtifact` rejects. Under CPU load the 10ms elapses before the tombstone is visible, the upload's finalize CAS still matches the pending claim, the persistence promise resolves instead of rejecting, and the rejection assertion fails.

Observed 2026-08-06: failed once during a full-suite run on a loaded machine, then passed 3/3 in isolation and 16/16 on a clean full-suite re-run. A genuine flake, not a regression.

## Fix

Deterministic, not a bigger timer. `deleteForUser` sets `rawArtifactStatus: 'deleting'` in exactly one place (the CAS in `conversation-intake.service.ts`), so the test spies on the shared `ConversationIntake` repository's `update`, delegates to the real implementation, and opens the gate only when a `deleting` write comes back with `affected === 1`. The upload is released after that, so the finalize CAS can never win regardless of scheduling.

Three details:

- **Gate on the committed result, not the invocation.** Signalling on call would reintroduce a smaller version of the same race. Requiring `affected === 1` also stops a losing attempt in the CAS retry loop from opening the gate early.
- **`Promise.race([tombstoned, deletion])` rather than a bare await.** If `deleteForUser` ever fails before tombstoning, its real error surfaces instead of the test hanging to the 10s jest timeout.
- **The spy is restored in a `finally`.** `tests/setup.ts` only calls `jest.clearAllMocks()`, which does not undo a `mockImplementation`, and the later `retries the tombstone CAS when another replica wins a claim first` test spies on the same repository instance — a leak would corrupt it.

No production code changed.

## Verification

All runs with 16 spinning `node` processes saturating every core — the condition that broke the timer.

- Targeted test (`-t "tombstones deletion"`): **10/10 passed**
- Whole file: **5/5 passed**, 49 tests each — confirms no spy leakage into the later test
- **Mutation check**: with the gate replaced by an immediate `releaseUpload()`, the test fails at the rejection assertion — the same failure mode originally reported. The gate makes it deterministic without making it vacuous.
- Test file typechecks clean

## Pre-existing, not touched

Confirmed identical on the unmodified tree:

- `metrics`, `circuit-breaker`, and `deduplication` suites fail to run with a jest `moduleNameMapper` configuration error
- `tsc` reports two `TS2345` errors in `apps/api/src/services/conversation-intake.service.ts` (lines 1048 and 1076)

🤖 Generated with [Claude Code](https://claude.com/claude-code)