### PR TITLE
ci: cover metrics, circuit breaker and dedup suites; fix intake CAS types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
           src/services/__tests__/storage-managed-identity.test.ts
           src/services/__tests__/auth.service.test.ts
           src/services/__tests__/mystira-auth.service.test.ts
+          src/services/__tests__/metrics.service.test.ts
+          src/services/__tests__/circuit-breaker.service.test.ts
+          src/services/__tests__/deduplication.service.test.ts
           src/db/migrations/__tests__/conversation-intake.migration.test.ts
           src/routes/__tests__/chat-export.routes.test.ts
           src/routes/__tests__/extension.routes.test.ts

--- a/apps/api/src/services/conversation-intake.service.ts
+++ b/apps/api/src/services/conversation-intake.service.ts
@@ -1036,7 +1036,10 @@ export class ConversationIntakeService {
     for (let attempt = 0; attempt < 10; attempt += 1) {
       const candidate = await repository.findOneBy({ id, userId });
       if (!candidate) return false;
-      if (candidate.batonPublishClaimId) {
+      // Bound to a const so the truthy check still narrows inside the transaction
+      // callback, where narrowing of a property read would otherwise be lost.
+      const batonPublishClaimId = candidate.batonPublishClaimId;
+      if (batonPublishClaimId) {
         const claimActive =
           candidate.batonPublishClaimedAt &&
           candidate.batonPublishClaimedAt.getTime() > Date.now() - BATON_PUBLISH_LEASE_MS;
@@ -1049,7 +1052,7 @@ export class ConversationIntakeService {
               id,
               userId,
               rawArtifactStatus: candidate.rawArtifactStatus,
-              batonPublishClaimId: candidate.batonPublishClaimId,
+              batonPublishClaimId,
               batonPublishClaimedAt: candidate.batonPublishClaimedAt || IsNull(),
             },
             { batonPublishClaimId: null, batonPublishClaimedAt: null }
@@ -1069,7 +1072,11 @@ export class ConversationIntakeService {
             })
             .orderBy('attempt.createdAt', 'DESC')
             .getOne();
-          if (!strandedBoundary) return { cleared: true, reanchored: false };
+          // The query filters errorCode to two literals, so a null one is
+          // unreachable. Folding it into the guard keeps the CAS typed without
+          // widening the where clause, and returns exactly what a no-match
+          // update would have returned anyway.
+          if (!strandedBoundary?.errorCode) return { cleared: true, reanchored: false };
           const reanchored = await manager
             .getRepository(BatonPublishAttempt)
             .update(


### PR DESCRIPTION
Follow-up to #179, covering the loose ends noted there.

## 1. Three suites CI never ran

`metrics.service.test.ts`, `circuit-breaker.service.test.ts` and `deduplication.service.test.ts` are not referenced by the `Test API conversation intake` step, which lists its test files explicitly. That is 65 tests running only on developer machines. They pass today; adding them to the existing step keeps them from rotting unnoticed.

## 2. Two type errors in `deleteForUser`

Both were TypeScript losing narrowing, not runtime faults, so this is a no-op at runtime:

- `candidate.batonPublishClaimId` is guarded truthy, but the narrowing did not survive into the `dataSource.transaction` callback. Binding it to a const before the guard restores it.
- `strandedBoundary.errorCode` is typed `string | null` while the query filters `errorCode IN ('baton_create_started', 'baton_ambiguous')`. Folding the null case into the existing guard returns `{ cleared: true, reanchored: false }` — exactly what the no-match update would have produced — rather than widening the where clause with `IsNull()`, which would have flipped that branch.

## Verification

Run with CI's own jest invocation, not a local variant:

- All 11 suites in the updated CI step pass — **138 tests**
- `pnpm --filter @convolens/api run build` succeeds
- Project-wide type errors drop from 42 to 40

## Correction to what I reported on #179

I claimed on #179 that these three suites "fail to run with a jest `moduleNameMapper` configuration error". That was wrong. It was an artefact of running jest with `NODE_OPTIONS=--experimental-vm-modules`, which nothing in this repo sets. With that flag the `.ts` files are treated as ESM, where `jest.mock` cannot intercept imports; without it ts-jest transpiles to CJS and everything works. The suites were never broken. Only the missing CI coverage was real.

## Still outstanding

`tsc --noEmit` remains at 40 errors, so the API does not typecheck as a whole. CI does not catch this because it runs `pnpm run build` (tsup/esbuild, no typecheck) rather than `tsc`. The bulk are `strictPropertyInitialization` on entities — `User.ts` (10), `Group.ts` (9), `Message.ts` (9) — plus legacy `src/api/*` express handler typing (9). Worth its own pass; deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)