### PR TITLE
feat(ai): route model traffic through the Sluice gateway

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -78,6 +78,15 @@ FRONTEND_URL=http://localhost:3000
 # ===========================================
 # Provider priority: Azure > OpenAI > Anthropic > Mock
 
+# Sluice AI Gateway - PREFERRED FOR ALL DEPLOYED ENVIRONMENTS
+# The org gateway. Routing through it is what makes this service's model spend
+# attributable; direct-provider calls below are billed with no record of which
+# service incurred them. Takes priority over every other provider when set.
+# Ask for a virtual key rather than reusing another service's.
+# SLUICE_BASE_URL=https://litellm.sluice.phoenixvc.tech
+# SLUICE_API_KEY=sk-...
+# SLUICE_MODEL=default                  # A logical route; Sluice resolves it
+
 # Azure AI Foundry (Azure OpenAI) - RECOMMENDED FOR ENTERPRISE
 # Get credentials from: https://portal.azure.com -> Azure AI Foundry
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com

--- a/apps/api/src/services/ai/catch-up-generator.service.ts
+++ b/apps/api/src/services/ai/catch-up-generator.service.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../utils/logger';
+import { SLUICE_APP } from './summary.service';
 import type {
   ConversationSummaryContent,
   SummaryActionItem,
@@ -315,7 +316,7 @@ async function requestCompletion(
       temperature: 0.2,
       // Required by Sluice ADR 10 — without it this call records as `(none)`
       // and its cost cannot be traced back to ConvoLens.
-      ...(isSluice ? { metadata: { app: 'convolens', agent: 'catch-up-generator' } } : {}),
+      ...(isSluice ? { metadata: { app: SLUICE_APP, agent: 'catch-up-generator' } } : {}),
     }),
   });
   if (!response.ok)

--- a/apps/api/src/services/ai/catch-up-generator.service.ts
+++ b/apps/api/src/services/ai/catch-up-generator.service.ts
@@ -15,7 +15,7 @@ export interface CatchUpSourceMessage {
 
 export interface CatchUpGenerationResult {
   content: ConversationSummaryContent;
-  provider: 'azure' | 'openai' | 'anthropic';
+  provider: 'sluice' | 'azure' | 'openai' | 'anthropic';
   model: string;
 }
 
@@ -46,6 +46,9 @@ const MAX_TOTAL_CHARACTERS = 168_000;
 const MAX_ITEMS_PER_SECTION = 8;
 
 function activeProvider(): CatchUpGenerationResult['provider'] | null {
+  // Sluice first: it is the only path on which this service's spend is
+  // attributable. See Sluice ADR 10.
+  if (process.env.SLUICE_BASE_URL && process.env.SLUICE_API_KEY) return 'sluice';
   if (process.env.AZURE_OPENAI_ENDPOINT && process.env.AZURE_OPENAI_API_KEY) return 'azure';
   if (process.env.OPENAI_API_KEY) return 'openai';
   if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
@@ -53,6 +56,8 @@ function activeProvider(): CatchUpGenerationResult['provider'] | null {
 }
 
 function activeModel(provider: CatchUpGenerationResult['provider']): string {
+  // A logical route, not a provider model name — Sluice resolves it.
+  if (provider === 'sluice') return process.env.SLUICE_MODEL || 'default';
   if (provider === 'azure') return process.env.AZURE_OPENAI_DEPLOYMENT || 'gpt-4';
   if (provider === 'openai') return process.env.OPENAI_MODEL || 'gpt-4-turbo-preview';
   return process.env.ANTHROPIC_MODEL || 'claude-3-sonnet-20240229';
@@ -283,18 +288,24 @@ async function requestCompletion(
   }
 
   const isAzure = provider === 'azure';
-  const endpoint = isAzure
-    ? `${process.env.AZURE_OPENAI_ENDPOINT!.replace(/\/$/, '')}/openai/deployments/${encodeURIComponent(model)}/chat/completions${process.env.AZURE_OPENAI_API_VERSION ? `?api-version=${encodeURIComponent(process.env.AZURE_OPENAI_API_VERSION)}` : ''}`
-    : 'https://api.openai.com/v1/chat/completions';
+  const isSluice = provider === 'sluice';
+  const endpoint = isSluice
+    ? `${process.env.SLUICE_BASE_URL!.replace(/\/$/, '')}/v1/chat/completions`
+    : isAzure
+      ? `${process.env.AZURE_OPENAI_ENDPOINT!.replace(/\/$/, '')}/openai/deployments/${encodeURIComponent(model)}/chat/completions${process.env.AZURE_OPENAI_API_VERSION ? `?api-version=${encodeURIComponent(process.env.AZURE_OPENAI_API_VERSION)}` : ''}`
+      : 'https://api.openai.com/v1/chat/completions';
   const response = await fetchWithTimeout(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(isAzure
-        ? { 'api-key': process.env.AZURE_OPENAI_API_KEY! }
-        : { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` }),
+      ...(isSluice
+        ? { Authorization: `Bearer ${process.env.SLUICE_API_KEY}` }
+        : isAzure
+          ? { 'api-key': process.env.AZURE_OPENAI_API_KEY! }
+          : { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` }),
     },
     body: JSON.stringify({
+      // Azure carries the deployment in the URL; Sluice and OpenAI take a model.
       ...(!isAzure ? { model } : {}),
       messages: [
         { role: 'system', content: systemPrompt() },
@@ -302,10 +313,15 @@ async function requestCompletion(
       ],
       max_tokens: 2_000,
       temperature: 0.2,
+      // Required by Sluice ADR 10 — without it this call records as `(none)`
+      // and its cost cannot be traced back to ConvoLens.
+      ...(isSluice ? { metadata: { app: 'convolens', agent: 'catch-up-generator' } } : {}),
     }),
   });
   if (!response.ok)
-    throw new Error(`${isAzure ? 'Azure OpenAI' : 'OpenAI'} request failed (${response.status})`);
+    throw new Error(
+      `${isSluice ? 'Sluice' : isAzure ? 'Azure OpenAI' : 'OpenAI'} request failed (${response.status})`
+    );
   const data = await response.json();
   return data.choices?.[0]?.message?.content || '';
 }

--- a/apps/api/src/services/ai/summary.service.ts
+++ b/apps/api/src/services/ai/summary.service.ts
@@ -104,7 +104,7 @@ export interface StreamCallback {
  * Untagged requests roll up at the gateway under `(none)` and cannot be
  * attributed back here, which defeats the purpose of routing through it.
  */
-const SLUICE_APP = 'convolens';
+export const SLUICE_APP = 'convolens';
 
 // AI Provider Configuration
 const AI_CONFIG = {

--- a/apps/api/src/services/ai/summary.service.ts
+++ b/apps/api/src/services/ai/summary.service.ts
@@ -4,15 +4,23 @@
  * FEATURE-1: AI-Powered Summary Generation
  *
  * This service provides chat summarization using multiple AI providers:
+ * - Sluice (the org AI gateway — preferred)
  * - Azure AI Foundry (Azure OpenAI Service)
  * - OpenAI API (Direct)
  * - Anthropic Claude API
  *
  * Provider Selection Priority:
- * 1. Azure AI Foundry (if AZURE_OPENAI_ENDPOINT configured)
- * 2. OpenAI (if OPENAI_API_KEY configured)
- * 3. Anthropic (if ANTHROPIC_API_KEY configured)
- * 4. Mock (fallback for development)
+ * 1. Sluice (if SLUICE_BASE_URL configured)
+ * 2. Azure AI Foundry (if AZURE_OPENAI_ENDPOINT configured)
+ * 3. OpenAI (if OPENAI_API_KEY configured)
+ * 4. Anthropic (if ANTHROPIC_API_KEY configured)
+ * 5. Mock (fallback for development)
+ *
+ * Sluice is preferred because it is the only path on which this service's model
+ * spend is attributable. Direct-provider calls are billed to a shared provider
+ * account with no record of which service or feature incurred them, so they are
+ * invisible to org cost reporting. The direct providers are retained as a
+ * fallback for local development and as a migration shim.
  *
  * Integration Points:
  * - Connects to Azure OpenAI, OpenAI API, or Anthropic Claude API
@@ -62,6 +70,8 @@ export interface SummaryOptions {
   };
 }
 
+export type AIProvider = 'sluice' | 'azure' | 'openai' | 'anthropic' | 'mock';
+
 export interface SummaryResult {
   summary: string;
   keyTopics?: string[];
@@ -73,7 +83,7 @@ export interface SummaryResult {
   sentiment?: 'positive' | 'neutral' | 'negative';
   generatedAt: Date;
   tokensUsed?: number;
-  provider: 'azure' | 'openai' | 'anthropic' | 'mock';
+  provider: AIProvider;
 }
 
 export interface StreamCallback {
@@ -82,8 +92,27 @@ export interface StreamCallback {
   onError?: (error: Error) => void;
 }
 
+/**
+ * Identifies this application to the Sluice gateway.
+ *
+ * Per Sluice ADR 10 (Request Metadata Contract), every request carries
+ * `metadata.app` and `metadata.agent` so gateway spend can be attributed to the
+ * calling service and the specific feature within it. Values are lowercase
+ * kebab-case and stable across deploys — each distinct value becomes its own
+ * Prometheus time series, so they must not embed versions or free-form input.
+ *
+ * Untagged requests roll up at the gateway under `(none)` and cannot be
+ * attributed back here, which defeats the purpose of routing through it.
+ */
+const SLUICE_APP = 'convolens';
+
 // AI Provider Configuration
 const AI_CONFIG = {
+  sluice: {
+    baseUrl: process.env.SLUICE_BASE_URL,
+    apiKey: process.env.SLUICE_API_KEY,
+    model: process.env.SLUICE_MODEL || 'default',
+  },
   azure: {
     endpoint: process.env.AZURE_OPENAI_ENDPOINT, // e.g., https://your-resource.openai.azure.com
     apiKey: process.env.AZURE_OPENAI_API_KEY,
@@ -113,9 +142,10 @@ const RETRY_CONFIG = {
 
 /**
  * Determines which AI provider to use based on configuration
- * Priority: Azure > OpenAI > Anthropic > Mock
+ * Priority: Sluice > Azure > OpenAI > Anthropic > Mock
  */
-function getActiveProvider(): 'azure' | 'openai' | 'anthropic' | 'mock' {
+function getActiveProvider(): AIProvider {
+  if (AI_CONFIG.sluice.baseUrl && AI_CONFIG.sluice.apiKey) return 'sluice';
   if (AI_CONFIG.azure.endpoint && AI_CONFIG.azure.apiKey) return 'azure';
   if (AI_CONFIG.openai.apiKey) return 'openai';
   if (AI_CONFIG.anthropic.apiKey) return 'anthropic';
@@ -222,13 +252,25 @@ function formatMessagesForAI(messages: ChatMessage[]): string {
  * Main Summary Service Class
  */
 export class SummaryService {
-  private provider: 'azure' | 'openai' | 'anthropic' | 'mock';
+  private provider: AIProvider;
 
   constructor() {
     this.provider = getActiveProvider();
     logger.info(`[SummaryService] Using AI provider: ${this.provider}`);
 
     // Log provider configuration (without secrets)
+    if (this.provider === 'sluice') {
+      logger.info(`[SummaryService] Sluice endpoint: ${AI_CONFIG.sluice.baseUrl}`);
+      logger.info(`[SummaryService] Sluice model route: ${AI_CONFIG.sluice.model}`);
+    } else {
+      // Surfaced at warn because direct-provider spend is not attributable to
+      // ConvoLens in org cost reporting. Expected locally; not in deployed envs.
+      logger.warn(
+        `[SummaryService] Not routing through Sluice (provider=${this.provider}). ` +
+          'Model spend on this path is unattributed. Set SLUICE_BASE_URL and SLUICE_API_KEY.'
+      );
+    }
+
     if (this.provider === 'azure') {
       logger.info(`[SummaryService] Azure endpoint: ${AI_CONFIG.azure.endpoint}`);
       logger.info(`[SummaryService] Azure deployment: ${AI_CONFIG.azure.deploymentName}`);
@@ -242,7 +284,12 @@ export class SummaryService {
     return {
       provider: this.provider,
       configured: this.provider !== 'mock',
-      endpoint: this.provider === 'azure' ? AI_CONFIG.azure.endpoint : undefined,
+      endpoint:
+        this.provider === 'sluice'
+          ? AI_CONFIG.sluice.baseUrl
+          : this.provider === 'azure'
+            ? AI_CONFIG.azure.endpoint
+            : undefined,
     };
   }
 
@@ -282,6 +329,9 @@ export class SummaryService {
       let result: SummaryResult;
 
       switch (this.provider) {
+        case 'sluice':
+          result = await withRetry(() => this.generateWithSluice(filteredMessages, options));
+          break;
         case 'azure':
           result = await withRetry(() => this.generateWithAzure(filteredMessages, options));
           break;
@@ -404,7 +454,68 @@ export class SummaryService {
   }
 
   /**
-   * OpenAI API Integration (Direct)
+   * Sluice Gateway Integration (preferred)
+   *
+   * Sluice is OpenAI-compatible, so the request shape matches the direct OpenAI
+   * path apart from the `metadata` block that ADR 10 requires for cost
+   * attribution. Model routing, provider fallback, rate limiting and spend caps
+   * are the gateway's concern, not ours — hence the logical `default` model
+   * rather than a hardcoded provider model name.
+   */
+  private async generateWithSluice(
+    messages: ChatMessage[],
+    options: SummaryOptions
+  ): Promise<SummaryResult> {
+    const systemPrompt = buildSystemPrompt(options);
+    const chatContent = formatMessagesForAI(messages);
+
+    const response = await fetchWithTimeout(
+      `${AI_CONFIG.sluice.baseUrl!.replace(/\/$/, '')}/v1/chat/completions`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${AI_CONFIG.sluice.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: AI_CONFIG.sluice.model,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: `Please summarize this conversation:\n\n${chatContent}` },
+          ],
+          max_tokens: options.maxLength || 1000,
+          temperature: 0.7,
+          // Required by Sluice ADR 10. Without it this call is recorded as
+          // `(none)` and its cost cannot be traced back to ConvoLens.
+          metadata: {
+            app: SLUICE_APP,
+            agent: 'summarizer',
+          },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Sluice API error: ${error}`);
+    }
+
+    const data = await response.json();
+    const summary = data.choices[0]?.message?.content || 'Unable to generate summary';
+
+    return {
+      summary,
+      generatedAt: new Date(),
+      tokensUsed: data.usage?.total_tokens,
+      provider: 'sluice',
+    };
+  }
+
+  /**
+   * OpenAI API Integration (direct)
+   *
+   * Retained as a fallback. Spend on this path is not attributable to
+   * ConvoLens — prefer Sluice.
    */
   private async generateWithOpenAI(
     messages: ChatMessage[],


### PR DESCRIPTION
First of three services onboarded following the egress audit. ConvoLens called Azure OpenAI, OpenAI and Anthropic directly, so its model spend was billed to shared provider accounts with **no record of which service incurred it**.

It is also named **adopter #3** in Sluice [ADR 10](https://github.com/phoenixvc/sluice/blob/dev/docs/architecture/10-request-metadata-contract.md) (as `whatssummarize`) — a contract accepted in May 2026 that was never adopted here.

## What changed

Sluice becomes the top-priority provider in both AI services. It's OpenAI-compatible, so the request shape is unchanged apart from the metadata block ADR 10 requires:

```ts
metadata: { app: 'convolens', agent: 'summarizer' }          // summary.service.ts
metadata: { app: 'convolens', agent: 'catch-up-generator' }  // catch-up-generator.service.ts
```

Without that block the call records at the gateway as `(none)` and can't be traced back here — which would defeat the point of routing through it.

**`agent` is per-service, not one shared value.** Collapsing both into `convolens` would leave the per-agent rollup ADR 10 is built for with nothing to group by.

**Model is a logical route (`default`)**, not a provider model name. Routing, fallback, rate limiting and spend caps are the gateway's job.

## Fallback behaviour

Direct providers are retained for local development and as a migration shim, but selecting one now logs a **warning** — unattributed spend is expected on a laptop and is not expected in a deployed environment. It's a warning rather than an error precisely so local work doesn't break.

## Sequencing

[sluice#155](https://github.com/phoenixvc/sluice/pull/155) (ADR 17) will make these fields **mandatory**, rejecting untagged requests with 400. This tagging is a prerequisite for that, not an optional nicety.

Deploy config needs `SLUICE_BASE_URL` and `SLUICE_API_KEY` — **request a ConvoLens-specific virtual key** rather than reusing another service's, or attribution collapses back into one bucket at the key level.

## Verification

- `tsc --noEmit` clean
- **165 tests across 16 suites pass**
- `.env.example` documents the new vars with the attribution rationale

Baton: `96b2e444`. Remaining: mystira-workspace (6 services, .NET), codeflow-engine (5 providers, Python).