### PR TITLE
Point prod at the shared PostgreSQL server and resolve secrets from Key Vault

### DIFF
--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -190,6 +190,16 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
   key_vault_id = azurerm_key_vault.kv.id
 }
 
+# The container app resolves jwt-secret from the vault rather than holding the
+# literal, so this needs to exist there. The value still originates from CI
+# (TF_VAR_api_jwt_secret) — the vault becomes the distribution point, not a new
+# source of truth.
+resource "azurerm_key_vault_secret" "api_jwt_secret" {
+  name         = "api-jwt-secret"
+  value        = var.api_jwt_secret
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
 resource "azurerm_container_registry" "acr" {
   count                         = var.enable_container_registry ? 1 : 0
   name                          = local.acr_name
@@ -221,19 +231,30 @@ resource "azurerm_container_app" "api" {
     type = "SystemAssigned"
   }
 
+  # Secrets are Key Vault references, not literals. The vault is the single place
+  # a value is rotated; previously the same secret lived both here and in the
+  # vault, so rotation meant changing it twice and the vault was authoritative
+  # for nothing. Resolution uses the system-assigned identity, which already
+  # holds Key Vault Secrets User via azurerm_role_assignment.api_key_vault_secrets_user.
   secret {
-    name  = "appinsights-connection-string"
-    value = azurerm_application_insights.ai.connection_string
+    name                = "appinsights-connection-string"
+    key_vault_secret_id = azurerm_key_vault_secret.appinsights_connection_string.versionless_id
+    identity            = "System"
+  }
+
+  # The scoped role's password on the shared server. This secret was created out
+  # of band during the migration, so it is referenced by URI: managing it here
+  # would mean Terraform holding the value in state to no benefit.
+  secret {
+    name                = "db-password"
+    key_vault_secret_id = "${azurerm_key_vault.kv.vault_uri}secrets/${var.shared_postgres_password_secret_name}"
+    identity            = "System"
   }
 
   secret {
-    name  = "db-password"
-    value = random_password.postgres_admin.result
-  }
-
-  secret {
-    name  = "jwt-secret"
-    value = var.api_jwt_secret
+    name                = "jwt-secret"
+    key_vault_secret_id = azurerm_key_vault_secret.api_jwt_secret.versionless_id
+    identity            = "System"
   }
 
   dynamic "secret" {
@@ -323,11 +344,15 @@ resource "azurerm_container_app" "api" {
       }
       env {
         name  = "DB_TYPE"
-        value = var.enable_postgres ? "postgres" : "sqlite"
+        value = "postgres"
       }
+      # The shared server, not azurerm_postgresql_flexible_server.postgres. That
+      # resource is the pre-migration server and is retained only as the rollback
+      # path; pointing the app back at it would undo the 2026-08-06 migration and
+      # reconnect as a server administrator.
       env {
         name  = "DB_HOST"
-        value = var.enable_postgres ? azurerm_postgresql_flexible_server.postgres[0].fqdn : ""
+        value = var.shared_postgres_fqdn
       }
       env {
         name  = "DB_PORT"
@@ -335,7 +360,7 @@ resource "azurerm_container_app" "api" {
       }
       env {
         name  = "DB_USERNAME"
-        value = var.postgres_admin_login
+        value = var.shared_postgres_username
       }
       env {
         name        = "DB_PASSWORD"
@@ -343,15 +368,15 @@ resource "azurerm_container_app" "api" {
       }
       env {
         name  = "DB_NAME"
-        value = var.enable_postgres ? azurerm_postgresql_flexible_server_database.app[0].name : var.database_name
+        value = var.shared_postgres_database
       }
       env {
         name  = "DB_SSL"
-        value = var.enable_postgres ? "true" : "false"
+        value = "true"
       }
       env {
         name  = "DB_MIGRATIONS_RUN"
-        value = var.enable_postgres ? "true" : "false"
+        value = "true"
       }
       env {
         name  = "DATABASE_PATH"

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -45,9 +45,37 @@ variable "database_name" {
 
 variable "postgres_admin_login" {
   type        = string
-  description = "PostgreSQL administrator login. The password is generated and stored in Key Vault."
+  description = "Administrator login for the legacy nl-prod-convolens-pg server. Retained for the rollback path only; the application no longer connects as this role."
   default     = "convolensadmin"
   sensitive   = true
+}
+
+# The application moved to the org-owned shared server on 2026-08-06. See
+# neuralliquid-org/docs/adr/0002-shared-data-plane-ownership.md. The server is
+# owned by neuralliquid-org Terraform; convolens owns its database, role and
+# schema, and the settings below describe how to reach it.
+variable "shared_postgres_fqdn" {
+  type        = string
+  description = "Host of the org-owned shared PostgreSQL server."
+  default     = "nl-prod-shared-pg.postgres.database.azure.com"
+}
+
+variable "shared_postgres_username" {
+  type        = string
+  description = "Scoped login role that owns the convolens database. Not a server administrator, and holds no rights on any other tenant's objects."
+  default     = "convolens"
+}
+
+variable "shared_postgres_database" {
+  type        = string
+  description = "Database name on the shared server."
+  default     = "convolens"
+}
+
+variable "shared_postgres_password_secret_name" {
+  type        = string
+  description = "Key Vault secret holding the password for shared_postgres_username. Created out of band during the migration, so it is referenced by URI rather than managed here — Terraform never reads the value."
+  default     = "shared-pg-convolens-password"
 }
 
 variable "postgres_sku_name" {


### PR DESCRIPTION
Found while auditing which secrets the container app actually consumes, during the org-level work to codify `nl-prod-shared-pg`.

## The landmine

Convolens was migrated onto the org-owned `nl-prod-shared-pg` on 2026-08-06 and cut over **by hand** â€” `DB_HOST`, `DB_USERNAME`, and a rotated `db-password`. The Terraform was never updated.

| Setting | Live today | What `terraform apply` would set |
|---|---|---|
| `DB_HOST` | `nl-prod-shared-pg.postgres.database.azure.com` | `azurerm_postgresql_flexible_server.postgres[0].fqdn` â†’ **`nl-prod-convolens-pg`** |
| `DB_USERNAME` | `convolens` (scoped role) | `var.postgres_admin_login` â†’ **`convolensadmin`** (server admin) |
| `db-password` | shared-server role password | `random_password.postgres_admin.result` â†’ **old server's admin password** |

So a prod apply would point the application back at the pre-migration server, reconnecting as a server administrator. `revision_mode = "Single"`, so that replaces the running revision. The prod apply is `workflow_dispatch`-only, which is the only reason it hasn't already fired.

The app now targets the shared server through explicit `shared_postgres_*` variables. `azurerm_postgresql_flexible_server.postgres` is **deliberately left in place** â€” it is the documented rollback path, and deleting it is a separate decision. `DB_TYPE`, `DB_SSL` and `DB_MIGRATIONS_RUN` no longer key off `enable_postgres`, because the app is on Postgres regardless of whether this stack still provisions a server.

## The Key Vault was authoritative for nothing

The container app held `appinsights-connection-string`, `db-password` and `jwt-secret` as literal values, while the vault stored overlapping copies with `keyVaultUrl: null` on every one. Rotating a secret meant changing it in two places â€” which is exactly how the shared server's admin password ended up in the wrong vault in the first place.

Those three are now `key_vault_secret_id` references resolved by the system-assigned identity, which **already** held `Key Vault Secrets User` via `azurerm_role_assignment.api_key_vault_secrets_user`. No new grant was needed.

- `jwt-secret` needed a vault secret to point at. Its value still originates from CI, so the vault becomes the distribution point, not a new source of truth.
- `db-password` references `shared-pg-convolens-password` **by URI** rather than as a managed resource, so Terraform never reads the value into state.
- `acr-password` stays inline. It is a registry pull credential, and a vault round-trip adds a failure mode at image pull for no rotation benefit.

## Verified against state

My earlier note said this could not be planned. That was wrong — it was an Azure account-context problem, not a missing backend. With the subscription passed explicitly, `nl-tfstate-rg` / `nltfstateconvolens` resolve fine and the prod state is reachable.

**On `main`, a prod plan produces exactly the revert described above:**

```
~ env {
      name  = "DB_HOST"
    ~ value = "nl-prod-shared-pg.postgres.database.azure.com" -> "nl-prod-convolens-pg.postgres.database.azure.com"
  }
```

**On this branch, that diff is gone.** `DB_HOST` no longer appears as a change at all, and `DB_USERNAME` reports *"the value is unchanged"* — the config now describes the live shared-server configuration rather than fighting it.

The remaining plan is `1 to add, 2 to change, 0 to destroy`: the new `api-jwt-secret` vault secret, the container app's secret blocks becoming Key Vault references, and a sensitivity-only change on `DB_USERNAME` (it is no longer derived from the sensitive `postgres_admin_login`).

Both plans were run with the same overrides CI uses — the live image digest and `api_target_port`. One caveat when reproducing locally: without `TF_VAR_mystira_identity_client_id` set, the plan also shows `MYSTIRA_IDENTITY_CLIENT_ID` being removed. That is an artifact of running outside CI, which supplies it from secrets, and is not part of this change.

## Related

- [neuralliquid-org#5](https://github.com/neuralliquid/neuralliquid-org/pull/5) â€” the shared server is now org-owned Terraform, with ADR 0002 setting the ownership line at the database boundary
- [house-of-veritas#184](https://github.com/neuralliquid/house-of-veritas/pull/184) â€” the other tenant

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
