### PR TITLE
fix(ci): give the prod apply job the variables it needs

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -264,8 +264,46 @@ jobs:
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} state rm azurerm_key_vault_access_policy.deployer || true
           terraform -chdir=infra/terraform/env/${{ matrix.environment }} import -input=false azurerm_key_vault_access_policy.deployer "$POLICY_ID"
 
+      # Mirrors the plan job. Without it the apply resolves container_image_api
+      # from terraform.tfvars, which holds a placeholder — so a "successful"
+      # apply would replace the production API with a hello-world container.
+      - name: Resolve Current Production API Runtime
+        id: prod-api
+        if: matrix.environment == 'prod'
+        run: |
+          set -euo pipefail
+          DEFAULT_IMAGE="mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+          CURRENT_IMAGE=$(az containerapp show             --resource-group nl-prod-convolens-rg             --name nl-prod-convolens-api             --query 'properties.template.containers[0].image'             -o tsv 2>/dev/null || true)
+          CURRENT_PORT=$(az containerapp show             --resource-group nl-prod-convolens-rg             --name nl-prod-convolens-api             --query 'properties.configuration.ingress.targetPort'             -o tsv 2>/dev/null || true)
+          if [ -z "$CURRENT_IMAGE" ]; then
+            CURRENT_IMAGE="$DEFAULT_IMAGE"
+          fi
+          if [ "$CURRENT_IMAGE" = "$DEFAULT_IMAGE" ] || [ -z "$CURRENT_PORT" ]; then
+            CURRENT_PORT="80"
+          fi
+          echo "image=$CURRENT_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "target-port=$CURRENT_PORT" >> "$GITHUB_OUTPUT"
+
+      # These are the same variables the plan job sets. The apply job had none of
+      # them, so it failed outright on api_jwt_secret, which has no default — and
+      # anything it did not fail on it would have silently reset, because an unset
+      # TF_VAR resolves to an empty value rather than to the current one.
       - name: Terraform Apply
-        run: terraform -chdir=infra/terraform/env/${{ matrix.environment }} apply -auto-approve
+        env:
+          TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
+          TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
+          TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
+        run: |
+          set -euo pipefail
+          APPLY_ARGS=()
+          if [ "${{ matrix.environment }}" = "prod" ]; then
+            APPLY_ARGS+=(
+              -var "container_image_api=${{ steps.prod-api.outputs.image }}"
+              -var "api_target_port=${{ steps.prod-api.outputs.target-port }}"
+            )
+          fi
+          terraform -chdir=infra/terraform/env/${{ matrix.environment }} apply             -auto-approve             "${APPLY_ARGS[@]}"
 
       - name: Capture Outputs
         id: outputs


### PR DESCRIPTION
Found while trying to deploy #184 through CI. The prod apply failed:

```
Error: No value for required variable
  on variables.tf line 117: variable "api_jwt_secret"
```

## Cause

The Apply job runs bare `terraform apply` — no `env` block, no `-var` arguments. The Plan job supplies four `TF_VAR_*` values and, for prod, the current container image and target port. The Apply job supplies none of them.

## That failure was the lucky outcome

`api_jwt_secret` has no default, so Terraform refused before touching state. Nothing was changed and convolens stayed on revision `0000044`.

The variables that *do* have defaults would not have refused. **An unset `TF_VAR` resolves to the default, not to the live value** — so `mystira_admin_emails`, `mystira_admin_subjects` and `mystira_identity_client_id` would have been silently cleared on the container app and the frontend. I saw exactly that in a local plan before supplying them by hand.

Worse still: `container_image_api` defaults in `terraform.tfvars` to

```
mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
```

Without the image-resolution step the plan job has, a **"successful" prod apply would have replaced the production API with a hello-world container.**

## Fix

The apply job now mirrors the plan job: same `env` block, same `Resolve Current Production API Runtime` step, same `-var` arguments for prod.

## Why it matters beyond this PR

The apply path is the only sanctioned way to deploy prod infrastructure changes, and it could not work. That is why #184's shared-server and Key Vault changes are merged but still unapplied — and it is the same failure mode as the `DB_HOST` drift that PR fixed: configuration quietly disagreeing with the deployment it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)