### PR TITLE
chore(infra): retire the pre-migration PostgreSQL server

### DIFF
--- a/infra/terraform/env/prod/terraform.tfvars
+++ b/infra/terraform/env/prod/terraform.tfvars
@@ -10,7 +10,13 @@ custom_hostname = "convolens.neuralliquid.ai"
 
 enable_budget_alerts      = true
 enable_container_registry = true
-enable_postgres           = true
+# The pre-migration server. Convolens moved to the org-owned nl-prod-shared-pg on
+# 2026-08-06 and has run there since; this stack no longer provisions a database
+# for the application, it only described the server that was left behind as a
+# rollback path. Setting this false destroys nl-prod-convolens-pg, its database,
+# its firewall rule and the old admin secret. There is no soft delete for a
+# flexible server, so this is the point of no return for that rollback.
+enable_postgres           = false
 enable_redis              = false
 
 admin_email           = ""

--- a/infra/terraform/env/prod/terraform.tfvars
+++ b/infra/terraform/env/prod/terraform.tfvars
@@ -16,8 +16,8 @@ enable_container_registry = true
 # rollback path. Setting this false destroys nl-prod-convolens-pg, its database,
 # its firewall rule and the old admin secret. There is no soft delete for a
 # flexible server, so this is the point of no return for that rollback.
-enable_postgres           = false
-enable_redis              = false
+enable_postgres = false
+enable_redis    = false
 
 admin_email           = ""
 monthly_budget_amount = 75


### PR DESCRIPTION
Convolens moved to the org-owned `nl-prod-shared-pg` on 2026-08-06 and has run there since — revision `0000044`, as the scoped `convolens` role, healthy throughout. House of Veritas completed its own cutover on 2026-08-07 and reports `backend: postgres`.

Both tenants are on the shared server, so `nl-prod-convolens-pg` has no remaining purpose beyond being a rollback nobody expects to use, and a second `B1ms` on the bill.

## Verified destroy set

CI plan against this branch:

```
# azurerm_key_vault_secret.postgres_password[0]                will be destroyed
# azurerm_postgresql_flexible_server.postgres[0]               will be destroyed
# azurerm_postgresql_flexible_server_database.app[0]           will be destroyed
# azurerm_postgresql_flexible_server_firewall_rule.azure_services[0] will be destroyed

Plan: 0 to add, 0 to change, 4 to destroy.
```

**Zero changes to the container app.** Every other setting was decoupled from `enable_postgres` in #184, so `DB_TYPE`, `DB_SSL` and `DB_MIGRATIONS_RUN` are unaffected and the app keeps pointing at the shared server. That decoupling is what makes this a clean four-resource destroy rather than a config revert.

## This is irreversible

There is no soft delete for a PostgreSQL Flexible Server. Deleting it ends the rollback path for the 2026-08-06 migration, and its point-in-time restore window goes with it.

That is why the consequence is written next to the flag in `terraform.tfvars` rather than left as a quiet `true` → `false`, and why the destroy set was confirmed by a real plan before merging rather than inferred from the four `count` expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)