### PR TITLE
feat(infra): wire Sluice into production, gated on the key

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -150,6 +150,7 @@ jobs:
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
         run: |
           set -euo pipefail
           PLAN_ARGS=()
@@ -294,6 +295,7 @@ jobs:
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
         run: |
           set -euo pipefail
           APPLY_ARGS=()

--- a/infra/terraform/env/prod/main.tf
+++ b/infra/terraform/env/prod/main.tf
@@ -19,6 +19,13 @@ locals {
   ingestion_queue_name = "ingestion"
   publish_queue_name   = "baton-publish"
 
+  # Wiring the gateway is opt-in on the key alone. Absent it, no Sluice settings
+  # reach the container app and the application falls through to a direct
+  # provider exactly as it does today — so this stack can be applied before the
+  # key exists without breaking anything, and without pretending to be
+  # configured.
+  sluice_enabled = trimspace(var.sluice_api_key) != ""
+
   tags = merge(
     {
       org         = var.org
@@ -194,6 +201,18 @@ resource "azurerm_key_vault_secret" "appinsights_connection_string" {
 # literal, so this needs to exist there. The value still originates from CI
 # (TF_VAR_api_jwt_secret) — the vault becomes the distribution point, not a new
 # source of truth.
+# Sluice is the only path on which this service's AI spend is attributable, so
+# the application prefers it (apps/api/src/services/ai/*). It selects Sluice only
+# when both SLUICE_BASE_URL and SLUICE_API_KEY are present, which is why all
+# three settings below are gated together: a half-configured gateway would leave
+# the app silently on a direct provider while looking configured.
+resource "azurerm_key_vault_secret" "sluice_api_key" {
+  count        = local.sluice_enabled ? 1 : 0
+  name         = "sluice-api-key"
+  value        = var.sluice_api_key
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
 resource "azurerm_key_vault_secret" "api_jwt_secret" {
   name         = "api-jwt-secret"
   value        = var.api_jwt_secret
@@ -240,6 +259,16 @@ resource "azurerm_container_app" "api" {
     name                = "appinsights-connection-string"
     key_vault_secret_id = azurerm_key_vault_secret.appinsights_connection_string.versionless_id
     identity            = "System"
+  }
+
+  dynamic "secret" {
+    for_each = azurerm_key_vault_secret.sluice_api_key
+
+    content {
+      name                = "sluice-api-key"
+      key_vault_secret_id = secret.value.versionless_id
+      identity            = "System"
+    }
   }
 
   # The scoped role's password on the shared server. This secret was created out
@@ -398,6 +427,35 @@ resource "azurerm_container_app" "api" {
         name  = "AZURE_PROVIDER_ENABLED"
         value = "true"
       }
+
+      # All three or none — see local.sluice_enabled.
+      dynamic "env" {
+        for_each = local.sluice_enabled ? [1] : []
+
+        content {
+          name  = "SLUICE_BASE_URL"
+          value = var.sluice_base_url
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.sluice_enabled ? [1] : []
+
+        content {
+          name        = "SLUICE_API_KEY"
+          secret_name = "sluice-api-key"
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.sluice_enabled ? [1] : []
+
+        content {
+          name  = "SLUICE_MODEL"
+          value = var.sluice_model
+        }
+      }
+
       env {
         name  = "BATON_BASE_URL"
         value = "https://baton-backend.up.railway.app"

--- a/infra/terraform/env/prod/variables.tf
+++ b/infra/terraform/env/prod/variables.tf
@@ -54,6 +54,39 @@ variable "postgres_admin_login" {
 # neuralliquid-org/docs/adr/0002-shared-data-plane-ownership.md. The server is
 # owned by neuralliquid-org Terraform; convolens owns its database, role and
 # schema, and the settings below describe how to reach it.
+variable "sluice_base_url" {
+  type        = string
+  description = "Sluice LiteLLM gateway used for governed AI requests."
+  default     = "https://litellm.sluice.phoenixvc.tech"
+
+  validation {
+    condition     = startswith(var.sluice_base_url, "https://")
+    error_message = "sluice_base_url must use HTTPS."
+  }
+}
+
+variable "sluice_api_key" {
+  type        = string
+  description = <<-EOT
+    Restricted ConvoLens Sluice virtual key. Empty by default, and that is the
+    switch: with no key, no Sluice settings reach the container app and the
+    application uses a direct provider, exactly as it does without this stack.
+
+    Deliberately not a required variable. A required one with no default breaks
+    every plan and apply until the value exists — see the api_jwt_secret failure
+    fixed in #185 — and that cost is paid by everyone applying this stack, not
+    just by whoever wants the gateway on.
+  EOT
+  sensitive   = true
+  default     = ""
+}
+
+variable "sluice_model" {
+  type        = string
+  description = "Sluice capability alias for grounded conversation catch-ups. A logical route, not a provider model name — Sluice resolves it."
+  default     = "convolens-catch-up-v1"
+}
+
 variable "shared_postgres_fqdn" {
   type        = string
   description = "Host of the org-owned shared PostgreSQL server."


### PR DESCRIPTION
Supersedes the Terraform in #175, re-cut from current main.

## The gap this closes

#183 merged the application side: `apps/api` selects Sluice when `SLUICE_BASE_URL` and `SLUICE_API_KEY` are both present, because — quoting the code — it "is the only path on which this service's spend is attributable. See Sluice ADR 10."

The infrastructure side never merged. Production has **no `SLUICE_*` settings at all**:

```
env vars matching SLUICE on nl-prod-convolens-api → []
```

So that routing has been inert since #183. `getProvider()` falls through to a direct provider and the spend attribution the ADR asked for isn't happening.

## Two deliberate differences from #175

**System-assigned identity, not a new user-assigned one.** The app's system identity already holds `Key Vault Secrets User` on this vault, and the other three secrets moved onto it in #184. A second identity on the same app reading the same vault is a distinction without a difference.

**`sluice_api_key` defaults to empty and gates itself**, rather than being required with a non-empty validation. `local.sluice_enabled` gates the Key Vault secret, the container app secret, and all three env vars together.

That second one matters. As #175 wrote it, the variable is required with no default — so merging it breaks **every** convolens plan and apply until the value exists. That is exactly the `api_jwt_secret` failure fixed in #185, and the cost falls on everyone applying the stack, not just on whoever wants the gateway on.

Gating all three settings as one unit also prevents a half-configured gateway: a `SLUICE_BASE_URL` without a key would look configured while the app quietly used a direct provider.

## Behaviour

| `sluice_api_key` | Result |
| --- | --- |
| unset (default) | No Sluice resources, no env vars. Production identical to today. |
| supplied | Key Vault secret created, referenced via system identity, all three env vars set, gateway active. |

## Also

`TF_VAR_sluice_api_key` added to **both** the plan and apply jobs in `infrastructure.yml`. #175 added it only to `deploy-prod.yml`, so the infrastructure workflow would still have failed on it.

## Verification status

`terraform fmt` and `validate` pass. **A plan has not been run** — the machine this was authored on ran out of disk, which corrupted the Azure CLI token cache and blocked local Azure calls. CI uses OIDC and is unaffected, so the plan on this PR is the real check.

Expected with no `SLUICE_API_KEY` secret configured: **no changes**. If the secret does exist in the repo, expect one Key Vault secret created and the container app updated.

Closes the infrastructure half of #175; that PR's application changes are already superseded by #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)