### PR TITLE
ci(deploy): refuse to ship production without the Sluice key

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,6 +53,25 @@ jobs:
             fi
           done
 
+      # Sluice owns provider credentials, model routing, budgets and telemetry,
+      # and is the only path on which this service's model spend is attributable
+      # (Sluice ADR 10). The application degrades to a direct provider when the
+      # key is absent — quietly, and billed with no record of which service
+      # incurred it. That degradation is acceptable locally and not in
+      # production, so the refusal lives here rather than in a Terraform
+      # variable: a required variable would break every plan and apply for
+      # everyone, while this fails only the thing that should fail, loudly.
+      - name: Verify Governed AI Configuration
+        env:
+          SLUICE_API_KEY: ${{ secrets.SLUICE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SLUICE_API_KEY" ]; then
+            echo "Error: the restricted SLUICE_API_KEY production secret is required for grounded catch-ups." >&2
+            echo "Without it the service falls back to a direct provider and its spend is not attributable." >&2
+            exit 1
+          fi
+
       - name: Azure Login
         uses: azure/login@v2
         with:
@@ -232,6 +251,7 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
         run: |
@@ -300,6 +320,7 @@ jobs:
         env:
           TF_VAR_mystira_identity_client_id: ${{ secrets.MYSTIRA_IDENTITY_CLIENT_ID }}
           TF_VAR_api_jwt_secret: ${{ secrets.JWT_SECRET || secrets.NEXTAUTH_SECRET }}
+          TF_VAR_sluice_api_key: ${{ secrets.SLUICE_API_KEY }}
           TF_VAR_mystira_admin_emails: ${{ vars.MYSTIRA_ADMIN_EMAILS }}
           TF_VAR_mystira_admin_subjects: ${{ vars.MYSTIRA_ADMIN_SUBJECTS }}
 


### PR DESCRIPTION
Carries over the last substantive change from #175. Its application half was superseded by #183, its Terraform half by #187.

## Why a gate at all

Sluice owns provider credentials, model routing, budgets and telemetry, and is the only path on which this service's model spend is attributable (Sluice ADR 10).

When the key is absent the application **does not fail**. It degrades to a direct provider — quietly — and that spend is billed with no record of which service incurred it. Right locally, wrong in production.

Production deploys now refuse to proceed without `SLUICE_API_KEY`, and say why:

```
Error: the restricted SLUICE_API_KEY production secret is required for grounded catch-ups.
Without it the service falls back to a direct provider and its spend is not attributable.
```

## Why here and not in a Terraform variable

#175 put this in a `sluice_api_key` validation requiring a non-empty value. That enforces the policy, but a required variable with no default breaks **every** plan and apply for anyone touching the stack — precisely the `api_jwt_secret` failure fixed in #185.

Splitting the two concerns gets both properties:

| Layer | Behaviour |
| --- | --- |
| Terraform (#187) | Key optional. Gated resources. Applies never break. |
| Deploy workflow (here) | Key mandatory. Production ships governed or not at all. |

The fail-safe is deliberately silent so that infrastructure work is never blocked by an unrelated secret; this supplies the loud refusal at the point where silence is actually dangerous.

## Also

Threads `TF_VAR_sluice_api_key` through this workflow's Terraform steps, matching what #187 did for `infrastructure.yml`.

## Note before merging

There is currently **no `SLUICE_API_KEY` repository secret** — the CI plan on #187 returned "No changes", which is how I know. **Merging this will fail the next production deploy until that secret is added.** That is the intended behaviour, but it is a live consequence rather than a latent one, so it is worth adding the secret first or merging in the same sitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)