### PR TITLE
ci: discover complete test and typecheck gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,14 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: "true"
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
 
-      # Every workspace project that has a typecheck script. @convolens/web and
-      # @convolens/monitoring do not define one yet.
+      # Runs in every workspace project that defines a typecheck script. Use an
+      # exclusion, not an allowlist: a new project must be gated the moment it
+      # lands. @convolens/web is the one carve-out — its existing typecheck
+      # baseline is not clean, and next.config.mjs sets
+      # typescript.ignoreBuildErrors. Drive that to zero, then delete the
+      # exclusion and the ignoreBuildErrors escape hatch.
       - name: Typecheck
-        run: >-
-          pnpm --filter @convolens/api
-          --filter @convolens/chrome-extension
-          --filter @convolens/config
-          --filter @convolens/contexts
-          --filter @convolens/ui
-          --filter @convolens/utils
-          run typecheck
+        run: pnpm -r --filter '!@convolens/web' run typecheck
 
       - name: Test extension capture matrix
         run: pnpm --filter @convolens/chrome-extension test
@@ -70,20 +67,10 @@ jobs:
       - name: Test extension persistence fixtures
         run: xvfb-run --auto-servernum pnpm --filter @convolens/chrome-extension test:browser:persistence
 
-      - name: Test API conversation intake
-        run: >-
-          pnpm --filter @convolens/api exec jest --config=jest.config.js --runInBand
-          src/services/__tests__/conversation-intake.service.test.ts
-          src/services/__tests__/selector-report.service.test.ts
-          src/services/__tests__/storage-managed-identity.test.ts
-          src/services/__tests__/auth.service.test.ts
-          src/services/__tests__/mystira-auth.service.test.ts
-          src/services/__tests__/metrics.service.test.ts
-          src/services/__tests__/circuit-breaker.service.test.ts
-          src/services/__tests__/deduplication.service.test.ts
-          src/db/migrations/__tests__/conversation-intake.migration.test.ts
-          src/routes/__tests__/chat-export.routes.test.ts
-          src/routes/__tests__/extension.routes.test.ts
+      # Runs every suite matched by jest.config.js testMatch. Do not reintroduce
+      # an explicit file list here: new suites must be picked up automatically.
+      - name: Test API
+        run: pnpm --filter @convolens/api exec jest --config=jest.config.js --ci --runInBand
 
       - name: Package and inspect extension
         run: pnpm --filter @convolens/chrome-extension package

--- a/apps/chrome-extension/tests/phase9-release-evidence.test.ts
+++ b/apps/chrome-extension/tests/phase9-release-evidence.test.ts
@@ -39,7 +39,11 @@ test("runs extension, intake, and inspected-package evidence in CI", () => {
   assert.match(workflow, /@convolens\/chrome-extension test/);
   assert.match(
     workflow,
-    /jest --config=jest\.config\.js --runInBand[\s\S]*src\/services\/__tests__\/conversation-intake\.service\.test\.ts/,
+    /@convolens\/api exec jest --config=jest\.config\.js --ci --runInBand/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /src\/services\/__tests__\/conversation-intake\.service\.test\.ts/,
   );
   assert.match(workflow, /test:browser:persistence/);
   assert.match(workflow, /@convolens\/chrome-extension package/);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "jest --config=jest.config.js",
     "test:watch": "jest --config=jest.config.js --watch",
     "test:coverage": "jest --config=jest.config.js --coverage",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -40,9 +40,7 @@
     "types": [
       "node",
       "jest",
-      "@testing-library/jest-dom",
-      "@testing-library/react",
-      "@testing-library/user-event"
+      "@testing-library/jest-dom"
     ],
     "composite": true,
     "plugins": [

--- a/docs/HANDOFF-2026-08-09-CI-GATE-AND-REPO-CLOSEOUT.md
+++ b/docs/HANDOFF-2026-08-09-CI-GATE-AND-REPO-CLOSEOUT.md
@@ -1,0 +1,72 @@
+# CI pattern gates and repository closeout handoff
+
+Date: 2026-08-09
+
+## Outcome
+
+PR [#189](https://github.com/neuralliquid/convolens/pull/189) recovers the
+durable portion of unpublished local commit `93ec45f` without carrying forward
+its superseded authentication and API-documentation changes.
+
+The PR:
+
+- runs every API Jest suite matched by `apps/api/jest.config.js` instead of a
+  hand-maintained file list;
+- discovers workspace `typecheck` scripts recursively, with the existing web
+  type-error baseline as the only documented exclusion;
+- adds explicit `typecheck` scripts for the web and monitoring packages;
+- removes Testing Library packages that are not global type packages from the
+  web TypeScript `types` array; and
+- updates the extension release-evidence contract so CI rejects a return to an
+  explicit API test-path allowlist.
+
+## Review and verification
+
+Implementation commit before this handoff: `a0eb4daf322c5043130c61104b392a90c22b4557`.
+
+- Recursive typecheck passed across seven workspace projects.
+- All 16 API suites and 165 tests passed.
+- All 167 extension tests passed after the workflow-contract update.
+- Exact-head GitHub Actions run
+  [31303824238](https://github.com/neuralliquid/convolens/actions/runs/31303824238)
+  passed before this handoff was added.
+- The initial thread-aware ready-state review query reported no reviews,
+  comments, or review threads.
+- Manual self-review found no correctness, security, or privacy issue in the
+  implementation diff.
+
+Because this handoff changes the PR head, merge still requires fresh exact-head
+CI, a repeated thread-aware review query, a current base comparison, and clean
+mergeability.
+
+## Repository cleanup completed
+
+The two superseded linked worktrees and their filesystem remnants were removed.
+Eight obsolete local branches and eleven obsolete remote topic branches were
+removed only after their merged, closed, or superseded PR dispositions were
+verified. The remaining worktrees and branches are `main` plus the PR #189
+worktree and branch.
+
+The primary checkout intentionally retains the untracked repository guidance
+file `AGENTS.md`.
+
+## Open boundaries
+
+- `@convolens/web` remains excluded from the recursive typecheck gate because
+  its existing baseline is not clean and `next.config.mjs` still ignores build
+  type errors. Drive that baseline to zero before removing the exclusion.
+- GitHub reported one high-severity default-branch Dependabot alert during the
+  PR push. Baton task `0822e9fc-9a20-4b60-bd8b-4494ba786f76` remains open for
+  alert `328`.
+- Local CodeRabbit CLI review was unavailable because the CLI is not installed.
+  GitHub bot reviews and review threads must be checked again at the final PR
+  head before merge.
+- CI, deployment, and this repository cleanup do not prove authentic WhatsApp
+  intake or grounded-todo/Baton publication acceptance. Those staffed gates
+  remain open and require their own explicit authorization.
+
+## Baton
+
+Task `58aac86f-af30-4aff-a45f-6904e8f4ebd6`, **Replace hand-listed CI gates
+with pattern-derived discovery**, tracks PR #189 and closes only after the PR is
+merged and post-merge state is verified.

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
## What changed

- Run every API Jest suite matched by `jest.config.js` instead of maintaining a hand-written file list.
- Discover workspace typecheck scripts recursively, with the existing web baseline as the single documented exclusion.
- Add explicit typecheck scripts for the web and monitoring packages.
- Remove invalid Testing Library package entries from the web `types` array.

## Why

The previous allowlists could silently omit newly added test suites or workspace projects. This makes new API tests and new typechecked packages enter CI by default.

This is the narrow CI portion recovered from local commit `93ec45f`; its superseded auth and documentation changes were deliberately excluded.

## Validation

- `pnpm -r --filter '!@convolens/web' run typecheck` — passed across 7 projects.
- `pnpm --filter @convolens/api exec jest --config=jest.config.js --ci --runInBand` — 16 suites and 165 tests passed.
- `git diff --check` — passed.
- Web typecheck remains an explicitly documented baseline exclusion; current measurement returns 109 TypeScript error lines.